### PR TITLE
Feature: Add caching for HTTP responses

### DIFF
--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -12,6 +12,7 @@ class Config:
     user_agent: str
     follow_redirects: bool
     timeout: httpx.Timeout
+    http_cache: bool
 
     def dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -65,6 +66,7 @@ def get_config(
     user_agent: Optional[str] = None,
     follow_redirects: bool = True,
     timeout: Optional[Union[float, httpx.Timeout]] = None,
+    http_cache: bool = True,
 ) -> Config:
     return Config(
         build_base_url(base_url),
@@ -72,4 +74,5 @@ def get_config(
         build_user_agent(user_agent),
         follow_redirects,
         build_timeout(timeout),
+        http_cache,
     )

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -205,10 +205,7 @@ class GitHubCore(Generic[A]):
         else:
             transport = httpx.HTTPTransport()
 
-        return httpx.Client(
-            **self._get_client_defaults(),
-            transport=transport,
-        )
+        return httpx.Client(**self._get_client_defaults(), transport=transport)
 
     # get or create sync client
     @contextmanager

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -80,6 +80,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        http_cache: bool = True,
     ):
         ...
 
@@ -95,6 +96,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        http_cache: bool = True,
     ):
         ...
 
@@ -110,6 +112,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        http_cache: bool = True,
     ):
         ...
 
@@ -124,6 +127,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        http_cache: bool = True,
     ):
         auth = auth or UnauthAuthStrategy()  # type: ignore
         self.auth: A = (  # type: ignore
@@ -140,6 +144,7 @@ class GitHubCore(Generic[A]):
         self.__async_client: ContextVar[Optional[httpx.AsyncClient]] = ContextVar(
             "async_client", default=None
         )
+        self._http_cache = http_cache
 
     # sync context
     def __enter__(self):
@@ -190,7 +195,7 @@ class GitHubCore(Generic[A]):
     def _create_sync_client(self) -> httpx.Client:
         return httpx.Client(
             **self._get_client_defaults(),
-            transport=hishel.CacheTransport(httpx.HTTPTransport()),
+            transport=hishel.CacheTransport(httpx.HTTPTransport(), storage=hishel.InMemoryStorage()),
         )
 
     # get or create sync client
@@ -209,7 +214,7 @@ class GitHubCore(Generic[A]):
     def _create_async_client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
             **self._get_client_defaults(),
-            transport=hishel.AsyncCacheTransport(httpx.AsyncHTTPTransport()),
+            transport=hishel.AsyncCacheTransport(httpx.AsyncHTTPTransport(), storage=hishel.AsyncInMemoryStorage()),
         )
 
     # get or create async client

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -231,10 +231,7 @@ class GitHubCore(Generic[A]):
         else:
             transport = httpx.AsyncHTTPTransport()
 
-        return httpx.AsyncClient(
-            **self._get_client_defaults(),
-            transport=transport
-        )
+        return httpx.AsyncClient(**self._get_client_defaults(), transport=transport)
 
     # get or create async client
     @asynccontextmanager

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import httpx
+import hishel
 
 from .response import Response
 from .utils import obj_to_jsonable
@@ -187,7 +188,10 @@ class GitHubCore(Generic[A]):
 
     # create sync client
     def _create_sync_client(self) -> httpx.Client:
-        return httpx.Client(**self._get_client_defaults())
+        return httpx.Client(
+            **self._get_client_defaults(),
+            transport=hishel.CacheTransport(httpx.HTTPTransport()),
+        )
 
     # get or create sync client
     @contextmanager
@@ -203,7 +207,10 @@ class GitHubCore(Generic[A]):
 
     # create async client
     def _create_async_client(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(**self._get_client_defaults())
+        return httpx.AsyncClient(
+            **self._get_client_defaults(),
+            transport=hishel.AsyncCacheTransport(httpx.AsyncHTTPTransport()),
+        )
 
     # get or create async client
     @asynccontextmanager

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -84,6 +84,7 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
+            http_cache: bool = True,
         ):
             ...
 
@@ -99,6 +100,7 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
+            http_cache: bool = True,
         ):
             ...
 
@@ -114,6 +116,7 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
+            http_cache: bool = True,
         ):
             ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ include = ["githubkit/py.typed"]
 python = "^3.8"
 pydantic = ">=2.0.0, <3.0.0, !=2.5.0, !=2.5.1"
 httpx = ">=0.23.0, <1.0.0"
-hishel = ">=0.0.19"
+hishel = ">=0.0.20"
 typing-extensions = "^4.3.0"
 anyio = { version = "^3.6.1", optional = true }
 PyJWT = { version = "^2.4.0", extras = ["crypto"], optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ include = ["githubkit/py.typed"]
 python = "^3.8"
 pydantic = ">=2.0.0, <3.0.0, !=2.5.0, !=2.5.1"
 httpx = ">=0.23.0, <1.0.0"
+hishel = ">=0.0.19"
 typing-extensions = "^4.3.0"
 anyio = { version = "^3.6.1", optional = true }
 PyJWT = { version = "^2.4.0", extras = ["crypto"], optional = true }


### PR DESCRIPTION
Closes #61 

Adds [RFC9111 HTTP caching](https://www.rfc-editor.org/rfc/rfc9111.html), which caches responses that the server suggests reusing.

If we want to provide a way to disable caching, perhaps we should add something like `http_cache` boolean to the `GitHub` class?