### PR TITLE
Feature: allow integer app id

### DIFF
--- a/githubkit/auth/app.py
+++ b/githubkit/auth/app.py
@@ -33,7 +33,7 @@ class AppAuth(httpx.Auth):
     """GitHub App or Installation Authentication Hook"""
 
     github: "GitHubCore"
-    app_id: str | int
+    app_id: Union[str, int]
     private_key: str
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
@@ -219,7 +219,7 @@ class AppAuth(httpx.Auth):
 class AppAuthStrategy(BaseAuthStrategy):
     """GitHub App Authentication"""
 
-    app_id: str | int
+    app_id: Union[str, int]
     private_key: str
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
@@ -266,7 +266,7 @@ class AppAuthStrategy(BaseAuthStrategy):
 class AppInstallationAuthStrategy(BaseAuthStrategy):
     """GitHub App Installation Authentication"""
 
-    app_id: str | int
+    app_id: Union[str, int]
     private_key: str
     installation_id: int
     client_id: Optional[str] = None

--- a/githubkit/auth/app.py
+++ b/githubkit/auth/app.py
@@ -33,7 +33,7 @@ class AppAuth(httpx.Auth):
     """GitHub App or Installation Authentication Hook"""
 
     github: "GitHubCore"
-    app_id: str
+    app_id: str | int
     private_key: str
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
@@ -59,7 +59,7 @@ class AppAuth(httpx.Auth):
         time = datetime.now(timezone.utc) - timedelta(minutes=1)
         expire_time = time + timedelta(minutes=10)
         return jwt.encode(
-            {"iss": self.app_id, "iat": time, "exp": expire_time},
+            {"iss": str(self.app_id), "iat": time, "exp": expire_time},
             self.private_key,
             algorithm="RS256",
         )
@@ -219,7 +219,7 @@ class AppAuth(httpx.Auth):
 class AppAuthStrategy(BaseAuthStrategy):
     """GitHub App Authentication"""
 
-    app_id: str
+    app_id: str | int
     private_key: str
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
@@ -266,7 +266,7 @@ class AppAuthStrategy(BaseAuthStrategy):
 class AppInstallationAuthStrategy(BaseAuthStrategy):
     """GitHub App Installation Authentication"""
 
-    app_id: str
+    app_id: str | int
     private_key: str
     installation_id: int
     client_id: Optional[str] = None


### PR DESCRIPTION
Since GitHub application IDs are always integers, it would be nice if the `AppInstallationAuthStrategy` (and similar) classes allowed for `int` types in addition to `str`. We could just replace `str` with `int`, but that wouldn't be backwards compatible, so I decided to just keep both. I can update that though if only using `int` is preferred.