### PR TITLE
Fix: Add wrapper to prep data for JSON encoding

### DIFF
--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -301,18 +301,12 @@ class GitHubCore(Generic[A]):
 
     def _convert(self, obj: Any) -> Any:
         if isinstance(obj, dict):
-            for k, v in obj.items():
-                obj[k] = self._convert(v)
+            return {k: self._convert(v) for k, v in obj.items()}
 
-            return obj
+        if isinstance(obj, (list, tuple)):
+            return [self._convert(item) for item in obj]
 
-        if isinstance(obj, list):
-            for i, item in enumerate(obj):
-                obj[i] = self._convert(item)
-
-            return obj
-
-        if isinstance(obj, (int, float, str, bool, type(None))):
+        if obj is None or isinstance(obj, (int, float, str, bool)):
             return obj
 
         return pydantic_encoder(obj)

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import httpx
+from pydantic.json import pydantic_encoder
 
 from .response import Response
 from .config import Config, get_config
@@ -237,7 +238,7 @@ class GitHubCore(Generic[A]):
                     content=content,
                     data=data,
                     files=files,
-                    json=json,
+                    json=self._convert(json),
                     headers=headers,
                     cookies=cookies,
                 )
@@ -269,7 +270,7 @@ class GitHubCore(Generic[A]):
                     content=content,
                     data=data,
                     files=files,
-                    json=json,
+                    json=self._convert(json),
                     headers=headers,
                     cookies=cookies,
                 )
@@ -297,6 +298,24 @@ class GitHubCore(Generic[A]):
             rep = Response(response, error_model)
             raise RequestFailed(rep)
         return Response(response, response_model)
+
+    def _convert(self, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                obj[k] = self._convert(v)
+
+            return obj
+
+        if isinstance(obj, list):
+            for i, item in enumerate(obj):
+                obj[i] = self._convert(item)
+
+            return obj
+
+        if isinstance(obj, (int, float, str, bool, bytes, type(None))):
+            return obj
+
+        return pydantic_encoder(obj)
 
     # sync request and check
     def request(

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -312,7 +312,7 @@ class GitHubCore(Generic[A]):
 
             return obj
 
-        if isinstance(obj, (int, float, str, bool, bytes, type(None))):
+        if isinstance(obj, (int, float, str, bool, type(None))):
             return obj
 
         return pydantic_encoder(obj)


### PR DESCRIPTION
The `pydantic_encode` function doesn't work with `dict`. `list`, `str`, `int`, etc. objects out of the box, so I had to make a small wrapper to get it to work. I haven't tested this extensively, but I know it isn't throwing a validation error anymore.

Closes #21.