### PR TITLE
Feature: Tweak `Missing` type to implicitly allow `None` values

### DIFF
--- a/githubkit/utils.py
+++ b/githubkit/utils.py
@@ -39,7 +39,7 @@ class Unset(Enum):
 
 
 UNSET = Unset._UNSET
-Missing: TypeAlias = Union[Literal[UNSET], T]
+Missing: TypeAlias = Union[Literal[UNSET], T, None]
 
 
 def exclude_unset(data: Any) -> Any:

--- a/githubkit/utils.py
+++ b/githubkit/utils.py
@@ -39,6 +39,8 @@ class Unset(Enum):
 
 
 UNSET = Unset._UNSET
+# if the property is not required, we allow it to have the value null.
+# See https://github.com/yanyongyu/githubkit/issues/47
 Missing: TypeAlias = Union[Literal[UNSET], T, None]
 
 


### PR DESCRIPTION
As discussed in #47, I'm proposing this change to avoid issues when GitHub schema is not reliable regarding properties that are nullable or not.

Semantically, it's equivalent to say that "*if the property is not `required` in the OpenAPI schema, we allow it to have the value `null`*".