### PR TITLE
Fix: `rest_description_source` typo

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -130,7 +130,7 @@ def build():
     logger.info(f"Loaded config: {config!r}")
 
     logger.info("Start getting OpenAPI source...")
-    source = get_source(httpx.URL(config.rest_descrition_source))
+    source = get_source(httpx.URL(config.rest_description_source))
     logger.info(f"Getting schema from {source.uri} succeeded!")
 
     logger.info("Start parsing OpenAPI spec...")

--- a/codegen/config.py
+++ b/codegen/config.py
@@ -5,7 +5,7 @@ import openapi_schema_pydantic as oas
 
 
 class Config(BaseModel):
-    rest_descrition_source: str
+    rest_description_source: str
     webhook_schema_source: str
     class_overrides: Dict[str, str] = {}
     field_overrides: Dict[str, str] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ reportPrivateImportUsage = false
 reportShadowedImports = false
 
 [tool.codegen]
-rest-descrition-source = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.json"
+rest-description-source = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.json"
 webhook-schema-source = "https://unpkg.com/@octokit/webhooks-schemas/schema.json"
 client-output = "githubkit/rest/"
 webhooks-output = "githubkit/webhooks/models.py"


### PR DESCRIPTION
🥵

title: `:pencil2: fix typo`