### PR TITLE
Add support for REST-API-VERSION based on the used schema

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -72,7 +72,11 @@ def build_rest_api(data: OpenAPIData, config: Config):
     for tag, endpoints in data.endpoints_by_tag.items():
         logger.info(f"Building endpoints for tag {tag}...")
         tag_path = client_path / f"{tag}.py"
-        tag_path.write_text(client_template.render(tag=tag, endpoints=endpoints))
+        tag_path.write_text(
+            client_template.render(
+                tag=tag, endpoints=endpoints, rest_api_version=config.rest_api_version
+            )
+        )
         logger.info(f"Successfully built endpoints for tag {tag}!")
     logger.info("Successfully built endpoints!")
 

--- a/codegen/config.py
+++ b/codegen/config.py
@@ -6,6 +6,7 @@ import openapi_schema_pydantic as oas
 
 class Config(BaseModel):
     rest_description_source: str
+    rest_api_version: str
     webhook_schema_source: str
     class_overrides: Dict[str, str] = {}
     field_overrides: Dict[str, str] = {}

--- a/codegen/templates/client/_request.py.jinja
+++ b/codegen/templates/client/_request.py.jinja
@@ -68,9 +68,9 @@ params=exclude_unset(params),
 {{ name }}=exclude_unset({{ name }}),
 {% endif %}
 {% if endpoint.header_params %}
-headers=exclude_unset({**headers, **{'X-Github-Api-Version': self._REST_API_VERSION}}),
+headers=exclude_unset({**headers, "X-Github-Api-Version": self._REST_API_VERSION}),
 {% else %}
-headers={'X-Github-Api-Version': self._REST_API_VERSION},
+headers={"X-Github-Api-Version": self._REST_API_VERSION},
 {% endif %}
 {% if endpoint.cookie_params %}
 cookies=exclude_unset(cookies),

--- a/codegen/templates/client/_request.py.jinja
+++ b/codegen/templates/client/_request.py.jinja
@@ -68,7 +68,9 @@ params=exclude_unset(params),
 {{ name }}=exclude_unset({{ name }}),
 {% endif %}
 {% if endpoint.header_params %}
-headers=exclude_unset(headers),
+headers=exclude_unset({**headers, **{'X-Github-Api-Version': self._REST_API_VERSION}}),
+{% else %}
+headers={'X-Github-Api-Version': self._REST_API_VERSION},
 {% endif %}
 {% if endpoint.cookie_params %}
 cookies=exclude_unset(cookies),

--- a/codegen/templates/client/_request.py.jinja
+++ b/codegen/templates/client/_request.py.jinja
@@ -68,9 +68,9 @@ params=exclude_unset(params),
 {{ name }}=exclude_unset({{ name }}),
 {% endif %}
 {% if endpoint.header_params %}
-headers=exclude_unset({**headers, "X-Github-Api-Version": self._REST_API_VERSION}),
+headers=exclude_unset({**headers, "X-GitHub-Api-Version": self._REST_API_VERSION}),
 {% else %}
-headers={"X-Github-Api-Version": self._REST_API_VERSION},
+headers={"X-GitHub-Api-Version": self._REST_API_VERSION},
 {% endif %}
 {% if endpoint.cookie_params %}
 cookies=exclude_unset(cookies),

--- a/codegen/templates/client/client.py.jinja
+++ b/codegen/templates/client/client.py.jinja
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
 class {{ pascal_case(tag) }}Client:
+    _REST_API_VERSION = "{{ rest_api_version }}"
+
     def __init__(self, github: "GitHubCore"):
         self._github = github
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ reportPrivateImportUsage = false
 reportShadowedImports = false
 
 [tool.codegen]
-rest-description-source = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.json"
+rest-description-source = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.2022-11-28.json"
+rest-api-version = "2022-11-28"
 webhook-schema-source = "https://unpkg.com/@octokit/webhooks-schemas/schema.json"
 client-output = "githubkit/rest/"
 webhooks-output = "githubkit/webhooks/models.py"


### PR DESCRIPTION
This PR is related to #9  and adds a REST-API-VERSION property for each Rest Client (at first I added it to the RestNamespace but that resulted in circular dependencies, maybe another place is better suited?) and adds an appropriate header when doing requests.

Tested this in my own project using githubkit as there are no tests available.

I did not regenerate the classes itself as this would clutter the PR.