### PR TITLE
Allow Organization `name` and `blog` to be nullable

### DIFF
--- a/githubkit/rest/actions.py
+++ b/githubkit/rest/actions.py
@@ -5419,6 +5419,50 @@ class ActionsClient:
             headers=exclude_unset(headers),
         )
 
+    def force_cancel_workflow_run(
+        self,
+        owner: str,
+        repo: str,
+        run_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[EmptyObject]":
+        url = f"/repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "POST",
+            url,
+            headers=exclude_unset(headers),
+            response_model=EmptyObject,
+            error_models={
+                "409": BasicError,
+            },
+        )
+
+    async def async_force_cancel_workflow_run(
+        self,
+        owner: str,
+        repo: str,
+        run_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[EmptyObject]":
+        url = f"/repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "POST",
+            url,
+            headers=exclude_unset(headers),
+            response_model=EmptyObject,
+            error_models={
+                "409": BasicError,
+            },
+        )
+
     def list_jobs_for_workflow_run(
         self,
         owner: str,

--- a/githubkit/rest/models.py
+++ b/githubkit/rest/models.py
@@ -2932,9 +2932,9 @@ class OrganizationFull(GitHubRestModel):
     public_members_url: str = Field(default=...)
     avatar_url: str = Field(default=...)
     description: Union[str, None] = Field(default=...)
-    name: Missing[str] = Field(default=UNSET)
+    name: Missing[Union[str, None]] = Field(default=UNSET)
     company: Missing[Union[str, None]] = Field(default=UNSET)
-    blog: Missing[str] = Field(default=UNSET)
+    blog: Missing[Union[str, None]] = Field(default=UNSET)
     location: Missing[Union[str, None]] = Field(default=UNSET)
     email: Missing[Union[str, None]] = Field(default=UNSET)
     twitter_username: Missing[Union[str, None]] = Field(default=UNSET)
@@ -4459,7 +4459,7 @@ class RepositoryRuleDeletion(GitHubRestModel):
 class RepositoryRuleRequiredLinearHistory(GitHubRestModel):
     """required_linear_history
 
-    Prevent merge commits from being pushed to matching branches.
+    Prevent merge commits from being pushed to matching refs.
     """
 
     type: Literal["required_linear_history"] = Field(default=...)
@@ -4468,8 +4468,8 @@ class RepositoryRuleRequiredLinearHistory(GitHubRestModel):
 class RepositoryRuleRequiredDeployments(GitHubRestModel):
     """required_deployments
 
-    Choose which environments must be successfully deployed to before branches can
-    be merged into a branch that matches this rule.
+    Choose which environments must be successfully deployed to before refs can be
+    merged into a branch that matches this rule.
     """
 
     type: Literal["required_deployments"] = Field(default=...)
@@ -4490,7 +4490,7 @@ class RepositoryRuleRequiredDeploymentsPropParameters(GitHubRestModel):
 class RepositoryRuleRequiredSignatures(GitHubRestModel):
     """required_signatures
 
-    Commits pushed to matching branches must have verified signatures.
+    Commits pushed to matching refs must have verified signatures.
     """
 
     type: Literal["required_signatures"] = Field(default=...)
@@ -4554,7 +4554,7 @@ class RepositoryRuleRequiredStatusChecks(GitHubRestModel):
 
     Choose which status checks must pass before branches can be merged into a branch
     that matches this rule. When enabled, commits must first be pushed to another
-    branch, then merged or pushed directly to a branch that matches this rule after
+    branch, then merged or pushed directly to a ref that matches this rule after
     status checks have passed.
     """
 
@@ -4579,7 +4579,7 @@ class RepositoryRuleRequiredStatusChecksPropParameters(GitHubRestModel):
 class RepositoryRuleNonFastForward(GitHubRestModel):
     """non_fast_forward
 
-    Prevent users with push access from force pushing to branches.
+    Prevent users with push access from force pushing to refs.
     """
 
     type: Literal["non_fast_forward"] = Field(default=...)
@@ -5147,9 +5147,9 @@ class TeamOrganization(GitHubRestModel):
     public_members_url: str = Field(default=...)
     avatar_url: str = Field(default=...)
     description: Union[str, None] = Field(default=...)
-    name: Missing[str] = Field(default=UNSET)
+    name: Missing[Union[str, None]] = Field(default=UNSET)
     company: Missing[Union[str, None]] = Field(default=UNSET)
-    blog: Missing[str] = Field(default=UNSET)
+    blog: Missing[Union[str, None]] = Field(default=UNSET)
     location: Missing[Union[str, None]] = Field(default=UNSET)
     email: Missing[Union[str, None]] = Field(default=UNSET)
     twitter_username: Missing[Union[str, None]] = Field(default=UNSET)
@@ -9002,6 +9002,10 @@ class EnvironmentPropProtectionRulesItemsAnyof1(GitHubRestModel):
 
     id: int = Field(default=...)
     node_id: str = Field(default=...)
+    prevent_self_review: Missing[bool] = Field(
+        description="Whether deployments to this environment can be approved by the user who created the deployment.",
+        default=UNSET,
+    )
     type: str = Field(default=...)
     reviewers: Missing[
         List[EnvironmentPropProtectionRulesItemsAnyof1PropReviewersItems]
@@ -13300,6 +13304,35 @@ class KeySimple(GitHubRestModel):
 
     id: int = Field(default=...)
     key: str = Field(default=...)
+
+
+class EnterpriseWebhooks(GitHubRestModel):
+    """Enterprise
+
+    An enterprise on GitHub. Webhook payloads contain the `enterprise` property when
+    the webhook is configured
+    on an enterprise account or an organization that's part of an enterprise
+    account. For more information,
+    see "[About enterprise accounts](https://docs.github.com/admin/overview/about-
+    enterprise-accounts)."
+    """
+
+    description: Missing[Union[str, None]] = Field(
+        description="A short description of the enterprise.", default=UNSET
+    )
+    html_url: str = Field(default=...)
+    website_url: Missing[Union[str, None]] = Field(
+        description="The enterprise's website URL.", default=UNSET
+    )
+    id: int = Field(description="Unique identifier of the enterprise", default=...)
+    node_id: str = Field(default=...)
+    name: str = Field(description="The name of the enterprise.", default=...)
+    slug: str = Field(
+        description="The slug url identifier for the enterprise.", default=...
+    )
+    created_at: Union[datetime, None] = Field(default=...)
+    updated_at: Union[datetime, None] = Field(default=...)
+    avatar_url: str = Field(default=...)
 
 
 class SimpleInstallation(GitHubRestModel):
@@ -20793,6 +20826,7 @@ StarredRepository.update_forward_refs()
 Hovercard.update_forward_refs()
 HovercardPropContextsItems.update_forward_refs()
 KeySimple.update_forward_refs()
+EnterpriseWebhooks.update_forward_refs()
 SimpleInstallation.update_forward_refs()
 OrganizationSimpleWebhooks.update_forward_refs()
 RepositoryWebhooks.update_forward_refs()
@@ -21852,6 +21886,7 @@ __all__ = [
     "Hovercard",
     "HovercardPropContextsItems",
     "KeySimple",
+    "EnterpriseWebhooks",
     "SimpleInstallation",
     "OrganizationSimpleWebhooks",
     "RepositoryWebhooks",

--- a/githubkit/rest/types.py
+++ b/githubkit/rest/types.py
@@ -2021,9 +2021,9 @@ class OrganizationFullType(TypedDict):
     public_members_url: str
     avatar_url: str
     description: Union[str, None]
-    name: NotRequired[str]
+    name: NotRequired[Union[str, None]]
     company: NotRequired[Union[str, None]]
-    blog: NotRequired[str]
+    blog: NotRequired[Union[str, None]]
     location: NotRequired[Union[str, None]]
     email: NotRequired[Union[str, None]]
     twitter_username: NotRequired[Union[str, None]]
@@ -3027,7 +3027,7 @@ class RepositoryRuleDeletionType(TypedDict):
 class RepositoryRuleRequiredLinearHistoryType(TypedDict):
     """required_linear_history
 
