### PR TITLE
Fix: duplicate field name in path and body

### DIFF
--- a/codegen/parser/endpoints/endpoint.py
+++ b/codegen/parser/endpoints/endpoint.py
@@ -52,6 +52,10 @@ class EndpointData(BaseModel):
     def cookie_params(self) -> List[Parameter]:
         return [param for param in self.parameters if param.param_in == "cookie"]
 
+    @property
+    def param_names(self) -> List[str]:
+        return [param.prop_name for param in self.parameters]
+
     def get_imports(self) -> Set[str]:
         imports = set()
         for param in self.parameters:

--- a/codegen/templates/client/_param.py.jinja
+++ b/codegen/templates/client/_param.py.jinja
@@ -22,9 +22,11 @@
 {% endfor %}
 {% endmacro %}
 
-{% macro body_params(model) %}
+{% macro body_params(model, exclude=[]) %}
 {% for prop in model.properties %}
+{% if prop.prop_name not in exclude %}
 {{ prop.get_param_defination() }},
+{% endif %}
 {% endfor %}
 {% endmacro %}
 
@@ -44,7 +46,7 @@
 {{ cookie_params(endpoint) }}
 *,
 data: Unset = UNSET,
-{{ body_params(model) }}
+{{ body_params(model, endpoint.param_names) }}
 {% endmacro %}
 
 {% macro endpoint_params(endpoint, model) %}

--- a/githubkit/rest/actions.py
+++ b/githubkit/rest/actions.py
@@ -2192,7 +2192,6 @@ class ActionsClient:
         name: str,
         *,
         data: Unset = UNSET,
-        name: Union[Unset, str] = UNSET,
         value: Union[Unset, str] = UNSET,
         visibility: Union[Unset, Literal["all", "private", "selected"]] = UNSET,
         selected_repository_ids: Union[Unset, List[int]] = UNSET,
@@ -2235,7 +2234,6 @@ class ActionsClient:
         name: str,
         *,
         data: Unset = UNSET,
-        name: Union[Unset, str] = UNSET,
         value: Union[Unset, str] = UNSET,
         visibility: Union[Unset, Literal["all", "private", "selected"]] = UNSET,
         selected_repository_ids: Union[Unset, List[int]] = UNSET,
@@ -5570,7 +5568,6 @@ class ActionsClient:
         name: str,
         *,
         data: Unset = UNSET,
-        name: Union[Unset, str] = UNSET,
         value: Union[Unset, str] = UNSET,
     ) -> "Response":
         ...
@@ -5618,7 +5615,6 @@ class ActionsClient:
         name: str,
         *,
         data: Unset = UNSET,
-        name: Union[Unset, str] = UNSET,
         value: Union[Unset, str] = UNSET,
     ) -> "Response":
         ...
@@ -6468,7 +6464,6 @@ class ActionsClient:
         environment_name: str,
         *,
         data: Unset = UNSET,
-        name: Union[Unset, str] = UNSET,
         value: Union[Unset, str] = UNSET,
     ) -> "Response":
         ...
@@ -6522,7 +6517,6 @@ class ActionsClient:
         environment_name: str,
         *,
         data: Unset = UNSET,
-        name: Union[Unset, str] = UNSET,
         value: Union[Unset, str] = UNSET,
     ) -> "Response":
         ...


### PR DESCRIPTION
Just remove the duplicate field in body overload to avoid `SyntaxError`. fix #16 