### PR TITLE
Fix: `PullRequestSimplePropHead` label field can be `null`

### DIFF
--- a/githubkit/rest/models.py
+++ b/githubkit/rest/models.py
@@ -8382,7 +8382,7 @@ class PullRequestSimplePropLabelsItems(GitHubRestModel):
 class PullRequestSimplePropHead(GitHubRestModel):
     """PullRequestSimplePropHead"""
 
-    label: Union[None, str] = Field(default=...)
+    label: Union[str, None] = Field(default=...)
     ref: str = Field(default=...)
     repo: Union[None, Repository] = Field(
         title="Repository", description="A repository on GitHub.", default=...

--- a/githubkit/rest/models.py
+++ b/githubkit/rest/models.py
@@ -8065,7 +8065,7 @@ class PullRequestSimplePropLabelsItems(GitHubRestModel):
 class PullRequestSimplePropHead(GitHubRestModel):
     """PullRequestSimplePropHead"""
 
-    label: str = Field(default=...)
+    label: Union[None, str] = Field(default=...)
     ref: str = Field(default=...)
     repo: Union[None, Repository] = Field(
         title="Repository", description="A repository on GitHub.", default=...

--- a/githubkit/rest/types.py
+++ b/githubkit/rest/types.py
@@ -5669,7 +5669,7 @@ class PullRequestSimplePropLabelsItemsType(TypedDict):
 class PullRequestSimplePropHeadType(TypedDict):
     """PullRequestSimplePropHead"""
 
-    label: str
+    label: Union[None, str]
     ref: str
     repo: Union[None, RepositoryType]
     sha: str

--- a/githubkit/rest/types.py
+++ b/githubkit/rest/types.py
@@ -5841,7 +5841,7 @@ class PullRequestSimplePropLabelsItemsType(TypedDict):
 class PullRequestSimplePropHeadType(TypedDict):
     """PullRequestSimplePropHead"""
 
-    label: Union[None, str]
+    label: Union[str, None]
     ref: str
     repo: Union[None, RepositoryType]
     sha: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,12 @@ output_dir = "githubkit/rest/"
   "null",
 ] }
 
+# https://github.com/yanyongyu/githubkit/issues/64
+"/components/schemas/pull-request-simple/properties/head/properties/label" = { anyOf = [
+  { type = "null" },
+  { "$ref" = "#/components/schemas/label" },
+], "$ref" = "<unset>" }
+
 # https://github.com/github/rest-api-description/issues/1811
 "/components/schemas/pull-request-simple/properties/head/properties/repo" = { anyOf = [
   { type = "null" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,13 +125,14 @@ output_dir = "githubkit/rest/"
   "null",
 ] }
 
-# https://github.com/yanyongyu/githubkit/issues/64
-"/components/schemas/pull-request-simple/properties/head/properties/label" = { anyOf = [
-  { type = "null" },
-  { "$ref" = "#/components/schemas/label" },
-], "$ref" = "<unset>" }
 
 # https://github.com/github/rest-api-description/issues/1811
+# https://github.com/yanyongyu/githubkit/issues/56
+# https://github.com/yanyongyu/githubkit/issues/64
+"/components/schemas/pull-request-simple/properties/head/properties/label" = { type = [
+  "string",
+  "null",
+] }
 "/components/schemas/pull-request-simple/properties/head/properties/repo" = { anyOf = [
   { type = "null" },
   { "$ref" = "#/components/schemas/repository" },


### PR DESCRIPTION
A similar bug was fixed by: https://github.com/yanyongyu/githubkit/commit/67d4bf55278d65308f57d98044848ff5c4a6c032
So I did the same things and it now works locally.

Fixes #64 