-    Prevent merge commits from being pushed to matching branches.
+    Prevent merge commits from being pushed to matching refs.
     """
 
     type: Literal["required_linear_history"]
@@ -3036,8 +3036,8 @@ class RepositoryRuleRequiredLinearHistoryType(TypedDict):
 class RepositoryRuleRequiredDeploymentsType(TypedDict):
     """required_deployments
 
-    Choose which environments must be successfully deployed to before branches can
-    be merged into a branch that matches this rule.
+    Choose which environments must be successfully deployed to before refs can be
+    merged into a branch that matches this rule.
     """
 
     type: Literal["required_deployments"]
@@ -3053,7 +3053,7 @@ class RepositoryRuleRequiredDeploymentsPropParametersType(TypedDict):
 class RepositoryRuleRequiredSignaturesType(TypedDict):
     """required_signatures
 
-    Commits pushed to matching branches must have verified signatures.
+    Commits pushed to matching refs must have verified signatures.
     """
 
     type: Literal["required_signatures"]
@@ -3095,7 +3095,7 @@ class RepositoryRuleRequiredStatusChecksType(TypedDict):
 
     Choose which status checks must pass before branches can be merged into a branch
     that matches this rule. When enabled, commits must first be pushed to another
-    branch, then merged or pushed directly to a branch that matches this rule after
+    branch, then merged or pushed directly to a ref that matches this rule after
     status checks have passed.
     """
 
