### PR TITLE
Bug: fix `require_app_auth` matches unexpected routes

### DIFF
--- a/githubkit/auth/_url.py
+++ b/githubkit/auth/_url.py
@@ -3,7 +3,7 @@ import re
 import httpx
 
 APP_ROUTES = {
-    r"^/app",
+    r"/app",
     r"/app/hook/config",
     r"/app/hook/deliveries",
     r"/app/hook/deliveries/(?:.+?)",
@@ -26,7 +26,7 @@ APP_ROUTES = {
 }
 
 BYPASS_REGEX = re.compile(r"/login/(oauth/access_token|device/code)$")
-APP_AUTH_REGEX = re.compile(rf"(?:{'|'.join(APP_ROUTES)})[^/]*$", re.I)
+APP_AUTH_REGEX = re.compile(rf"^(?:{'|'.join(APP_ROUTES)})$", re.I)
 BASIC_AUTH_REGEX = re.compile(r"/applications/[^/]+/(token|grant)s?")
 OAUTH_BASE_REGEX = re.compile(r"^https://(api\.)?github\.com/?$")
 

--- a/githubkit/auth/_url.py
+++ b/githubkit/auth/_url.py
@@ -3,7 +3,7 @@ import re
 import httpx
 
 APP_ROUTES = {
-    r"/app",
+    r"^/app",
     r"/app/hook/config",
     r"/app/hook/deliveries",
     r"/app/hook/deliveries/(?:.+?)",


### PR DESCRIPTION
`APP_ROUTES` contains an `r"/app"` entry to match for the `/app` route. This will also match repositories which start with `app` causing `require_app_auth` to return true.

This change adjusts the `/app` regex to match at the beginning of the string and not anywhere within the url.path