@@ -3113,7 +3113,7 @@ class RepositoryRuleRequiredStatusChecksPropParametersType(TypedDict):
 class RepositoryRuleNonFastForwardType(TypedDict):
     """non_fast_forward
 
-    Prevent users with push access from force pushing to branches.
+    Prevent users with push access from force pushing to refs.
     """
 
     type: Literal["non_fast_forward"]
@@ -3485,9 +3485,9 @@ class TeamOrganizationType(TypedDict):
     public_members_url: str
     avatar_url: str
     description: Union[str, None]
-    name: NotRequired[str]
+    name: NotRequired[Union[str, None]]
     company: NotRequired[Union[str, None]]
-    blog: NotRequired[str]
+    blog: NotRequired[Union[str, None]]
     location: NotRequired[Union[str, None]]
     email: NotRequired[Union[str, None]]
     twitter_username: NotRequired[Union[str, None]]
@@ -6368,6 +6368,7 @@ class EnvironmentPropProtectionRulesItemsAnyof1Type(TypedDict):
 
     id: int
     node_id: str
+    prevent_self_review: NotRequired[bool]
     type: str
     reviewers: NotRequired[
         List[EnvironmentPropProtectionRulesItemsAnyof1PropReviewersItemsType]
@@ -9651,6 +9652,29 @@ class KeySimpleType(TypedDict):
 
     id: int
     key: str
+
+
+class EnterpriseWebhooksType(TypedDict):
+    """Enterprise
+
+    An enterprise on GitHub. Webhook payloads contain the `enterprise` property when
+    the webhook is configured
+    on an enterprise account or an organization that's part of an enterprise
+    account. For more information,
+    see "[About enterprise accounts](https://docs.github.com/admin/overview/about-
+    enterprise-accounts)."
+    """
+
+    description: NotRequired[Union[str, None]]
+    html_url: str
+    website_url: NotRequired[Union[str, None]]
+    id: int
+    node_id: str
+    name: str
+    slug: str
+    created_at: Union[datetime, None]
+    updated_at: Union[datetime, None]
+    avatar_url: str
 
 
 class SimpleInstallationType(TypedDict):
@@ -14649,6 +14673,7 @@ __all__ = [
     "HovercardType",
     "HovercardPropContextsItemsType",
     "KeySimpleType",
+    "EnterpriseWebhooksType",
     "SimpleInstallationType",
     "OrganizationSimpleWebhooksType",
     "RepositoryWebhooksType",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,14 @@ output_dir = "githubkit/rest/"
   "string",
   "null",
 ] }
+"/components/schemas/organization-full/properties/name" = { type = [
+  "string",
+  "null",
+] }
+"/components/schemas/organization-full/properties/blog" = { type = [
+  "string",
+  "null",
+] }
 "/components/schemas/team-organization/properties/company" = { type = [
   "string",
   "null",
@@ -200,6 +208,14 @@ output_dir = "githubkit/rest/"
   "null",
 ] }
 "/components/schemas/team-organization/properties/location" = { type = [
+  "string",
+  "null",
+] }
+"/components/schemas/team-organization/properties/name" = { type = [
+  "string",
+  "null",
+] }
+"/components/schemas/team-organization/properties/blog" = { type = [
   "string",
   "null",
 ] }


### PR DESCRIPTION
As discussed in #48, we've discovered another GitHub schema inconsistency: `name` and `blog` properties can actually be `null`.

Related to https://github.com/github/rest-api-description/issues/2507