### PR TITLE
Fix: `copilot seat details` schema fixed

### DIFF
--- a/codegen/parser/utils.py
+++ b/codegen/parser/utils.py
@@ -102,7 +102,8 @@ def merge_dict(old: dict, new: dict):
     # make change inplace to make json point correct
     for key, value in new.items():
         if value == UNSET_KEY:
-            del old[key]
+            if key in old:
+                del old[key]
         else:
             old[key] = (
                 merge_dict(old[key], value)

--- a/codegen/parser/utils.py
+++ b/codegen/parser/utils.py
@@ -102,8 +102,7 @@ def merge_dict(old: dict, new: dict):
     # make change inplace to make json point correct
     for key, value in new.items():
         if value == UNSET_KEY:
-            if key in old:
-                del old[key]
+            del old[key]
         else:
             old[key] = (
                 merge_dict(old[key], value)

--- a/githubkit/rest/code_scanning.py
+++ b/githubkit/rest/code_scanning.py
@@ -839,7 +839,7 @@ class CodeScanningClient:
         *,
         data: Literal[UNSET] = UNSET,
         headers: Optional[Dict[str, str]] = None,
-        state: Literal["configured", "not-configured"],
+        state: Missing[Literal["configured", "not-configured"]] = UNSET,
         query_suite: Missing[Literal["default", "extended"]] = UNSET,
         languages: Missing[
             List[
@@ -911,7 +911,7 @@ class CodeScanningClient:
         *,
         data: Literal[UNSET] = UNSET,
         headers: Optional[Dict[str, str]] = None,
-        state: Literal["configured", "not-configured"],
+        state: Missing[Literal["configured", "not-configured"]] = UNSET,
         query_suite: Missing[Literal["default", "extended"]] = UNSET,
         languages: Missing[
             List[

--- a/githubkit/rest/codespaces.py
+++ b/githubkit/rest/codespaces.py
@@ -54,6 +54,7 @@ from .models import (
     OrgsOrgCodespacesSecretsGetResponse200,
     ReposOwnerRepoCodespacesGetResponse200,
     UserCodespacesSecretsSecretNamePutBody,
+    CodespacesPermissionsCheckForDevcontainer,
     OrgsOrgCodespacesSecretsSecretNamePutBody,
     ReposOwnerRepoCodespacesNewGetResponse200,
     UserCodespacesCodespaceNamePublishPostBody,
@@ -1592,6 +1593,72 @@ class CodespacesClient:
                 "401": BasicError,
                 "403": BasicError,
                 "404": BasicError,
+            },
+        )
+
+    def check_permissions_for_devcontainer(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        devcontainer_path: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[CodespacesPermissionsCheckForDevcontainer]":
+        url = f"/repos/{owner}/{repo}/codespaces/permissions_check"
+
+        params = {
+            "ref": ref,
+            "devcontainer_path": devcontainer_path,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=CodespacesPermissionsCheckForDevcontainer,
+            error_models={
+                "401": BasicError,
+                "403": BasicError,
+                "404": BasicError,
+                "422": ValidationError,
+                "503": EnterprisesEnterpriseSecretScanningAlertsGetResponse503,
+            },
+        )
+
+    async def async_check_permissions_for_devcontainer(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        devcontainer_path: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[CodespacesPermissionsCheckForDevcontainer]":
+        url = f"/repos/{owner}/{repo}/codespaces/permissions_check"
+
+        params = {
+            "ref": ref,
+            "devcontainer_path": devcontainer_path,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=CodespacesPermissionsCheckForDevcontainer,
+            error_models={
+                "401": BasicError,
+                "403": BasicError,
+                "404": BasicError,
+                "422": ValidationError,
+                "503": EnterprisesEnterpriseSecretScanningAlertsGetResponse503,
             },
         )
 

--- a/githubkit/rest/copilot.py
+++ b/githubkit/rest/copilot.py
@@ -602,7 +602,7 @@ class CopilotClient:
             },
         )
 
-    def get_copilot_seat_assignment_details_for_user(
+    def get_copilot_seat_details_for_user(
         self,
         org: str,
         username: str,
@@ -626,7 +626,7 @@ class CopilotClient:
             },
         )
 
-    async def async_get_copilot_seat_assignment_details_for_user(
+    async def async_get_copilot_seat_details_for_user(
         self,
         org: str,
         username: str,

--- a/githubkit/rest/licenses.py
+++ b/githubkit/rest/licenses.py
@@ -137,6 +137,9 @@ class LicensesClient:
             url,
             headers=exclude_unset(headers),
             response_model=LicenseContent,
+            error_models={
+                "404": BasicError,
+            },
         )
 
     async def async_get_for_repo(
@@ -155,4 +158,7 @@ class LicensesClient:
             url,
             headers=exclude_unset(headers),
             response_model=LicenseContent,
+            error_models={
+                "404": BasicError,
+            },
         )

--- a/githubkit/rest/models.py
+++ b/githubkit/rest/models.py
@@ -584,8 +584,16 @@ class AppPermissions(GitHubRestModel):
         description="The level of permission to grant the access token for checks on code.",
         default=UNSET,
     )
+    codespaces: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to create, edit, delete, and list Codespaces.",
+        default=UNSET,
+    )
     contents: Missing[Literal["read", "write"]] = Field(
         description="The level of permission to grant the access token for repository contents, commits, branches, downloads, releases, and merges.",
+        default=UNSET,
+    )
+    dependabot_secrets: Missing[Literal["read", "write"]] = Field(
+        description="The leve of permission to grant the access token to manage Dependabot secrets.",
         default=UNSET,
     )
     deployments: Missing[Literal["read", "write"]] = Field(
@@ -614,6 +622,10 @@ class AppPermissions(GitHubRestModel):
     )
     pull_requests: Missing[Literal["read", "write"]] = Field(
         description="The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.",
+        default=UNSET,
+    )
+    repository_custom_properties: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to view and edit custom properties for a repository, when allowed by the property.",
         default=UNSET,
     )
     repository_hooks: Missing[Literal["read", "write"]] = Field(
@@ -661,11 +673,27 @@ class AppPermissions(GitHubRestModel):
         default=UNSET,
     )
     organization_custom_roles: Missing[Literal["read", "write"]] = Field(
-        description="The level of permission to grant the access token for custom repository roles management. This property is in beta and is subject to change.",
+        description="The level of permission to grant the access token for custom repository roles management.",
+        default=UNSET,
+    )
+    organization_custom_org_roles: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token for custom organization roles management.",
+        default=UNSET,
+    )
+    organization_custom_properties: Missing[Literal["read", "write", "admin"]] = Field(
+        description="The level of permission to grant the access token for custom property management.",
+        default=UNSET,
+    )
+    organization_copilot_seat_management: Missing[Literal["write"]] = Field(
+        description="The level of permission to grant the access token for managing access to GitHub Copilot for members of an organization with a Copilot Business subscription. This property is in beta and is subject to change.",
         default=UNSET,
     )
     organization_announcement_banners: Missing[Literal["read", "write"]] = Field(
         description="The level of permission to grant the access token to view and manage announcement banners for an organization.",
+        default=UNSET,
+    )
+    organization_events: Missing[Literal["read"]] = Field(
+        description="The level of permission to grant the access token to view events triggered by an activity in an organization.",
         default=UNSET,
     )
     organization_hooks: Missing[Literal["read", "write"]] = Field(
@@ -708,6 +736,34 @@ class AppPermissions(GitHubRestModel):
     )
     team_discussions: Missing[Literal["read", "write"]] = Field(
         description="The level of permission to grant the access token to manage team discussions and related comments.",
+        default=UNSET,
+    )
+    email_addresses: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to manage the email addresses belonging to a user.",
+        default=UNSET,
+    )
+    followers: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to manage the followers belonging to a user.",
+        default=UNSET,
+    )
+    git_ssh_keys: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to manage git SSH keys.",
+        default=UNSET,
+    )
+    gpg_keys: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to view and manage GPG keys belonging to a user.",
+        default=UNSET,
+    )
+    interaction_limits: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to view and manage interaction limits on a repository.",
+        default=UNSET,
+    )
+    profile: Missing[Literal["write"]] = Field(
+        description="The level of permission to grant the access token to manage the profile settings belonging to a user.",
+        default=UNSET,
+    )
+    starring: Missing[Literal["read", "write"]] = Field(
+        description="The level of permission to grant the access token to list and manage repositories a user is starring.",
         default=UNSET,
     )
 
@@ -846,7 +902,7 @@ class Repository(GitHubRestModel):
     stargazers_count: int = Field(default=...)
     watchers_count: int = Field(default=...)
     size: int = Field(
-        description="The size of the repository. Size is calculated hourly. When a repository is initially created, the size is 0.",
+        description="The size of the repository, in kilobytes. Size is calculated hourly. When a repository is initially created, the size is 0.",
         default=...,
     )
     default_branch: str = Field(
@@ -1949,6 +2005,9 @@ class OrganizationSecretScanningAlert(GitHubRestModel):
         description="The comment that was optionally added when this alert was closed",
         default=UNSET,
     )
+    validity: Missing[Literal["active", "inactive", "unknown"]] = Field(
+        description="The token status as of the latest validity check.", default=UNSET
+    )
 
 
 class Actor(GitHubRestModel):
@@ -2673,6 +2732,7 @@ class ApiOverviewPropDomains(GitHubRestModel):
     codespaces: Missing[List[str]] = Field(default=UNSET)
     copilot: Missing[List[str]] = Field(default=UNSET)
     packages: Missing[List[str]] = Field(default=UNSET)
+    actions: Missing[List[str]] = Field(default=UNSET)
 
 
 class SecurityAndAnalysisPropAdvancedSecurity(GitHubRestModel):
@@ -2790,7 +2850,7 @@ class MinimalRepository(GitHubRestModel):
     stargazers_count: Missing[int] = Field(default=UNSET)
     watchers_count: Missing[int] = Field(default=UNSET)
     size: Missing[int] = Field(
-        description="The size of the repository. Size is calculated hourly. When a repository is initially created, the size is 0.",
+        description="The size of the repository, in kilobytes. Size is calculated hourly. When a repository is initially created, the size is 0.",
         default=UNSET,
     )
     default_branch: Missing[str] = Field(default=UNSET)
@@ -3258,8 +3318,8 @@ class OrganizationActionsVariable(GitHubRestModel):
     selected_repositories_url: Missing[str] = Field(default=UNSET)
 
 
-class CodeScanningAlertRule(GitHubRestModel):
-    """CodeScanningAlertRule"""
+class CodeScanningAlertRuleSummary(GitHubRestModel):
+    """CodeScanningAlertRuleSummary"""
 
     id: Missing[Union[str, None]] = Field(
         description="A unique identifier for the rule used to detect the alert.",
@@ -3267,6 +3327,9 @@ class CodeScanningAlertRule(GitHubRestModel):
     )
     name: Missing[str] = Field(
         description="The name of the rule used to detect the alert.", default=UNSET
+    )
+    tags: Missing[Union[List[str], None]] = Field(
+        description="A set of tags applicable for the rule.", default=UNSET
     )
     severity: Missing[Union[None, Literal["none", "note", "warning", "error"]]] = Field(
         description="The severity of the alert.", default=UNSET
@@ -3276,21 +3339,6 @@ class CodeScanningAlertRule(GitHubRestModel):
     ] = Field(description="The security severity of the alert.", default=UNSET)
     description: Missing[str] = Field(
         description="A short description of the rule used to detect the alert.",
-        default=UNSET,
-    )
-    full_description: Missing[str] = Field(
-        description="description of the rule used to detect the alert.", default=UNSET
-    )
-    tags: Missing[Union[List[str], None]] = Field(
-        description="A set of tags applicable for the rule.", default=UNSET
-    )
-    help_: Missing[Union[str, None]] = Field(
-        description="Detailed documentation for the rule as GitHub Flavored Markdown.",
-        default=UNSET,
-        alias="help",
-    )
-    help_uri: Missing[Union[str, None]] = Field(
-        description="A link to the documentation for the rule used to detect the alert.",
         default=UNSET,
     )
 
@@ -3329,7 +3377,7 @@ class CodeScanningAlertInstance(GitHubRestModel):
     """CodeScanningAlertInstance"""
 
     ref: Missing[str] = Field(
-        description="The full Git reference, formatted as `refs/heads/<branch name>`,\n`refs/pull/<number>/merge`, or `refs/pull/<number>/head`.",
+        description="The Git reference, formatted as `refs/pull/<number>/merge`, `refs/pull/<number>/head`,\n`refs/heads/<branch name>` or simply `<branch name>`.",
         default=UNSET,
     )
     analysis_key: Missing[str] = Field(
@@ -3413,7 +3461,7 @@ class CodeScanningOrganizationAlertItems(GitHubRestModel):
         description="The dismissal comment associated with the dismissal of the alert.",
         default=UNSET,
     )
-    rule: CodeScanningAlertRule = Field(default=...)
+    rule: CodeScanningAlertRuleSummary = Field(default=...)
     tool: CodeScanningAnalysisTool = Field(default=...)
     most_recent_instance: CodeScanningAlertInstance = Field(default=...)
     repository: SimpleRepository = Field(
@@ -3643,9 +3691,9 @@ class CodespacesPublicKey(GitHubRestModel):
 
 
 class CopilotSeatBreakdown(GitHubRestModel):
-    """Copilot for Business Seat Breakdown
+    """Copilot Business Seat Breakdown
 
-    The breakdown of Copilot for Business seats for the organization.
+    The breakdown of Copilot Business seats for the organization.
     """
 
     total: Missing[int] = Field(
@@ -3674,15 +3722,15 @@ class CopilotSeatBreakdown(GitHubRestModel):
 
 
 class CopilotOrganizationDetails(GitHubRestModel, extra=Extra.allow):
-    """Copilot for Business Organization Details
+    """Copilot Business Organization Details
 
     Information about the seat breakdown and policies set for an organization with a
-    Copilot for Business subscription.
+    Copilot Business subscription.
     """
 
     seat_breakdown: CopilotSeatBreakdown = Field(
-        title="Copilot for Business Seat Breakdown",
-        description="The breakdown of Copilot for Business seats for the organization.",
+        title="Copilot Business Seat Breakdown",
+        description="The breakdown of Copilot Business seats for the organization.",
         default=...,
     )
     public_code_suggestions: Literal[
@@ -3690,6 +3738,10 @@ class CopilotOrganizationDetails(GitHubRestModel, extra=Extra.allow):
     ] = Field(
         description="The organization policy for allowing or disallowing Copilot to make suggestions that match public code.",
         default=...,
+    )
+    copilot_chat: Missing[Literal["enabled", "disabled", "unconfigured"]] = Field(
+        description="The organization policy for allowing or disallowing organization members to use Copilot Chat within their editor.",
+        default=UNSET,
     )
     seat_management_setting: Literal[
         "assign_all", "assign_selected", "disabled", "unconfigured"
@@ -3829,9 +3881,9 @@ class OrganizationPropPlan(GitHubRestModel):
 
 
 class CopilotSeatDetails(GitHubRestModel):
-    """Copilot for Business Seat Detail
+    """Copilot Business Seat Detail
 
-    Information about a Copilot for Business seat assignment for a user, team, or
+    Information about a Copilot Business seat assignment for a user, team, or
     organization.
     """
 
@@ -4062,6 +4114,42 @@ class Migration(GitHubRestModel):
     exclude: Missing[List[str]] = Field(
         description='Exclude related items from being returned in the response in order to improve performance of the request. The array can include any of: `"repositories"`.',
         default=UNSET,
+    )
+
+
+class OrganizationFineGrainedPermission(GitHubRestModel):
+    """Organization Fine-Grained Permission
+
+    A fine-grained permission that protects organization resources.
+    """
+
+    name: str = Field(default=...)
+    description: str = Field(default=...)
+
+
+class OrganizationRole(GitHubRestModel):
+    """Organization Role
+
+    Organization roles
+    """
+
+    id: int = Field(description="The unique identifier of the role.", default=...)
+    name: str = Field(description="The name of the role.", default=...)
+    description: Missing[Union[str, None]] = Field(
+        description="A short description about who this role is for or what permissions it grants.",
+        default=UNSET,
+    )
+    permissions: List[str] = Field(
+        description="A list of permissions included in this role.", default=...
+    )
+    organization: Union[None, SimpleUser] = Field(
+        title="Simple User", description="A GitHub user.", default=...
+    )
+    created_at: datetime = Field(
+        description="The date and time the role was created.", default=...
+    )
+    updated_at: datetime = Field(
+        description="The date and time the role was last updated.", default=...
     )
 
 
@@ -4306,6 +4394,235 @@ class Project(GitHubRestModel):
     )
 
 
+class OrgCustomProperty(GitHubRestModel):
+    """Organization Custom Property
+
+    Custom property defined on an organization
+    """
+
+    property_name: str = Field(description="The name of the property", default=...)
+    value_type: Literal["string", "single_select"] = Field(
+        description="The type of the value for the property", default=...
+    )
+    required: Missing[bool] = Field(
+        description="Whether the property is required.", default=UNSET
+    )
+    default_value: Missing[Union[str, None]] = Field(
+        description="Default value of the property", default=UNSET
+    )
+    description: Missing[Union[str, None]] = Field(
+        description="Short description of the property", default=UNSET
+    )
+    allowed_values: Missing[Union[List[str], None]] = Field(
+        description="Ordered list of allowed values of the property", default=UNSET
+    )
+
+
+class CustomPropertyValue(GitHubRestModel):
+    """Custom Property Value
+
+    Custom property name and associated value
+    """
+
+    property_name: str = Field(description="The name of the property", default=...)
+    value: Union[str, None] = Field(
+        description="The value assigned to the property", default=...
+    )
+
+
+class OrgRepoCustomPropertyValues(GitHubRestModel):
+    """Organization Repository Custom Property Values
+
+    List of custom property values for a repository
+    """
+
+    repository_id: int = Field(default=...)
+    repository_name: str = Field(default=...)
+    repository_full_name: str = Field(default=...)
+    properties: List[CustomPropertyValue] = Field(
+        description="List of custom property names and associated values", default=...
+    )
+
+
+class CodeOfConductSimple(GitHubRestModel):
+    """Code Of Conduct Simple
+
+    Code of Conduct Simple
+    """
+
+    url: str = Field(default=...)
+    key: str = Field(default=...)
+    name: str = Field(default=...)
+    html_url: Union[str, None] = Field(default=...)
+
+
+class FullRepository(GitHubRestModel):
+    """Full Repository
+
+    Full Repository
+    """
+
+    id: int = Field(default=...)
+    node_id: str = Field(default=...)
+    name: str = Field(default=...)
+    full_name: str = Field(default=...)
+    owner: SimpleUser = Field(
+        title="Simple User", description="A GitHub user.", default=...
+    )
+    private: bool = Field(default=...)
+    html_url: str = Field(default=...)
+    description: Union[str, None] = Field(default=...)
+    fork: bool = Field(default=...)
+    url: str = Field(default=...)
+    archive_url: str = Field(default=...)
+    assignees_url: str = Field(default=...)
+    blobs_url: str = Field(default=...)
+    branches_url: str = Field(default=...)
+    collaborators_url: str = Field(default=...)
+    comments_url: str = Field(default=...)
+    commits_url: str = Field(default=...)
+    compare_url: str = Field(default=...)
+    contents_url: str = Field(default=...)
+    contributors_url: str = Field(default=...)
+    deployments_url: str = Field(default=...)
+    downloads_url: str = Field(default=...)
+    events_url: str = Field(default=...)
+    forks_url: str = Field(default=...)
+    git_commits_url: str = Field(default=...)
+    git_refs_url: str = Field(default=...)
+    git_tags_url: str = Field(default=...)
+    git_url: str = Field(default=...)
+    issue_comment_url: str = Field(default=...)
+    issue_events_url: str = Field(default=...)
+    issues_url: str = Field(default=...)
+    keys_url: str = Field(default=...)
+    labels_url: str = Field(default=...)
+    languages_url: str = Field(default=...)
+    merges_url: str = Field(default=...)
+    milestones_url: str = Field(default=...)
+    notifications_url: str = Field(default=...)
+    pulls_url: str = Field(default=...)
+    releases_url: str = Field(default=...)
+    ssh_url: str = Field(default=...)
+    stargazers_url: str = Field(default=...)
+    statuses_url: str = Field(default=...)
+    subscribers_url: str = Field(default=...)
+    subscription_url: str = Field(default=...)
+    tags_url: str = Field(default=...)
+    teams_url: str = Field(default=...)
+    trees_url: str = Field(default=...)
+    clone_url: str = Field(default=...)
+    mirror_url: Union[str, None] = Field(default=...)
+    hooks_url: str = Field(default=...)
+    svn_url: str = Field(default=...)
+    homepage: Union[str, None] = Field(default=...)
+    language: Union[str, None] = Field(default=...)
+    forks_count: int = Field(default=...)
+    stargazers_count: int = Field(default=...)
+    watchers_count: int = Field(default=...)
+    size: int = Field(
+        description="The size of the repository, in kilobytes. Size is calculated hourly. When a repository is initially created, the size is 0.",
+        default=...,
+    )
+    default_branch: str = Field(default=...)
+    open_issues_count: int = Field(default=...)
+    is_template: Missing[bool] = Field(default=UNSET)
+    topics: Missing[List[str]] = Field(default=UNSET)
+    has_issues: bool = Field(default=...)
+    has_projects: bool = Field(default=...)
+    has_wiki: bool = Field(default=...)
+    has_pages: bool = Field(default=...)
+    has_downloads: Missing[bool] = Field(default=UNSET)
+    has_discussions: bool = Field(default=...)
+    archived: bool = Field(default=...)
+    disabled: bool = Field(
+        description="Returns whether or not this repository disabled.", default=...
+    )
+    visibility: Missing[str] = Field(
+        description="The repository visibility: public, private, or internal.",
+        default=UNSET,
+    )
+    pushed_at: datetime = Field(default=...)
+    created_at: datetime = Field(default=...)
+    updated_at: datetime = Field(default=...)
+    permissions: Missing[FullRepositoryPropPermissions] = Field(default=UNSET)
+    allow_rebase_merge: Missing[bool] = Field(default=UNSET)
+    template_repository: Missing[Union[None, Repository]] = Field(
+        title="Repository", description="A repository on GitHub.", default=UNSET
+    )
+    temp_clone_token: Missing[Union[str, None]] = Field(default=UNSET)
+    allow_squash_merge: Missing[bool] = Field(default=UNSET)
+    allow_auto_merge: Missing[bool] = Field(default=UNSET)
+    delete_branch_on_merge: Missing[bool] = Field(default=UNSET)
+    allow_merge_commit: Missing[bool] = Field(default=UNSET)
+    allow_update_branch: Missing[bool] = Field(default=UNSET)
+    use_squash_pr_title_as_default: Missing[bool] = Field(default=UNSET)
+    squash_merge_commit_title: Missing[
+        Literal["PR_TITLE", "COMMIT_OR_PR_TITLE"]
+    ] = Field(
+        description="The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
+        default=UNSET,
+    )
+    squash_merge_commit_message: Missing[
+        Literal["PR_BODY", "COMMIT_MESSAGES", "BLANK"]
+    ] = Field(
+        description="The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
+        default=UNSET,
+    )
+    merge_commit_title: Missing[Literal["PR_TITLE", "MERGE_MESSAGE"]] = Field(
+        description="The default value for a merge commit title.\n\n  - `PR_TITLE` - default to the pull request's title.\n  - `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
+        default=UNSET,
+    )
+    merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = Field(
+        description="The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
+        default=UNSET,
+    )
+    allow_forking: Missing[bool] = Field(default=UNSET)
+    web_commit_signoff_required: Missing[bool] = Field(default=UNSET)
+    subscribers_count: int = Field(default=...)
+    network_count: int = Field(default=...)
+    license_: Union[None, LicenseSimple] = Field(
+        title="License Simple",
+        description="License Simple",
+        default=...,
+        alias="license",
+    )
+    organization: Missing[Union[None, SimpleUser]] = Field(
+        title="Simple User", description="A GitHub user.", default=UNSET
+    )
+    parent: Missing[Repository] = Field(
+        title="Repository", description="A repository on GitHub.", default=UNSET
+    )
+    source: Missing[Repository] = Field(
+        title="Repository", description="A repository on GitHub.", default=UNSET
+    )
+    forks: int = Field(default=...)
+    master_branch: Missing[str] = Field(default=UNSET)
+    open_issues: int = Field(default=...)
+    watchers: int = Field(default=...)
+    anonymous_access_enabled: Missing[bool] = Field(
+        description="Whether anonymous git access is allowed.", default=True
+    )
+    code_of_conduct: Missing[CodeOfConductSimple] = Field(
+        title="Code Of Conduct Simple",
+        description="Code of Conduct Simple",
+        default=UNSET,
+    )
+    security_and_analysis: Missing[Union[SecurityAndAnalysis, None]] = Field(
+        default=UNSET
+    )
+
+
+class FullRepositoryPropPermissions(GitHubRestModel):
+    """FullRepositoryPropPermissions"""
+
+    admin: bool = Field(default=...)
+    maintain: Missing[bool] = Field(default=UNSET)
+    push: bool = Field(default=...)
+    triage: Missing[bool] = Field(default=UNSET)
+    pull: bool = Field(default=...)
+
+
 class RepositoryRulesetBypassActor(GitHubRestModel):
     """Repository Ruleset Bypass Actor
 
@@ -4313,7 +4630,8 @@ class RepositoryRulesetBypassActor(GitHubRestModel):
     """
 
     actor_id: int = Field(
-        description="The ID of the actor that can bypass a ruleset", default=...
+        description="The ID of the actor that can bypass a ruleset. If `actor_type` is `OrganizationAdmin`, this should be `1`.",
+        default=...,
     )
     actor_type: Literal[
         "RepositoryRole", "Team", "Integration", "OrganizationAdmin"
@@ -4469,7 +4787,7 @@ class RepositoryRuleRequiredDeployments(GitHubRestModel):
     """required_deployments
 
     Choose which environments must be successfully deployed to before refs can be
-    merged into a branch that matches this rule.
+    pushed into a ref that matches this rule.
     """
 
     type: Literal["required_deployments"] = Field(default=...)
@@ -4552,10 +4870,8 @@ class RepositoryRuleParamsStatusCheckConfiguration(GitHubRestModel):
 class RepositoryRuleRequiredStatusChecks(GitHubRestModel):
     """required_status_checks
 
-    Choose which status checks must pass before branches can be merged into a branch
-    that matches this rule. When enabled, commits must first be pushed to another
-    branch, then merged or pushed directly to a ref that matches this rule after
-    status checks have passed.
+    Choose which status checks must pass before the ref is updated. When enabled,
+    commits must first be pushed to another ref where the checks pass.
     """
 
     type: Literal["required_status_checks"] = Field(default=...)
@@ -4720,6 +5036,44 @@ class RepositoryRuleTagNamePatternPropParameters(GitHubRestModel):
     pattern: str = Field(description="The pattern to match with.", default=...)
 
 
+class RepositoryRuleParamsWorkflowFileReference(GitHubRestModel):
+    """WorkflowFileReference
+
+    A workflow that must run for this rule to pass
+    """
+
+    path: str = Field(description="The path to the workflow file", default=...)
+    ref: Missing[str] = Field(
+        description="The ref (branch or tag) of the workflow file to use", default=UNSET
+    )
+    repository_id: int = Field(
+        description="The ID of the repository where the workflow is defined",
+        default=...,
+    )
+    sha: Missing[str] = Field(
+        description="The commit SHA of the workflow file to use", default=UNSET
+    )
+
+
+class RepositoryRuleWorkflows(GitHubRestModel):
+    """workflows
+
+    Require all changes made to a targeted branch to pass the specified workflows
+    before they can be merged.
+    """
+
+    type: Literal["workflows"] = Field(default=...)
+    parameters: Missing[RepositoryRuleWorkflowsPropParameters] = Field(default=UNSET)
+
+
+class RepositoryRuleWorkflowsPropParameters(GitHubRestModel):
+    """RepositoryRuleWorkflowsPropParameters"""
+
+    workflows: List[RepositoryRuleParamsWorkflowFileReference] = Field(
+        description="Workflows that must pass for this rule to pass.", default=...
+    )
+
+
 class RepositoryRuleset(GitHubRestModel):
     """Repository ruleset
 
@@ -4779,6 +5133,7 @@ class RepositoryRuleset(GitHubRestModel):
                 RepositoryRuleCommitterEmailPattern,
                 RepositoryRuleBranchNamePattern,
                 RepositoryRuleTagNamePattern,
+                RepositoryRuleWorkflows,
             ]
         ]
     ] = Field(default=UNSET)
@@ -4805,6 +5160,123 @@ class RepositoryRulesetPropLinksPropHtml(GitHubRestModel):
     """RepositoryRulesetPropLinksPropHtml"""
 
     href: Missing[str] = Field(description="The html URL of the ruleset", default=UNSET)
+
+
+class RuleSuitesItems(GitHubRestModel):
+    """RuleSuitesItems"""
+
+    id: Missing[int] = Field(
+        description="The unique identifier of the rule insight.", default=UNSET
+    )
+    actor_id: Missing[int] = Field(
+        description="The number that identifies the user.", default=UNSET
+    )
+    actor_name: Missing[str] = Field(
+        description="The handle for the GitHub user account.", default=UNSET
+    )
+    before_sha: Missing[str] = Field(
+        description="The first commit sha before the push evaluation.", default=UNSET
+    )
+    after_sha: Missing[str] = Field(
+        description="The last commit sha in the push evaluation.", default=UNSET
+    )
+    ref: Missing[str] = Field(
+        description="The ref name that the evaluation ran on.", default=UNSET
+    )
+    repository_id: Missing[int] = Field(
+        description="The ID of the repository associated with the rule evaluation.",
+        default=UNSET,
+    )
+    repository_name: Missing[str] = Field(
+        description="The name of the repository without the `.git` extension.",
+        default=UNSET,
+    )
+    pushed_at: Missing[datetime] = Field(default=UNSET)
+    result: Missing[Literal["pass", "fail", "bypass"]] = Field(
+        description="The result of the rule evaluations for rules with the `active` enforcement status.",
+        default=UNSET,
+    )
+    evaluation_result: Missing[Literal["pass", "fail"]] = Field(
+        description="The result of the rule evaluations for rules with the `active` and `evaluate` enforcement statuses, demonstrating whether rules would pass or fail if all rules in the rule suite were `active`.",
+        default=UNSET,
+    )
+
+
+class RuleSuite(GitHubRestModel):
+    """Rule Suite
+
+    Response
+    """
+
+    id: Missing[int] = Field(
+        description="The unique identifier of the rule insight.", default=UNSET
+    )
+    actor_id: Missing[int] = Field(
+        description="The number that identifies the user.", default=UNSET
+    )
+    actor_name: Missing[str] = Field(
+        description="The handle for the GitHub user account.", default=UNSET
+    )
+    before_sha: Missing[str] = Field(
+        description="The first commit sha before the push evaluation.", default=UNSET
+    )
+    after_sha: Missing[str] = Field(
+        description="The last commit sha in the push evaluation.", default=UNSET
+    )
+    ref: Missing[str] = Field(
+        description="The ref name that the evaluation ran on.", default=UNSET
+    )
+    repository_id: Missing[int] = Field(
+        description="The ID of the repository associated with the rule evaluation.",
+        default=UNSET,
+    )
+    repository_name: Missing[str] = Field(
+        description="The name of the repository without the `.git` extension.",
+        default=UNSET,
+    )
+    pushed_at: Missing[datetime] = Field(default=UNSET)
+    result: Missing[Literal["pass", "fail", "bypass"]] = Field(
+        description="The result of the rule evaluations for rules with the `active` enforcement status.",
+        default=UNSET,
+    )
+    evaluation_result: Missing[Literal["pass", "fail"]] = Field(
+        description="The result of the rule evaluations for rules with the `active` and `evaluate` enforcement statuses, demonstrating whether rules would pass or fail if all rules in the rule suite were `active`.",
+        default=UNSET,
+    )
+    rule_evaluations: Missing[List[RuleSuitePropRuleEvaluationsItems]] = Field(
+        description="Details on the evaluated rules.", default=UNSET
+    )
+
+
+class RuleSuitePropRuleEvaluationsItems(GitHubRestModel):
+    """RuleSuitePropRuleEvaluationsItems"""
+
+    rule_source: Missing[RuleSuitePropRuleEvaluationsItemsPropRuleSource] = Field(
+        default=UNSET
+    )
+    enforcement: Missing[Literal["active", "evaluate", "deleted ruleset"]] = Field(
+        description="The enforcement level of this rule source.", default=UNSET
+    )
+    result: Missing[Literal["pass", "fail"]] = Field(
+        description="The result of the evaluation of the individual rule.",
+        default=UNSET,
+    )
+    rule_type: Missing[str] = Field(description="The type of rule.", default=UNSET)
+    details: Missing[str] = Field(
+        description="Any associated details with the rule evaluation.", default=UNSET
+    )
+
+
+class RuleSuitePropRuleEvaluationsItemsPropRuleSource(GitHubRestModel):
+    """RuleSuitePropRuleEvaluationsItemsPropRuleSource"""
+
+    type: Missing[str] = Field(description="The type of rule source.", default=UNSET)
+    id: Missing[Union[int, None]] = Field(
+        description="The ID of the rule source.", default=UNSET
+    )
+    name: Missing[Union[str, None]] = Field(
+        description="The name of the rule source.", default=UNSET
+    )
 
 
 class RepositoryAdvisoryVulnerability(GitHubRestModel):
@@ -5271,7 +5743,7 @@ class TeamDiscussion(GitHubRestModel):
         default=...,
     )
     private: bool = Field(
-        description="Whether or not this discussion should be restricted to team members and organization administrators.",
+        description="Whether or not this discussion should be restricted to team members and organization owners.",
         default=...,
     )
     team_url: str = Field(default=...)
@@ -5493,9 +5965,6 @@ class TeamRepository(GitHubRestModel):
     allow_rebase_merge: Missing[bool] = Field(
         description="Whether to allow rebase merges for pull requests.", default=True
     )
-    template_repository: Missing[Union[None, Repository]] = Field(
-        title="Repository", description="A repository on GitHub.", default=UNSET
-    )
     temp_clone_token: Missing[Union[str, None]] = Field(default=UNSET)
     allow_squash_merge: Missing[bool] = Field(
         description="Whether to allow squash merges for pull requests.", default=True
@@ -5626,185 +6095,6 @@ class RateLimitOverviewPropResources(GitHubRestModel):
     dependency_snapshots: Missing[RateLimit] = Field(title="Rate Limit", default=UNSET)
 
 
-class CodeOfConductSimple(GitHubRestModel):
-    """Code Of Conduct Simple
-
-    Code of Conduct Simple
-    """
-
-    url: str = Field(default=...)
-    key: str = Field(default=...)
-    name: str = Field(default=...)
-    html_url: Union[str, None] = Field(default=...)
-
-
-class FullRepository(GitHubRestModel):
-    """Full Repository
-
-    Full Repository
-    """
-
-    id: int = Field(default=...)
-    node_id: str = Field(default=...)
-    name: str = Field(default=...)
-    full_name: str = Field(default=...)
-    owner: SimpleUser = Field(
-        title="Simple User", description="A GitHub user.", default=...
-    )
-    private: bool = Field(default=...)
-    html_url: str = Field(default=...)
-    description: Union[str, None] = Field(default=...)
-    fork: bool = Field(default=...)
-    url: str = Field(default=...)
-    archive_url: str = Field(default=...)
-    assignees_url: str = Field(default=...)
-    blobs_url: str = Field(default=...)
-    branches_url: str = Field(default=...)
-    collaborators_url: str = Field(default=...)
-    comments_url: str = Field(default=...)
-    commits_url: str = Field(default=...)
-    compare_url: str = Field(default=...)
-    contents_url: str = Field(default=...)
-    contributors_url: str = Field(default=...)
-    deployments_url: str = Field(default=...)
-    downloads_url: str = Field(default=...)
-    events_url: str = Field(default=...)
-    forks_url: str = Field(default=...)
-    git_commits_url: str = Field(default=...)
-    git_refs_url: str = Field(default=...)
-    git_tags_url: str = Field(default=...)
-    git_url: str = Field(default=...)
-    issue_comment_url: str = Field(default=...)
-    issue_events_url: str = Field(default=...)
-    issues_url: str = Field(default=...)
-    keys_url: str = Field(default=...)
-    labels_url: str = Field(default=...)
-    languages_url: str = Field(default=...)
-    merges_url: str = Field(default=...)
-    milestones_url: str = Field(default=...)
-    notifications_url: str = Field(default=...)
-    pulls_url: str = Field(default=...)
-    releases_url: str = Field(default=...)
-    ssh_url: str = Field(default=...)
-    stargazers_url: str = Field(default=...)
-    statuses_url: str = Field(default=...)
-    subscribers_url: str = Field(default=...)
-    subscription_url: str = Field(default=...)
-    tags_url: str = Field(default=...)
-    teams_url: str = Field(default=...)
-    trees_url: str = Field(default=...)
-    clone_url: str = Field(default=...)
-    mirror_url: Union[str, None] = Field(default=...)
-    hooks_url: str = Field(default=...)
-    svn_url: str = Field(default=...)
-    homepage: Union[str, None] = Field(default=...)
-    language: Union[str, None] = Field(default=...)
-    forks_count: int = Field(default=...)
-    stargazers_count: int = Field(default=...)
-    watchers_count: int = Field(default=...)
-    size: int = Field(
-        description="The size of the repository. Size is calculated hourly. When a repository is initially created, the size is 0.",
-        default=...,
-    )
-    default_branch: str = Field(default=...)
-    open_issues_count: int = Field(default=...)
-    is_template: Missing[bool] = Field(default=UNSET)
-    topics: Missing[List[str]] = Field(default=UNSET)
-    has_issues: bool = Field(default=...)
-    has_projects: bool = Field(default=...)
-    has_wiki: bool = Field(default=...)
-    has_pages: bool = Field(default=...)
-    has_downloads: bool = Field(default=...)
-    has_discussions: bool = Field(default=...)
-    archived: bool = Field(default=...)
-    disabled: bool = Field(
-        description="Returns whether or not this repository disabled.", default=...
-    )
-    visibility: Missing[str] = Field(
-        description="The repository visibility: public, private, or internal.",
-        default=UNSET,
-    )
-    pushed_at: datetime = Field(default=...)
-    created_at: datetime = Field(default=...)
-    updated_at: datetime = Field(default=...)
-    permissions: Missing[FullRepositoryPropPermissions] = Field(default=UNSET)
-    allow_rebase_merge: Missing[bool] = Field(default=UNSET)
-    template_repository: Missing[Union[None, Repository]] = Field(
-        title="Repository", description="A repository on GitHub.", default=UNSET
-    )
-    temp_clone_token: Missing[Union[str, None]] = Field(default=UNSET)
-    allow_squash_merge: Missing[bool] = Field(default=UNSET)
-    allow_auto_merge: Missing[bool] = Field(default=UNSET)
-    delete_branch_on_merge: Missing[bool] = Field(default=UNSET)
-    allow_merge_commit: Missing[bool] = Field(default=UNSET)
-    allow_update_branch: Missing[bool] = Field(default=UNSET)
-    use_squash_pr_title_as_default: Missing[bool] = Field(default=UNSET)
-    squash_merge_commit_title: Missing[
-        Literal["PR_TITLE", "COMMIT_OR_PR_TITLE"]
-    ] = Field(
-        description="The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-        default=UNSET,
-    )
-    squash_merge_commit_message: Missing[
-        Literal["PR_BODY", "COMMIT_MESSAGES", "BLANK"]
-    ] = Field(
-        description="The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-        default=UNSET,
-    )
-    merge_commit_title: Missing[Literal["PR_TITLE", "MERGE_MESSAGE"]] = Field(
-        description="The default value for a merge commit title.\n\n  - `PR_TITLE` - default to the pull request's title.\n  - `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-        default=UNSET,
-    )
-    merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = Field(
-        description="The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-        default=UNSET,
-    )
-    allow_forking: Missing[bool] = Field(default=UNSET)
-    web_commit_signoff_required: Missing[bool] = Field(default=UNSET)
-    subscribers_count: int = Field(default=...)
-    network_count: int = Field(default=...)
-    license_: Union[None, LicenseSimple] = Field(
-        title="License Simple",
-        description="License Simple",
-        default=...,
-        alias="license",
-    )
-    organization: Missing[Union[None, SimpleUser]] = Field(
-        title="Simple User", description="A GitHub user.", default=UNSET
-    )
-    parent: Missing[Repository] = Field(
-        title="Repository", description="A repository on GitHub.", default=UNSET
-    )
-    source: Missing[Repository] = Field(
-        title="Repository", description="A repository on GitHub.", default=UNSET
-    )
-    forks: int = Field(default=...)
-    master_branch: Missing[str] = Field(default=UNSET)
-    open_issues: int = Field(default=...)
-    watchers: int = Field(default=...)
-    anonymous_access_enabled: Missing[bool] = Field(
-        description="Whether anonymous git access is allowed.", default=True
-    )
-    code_of_conduct: Missing[CodeOfConductSimple] = Field(
-        title="Code Of Conduct Simple",
-        description="Code of Conduct Simple",
-        default=UNSET,
-    )
-    security_and_analysis: Missing[Union[SecurityAndAnalysis, None]] = Field(
-        default=UNSET
-    )
-
-
-class FullRepositoryPropPermissions(GitHubRestModel):
-    """FullRepositoryPropPermissions"""
-
-    admin: bool = Field(default=...)
-    maintain: Missing[bool] = Field(default=UNSET)
-    push: bool = Field(default=...)
-    triage: Missing[bool] = Field(default=UNSET)
-    pull: bool = Field(default=...)
-
-
 class Artifact(GitHubRestModel):
     """Artifact
 
@@ -5883,7 +6173,7 @@ class Job(GitHubRestModel):
     )
     url: str = Field(default=...)
     html_url: Union[str, None] = Field(default=...)
-    status: Literal["queued", "in_progress", "completed"] = Field(
+    status: Literal["queued", "in_progress", "completed", "waiting"] = Field(
         description="The phase of the lifecycle that the job is currently in.",
         default=...,
     )
@@ -6023,7 +6313,7 @@ class ActionsWorkflowAccessToRepository(GitHubRestModel):
     """ActionsWorkflowAccessToRepository"""
 
     access_level: Literal["none", "user", "organization"] = Field(
-        description="Defines the level of access that workflows outside of the repository have to actions and reusable workflows within the\nrepository.\n\n`none` means the access is only possible from workflows in this repository. `user` level access allows sharing across user owned private repos only. `organization` level access allows sharing across the organization.",
+        description="Defines the level of access that workflows outside of the repository have to actions and reusable workflows within the\nrepository.\n\n`none` means the access is only possible from workflows in this repository. `user` level access allows sharing across user owned private repositories only. `organization` level access allows sharing across the organization.",
         default=...,
     )
 
@@ -7430,28 +7720,6 @@ class CheckSuitePreferencePropPreferencesPropAutoTriggerChecksItems(GitHubRestMo
     setting: bool = Field(default=...)
 
 
-class CodeScanningAlertRuleSummary(GitHubRestModel):
-    """CodeScanningAlertRuleSummary"""
-
-    id: Missing[Union[str, None]] = Field(
-        description="A unique identifier for the rule used to detect the alert.",
-        default=UNSET,
-    )
-    name: Missing[str] = Field(
-        description="The name of the rule used to detect the alert.", default=UNSET
-    )
-    tags: Missing[Union[List[str], None]] = Field(
-        description="A set of tags applicable for the rule.", default=UNSET
-    )
-    severity: Missing[Union[None, Literal["none", "note", "warning", "error"]]] = Field(
-        description="The severity of the alert.", default=UNSET
-    )
-    description: Missing[str] = Field(
-        description="A short description of the rule used to detect the alert.",
-        default=UNSET,
-    )
-
-
 class CodeScanningAlertItems(GitHubRestModel):
     """CodeScanningAlertItems"""
 
@@ -7501,6 +7769,43 @@ class CodeScanningAlertItems(GitHubRestModel):
     rule: CodeScanningAlertRuleSummary = Field(default=...)
     tool: CodeScanningAnalysisTool = Field(default=...)
     most_recent_instance: CodeScanningAlertInstance = Field(default=...)
+
+
+class CodeScanningAlertRule(GitHubRestModel):
+    """CodeScanningAlertRule"""
+
+    id: Missing[Union[str, None]] = Field(
+        description="A unique identifier for the rule used to detect the alert.",
+        default=UNSET,
+    )
+    name: Missing[str] = Field(
+        description="The name of the rule used to detect the alert.", default=UNSET
+    )
+    severity: Missing[Union[None, Literal["none", "note", "warning", "error"]]] = Field(
+        description="The severity of the alert.", default=UNSET
+    )
+    security_severity_level: Missing[
+        Union[None, Literal["low", "medium", "high", "critical"]]
+    ] = Field(description="The security severity of the alert.", default=UNSET)
+    description: Missing[str] = Field(
+        description="A short description of the rule used to detect the alert.",
+        default=UNSET,
+    )
+    full_description: Missing[str] = Field(
+        description="description of the rule used to detect the alert.", default=UNSET
+    )
+    tags: Missing[Union[List[str], None]] = Field(
+        description="A set of tags applicable for the rule.", default=UNSET
+    )
+    help_: Missing[Union[str, None]] = Field(
+        description="Detailed documentation for the rule as GitHub Flavored Markdown.",
+        default=UNSET,
+        alias="help",
+    )
+    help_uri: Missing[Union[str, None]] = Field(
+        description="A link to the documentation for the rule used to detect the alert.",
+        default=UNSET,
+    )
 
 
 class CodeScanningAlert(GitHubRestModel):
@@ -7558,7 +7863,7 @@ class CodeScanningAnalysis(GitHubRestModel):
     """CodeScanningAnalysis"""
 
     ref: str = Field(
-        description="The full Git reference, formatted as `refs/heads/<branch name>`,\n`refs/pull/<number>/merge`, or `refs/pull/<number>/head`.",
+        description="The Git reference, formatted as `refs/pull/<number>/merge`, `refs/pull/<number>/head`,\n`refs/heads/<branch name>` or simply `<branch name>`.",
         default=...,
     )
     commit_sha: str = Field(
@@ -7651,6 +7956,10 @@ class CodeScanningCodeqlDatabase(GitHubRestModel):
         description="The URL at which to download the CodeQL database. The `Accept` header must be set to the value of the `content_type` property.",
         default=...,
     )
+    commit_oid: Missing[Union[str, None]] = Field(
+        description="The commit SHA of the repository at the time the CodeQL database was created.",
+        default=UNSET,
+    )
 
 
 class CodeScanningDefaultSetup(GitHubRestModel):
@@ -7678,7 +7987,7 @@ class CodeScanningDefaultSetup(GitHubRestModel):
                 "swift",
             ]
         ]
-    ] = Field(description="Languages to be analysed.", default=UNSET)
+    ] = Field(description="Languages to be analyzed.", default=UNSET)
     query_suite: Missing[Literal["default", "extended"]] = Field(
         description="CodeQL query suite to be used.", default=UNSET
     )
@@ -7696,9 +8005,8 @@ class CodeScanningDefaultSetupUpdate(GitHubRestModel):
     Configuration for code scanning default setup.
     """
 
-    state: Literal["configured", "not-configured"] = Field(
-        description="Whether code scanning default setup has been configured or not.",
-        default=...,
+    state: Missing[Literal["configured", "not-configured"]] = Field(
+        description="The desired state of code scanning default setup.", default=UNSET
     )
     query_suite: Missing[Literal["default", "extended"]] = Field(
         description="CodeQL query suite to be used.", default=UNSET
@@ -7716,10 +8024,7 @@ class CodeScanningDefaultSetupUpdate(GitHubRestModel):
                 "swift",
             ]
         ]
-    ] = Field(
-        description="CodeQL languages to be analyzed. Supported values are: `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby`, and `swift`.",
-        default=UNSET,
-    )
+    ] = Field(description="CodeQL languages to be analyzed.", default=UNSET)
 
 
 class CodeScanningDefaultSetupUpdateResponse(GitHubRestModel):
@@ -7797,6 +8102,18 @@ class CodeownersErrorsPropErrorsItems(GitHubRestModel):
     )
     path: str = Field(
         description="The path of the file where the error occured.", default=...
+    )
+
+
+class CodespacesPermissionsCheckForDevcontainer(GitHubRestModel):
+    """Codespaces Permissions Check
+
+    Permission check result for a given devcontainer config.
+    """
+
+    accepted: bool = Field(
+        description="Whether the user has accepted the permissions defined by the devcontainer config",
+        default=...,
     )
 
 
@@ -9039,16 +9356,31 @@ class EnvironmentPropProtectionRulesItemsAnyof2(GitHubRestModel):
 class DeploymentBranchPolicy(GitHubRestModel):
     """Deployment branch policy
 
-    Details of a deployment branch policy.
+    Details of a deployment branch or tag policy.
     """
 
     id: Missing[int] = Field(
-        description="The unique identifier of the branch policy.", default=UNSET
+        description="The unique identifier of the branch or tag policy.", default=UNSET
     )
     node_id: Missing[str] = Field(default=UNSET)
     name: Missing[str] = Field(
-        description="The name pattern that branches must match in order to deploy to the environment.",
+        description="The name pattern that branches or tags must match in order to deploy to the environment.",
         default=UNSET,
+    )
+    type: Missing[Literal["branch", "tag"]] = Field(
+        description="Whether this rule targets a branch or tag.", default=UNSET
+    )
+
+
+class DeploymentBranchPolicyNamePatternWithType(GitHubRestModel):
+    """Deployment branch and tag policy name pattern"""
+
+    name: str = Field(
+        description="The name pattern that branches or tags must match in order to deploy to the environment.\n\nWildcard characters will not match `/`. For example, to match branches that begin with `release/` and contain an additional single slash, use `release/*/*`.\nFor more information about pattern matching syntax, see the [Ruby File.fnmatch documentation](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch).",
+        default=...,
+    )
+    type: Missing[Literal["branch", "tag"]] = Field(
+        description="Whether this rule targets a branch or tag", default=UNSET
     )
 
 
@@ -11765,6 +12097,24 @@ class RepositoryRuleDetailedOneof13(GitHubRestModel):
     )
 
 
+class RepositoryRuleDetailedOneof14(GitHubRestModel):
+    """RepositoryRuleDetailedOneof14"""
+
+    type: Literal["workflows"] = Field(default=...)
+    parameters: Missing[RepositoryRuleWorkflowsPropParameters] = Field(default=UNSET)
+    ruleset_source_type: Missing[Literal["Repository", "Organization"]] = Field(
+        description="The type of source for the ruleset that includes this rule.",
+        default=UNSET,
+    )
+    ruleset_source: Missing[str] = Field(
+        description="The name of the source of the ruleset that includes this rule.",
+        default=UNSET,
+    )
+    ruleset_id: Missing[int] = Field(
+        description="The ID of the ruleset that includes this rule.", default=UNSET
+    )
+
+
 class SecretScanningAlert(GitHubRestModel):
     """SecretScanningAlert"""
 
@@ -11829,6 +12179,9 @@ class SecretScanningAlert(GitHubRestModel):
     push_protection_bypassed_at: Missing[Union[datetime, None]] = Field(
         description="The time that push protection was bypassed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.",
         default=UNSET,
+    )
+    validity: Missing[Literal["active", "inactive", "unknown"]] = Field(
+        description="The token status as of the latest validity check.", default=UNSET
     )
 
 
@@ -11907,11 +12260,129 @@ class SecretScanningLocationIssueComment(GitHubRestModel):
     )
 
 
+class SecretScanningLocationDiscussionTitle(GitHubRestModel):
+    """SecretScanningLocationDiscussionTitle
+
+    Represents a 'discussion_title' secret scanning location type. This location
+    type shows that a secret was detected in the title of a discussion.
+    """
+
+    discussion_title_url: str = Field(
+        description="The URL to the discussion where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationDiscussionBody(GitHubRestModel):
+    """SecretScanningLocationDiscussionBody
+
+    Represents a 'discussion_body' secret scanning location type. This location type
+    shows that a secret was detected in the body of a discussion.
+    """
+
+    discussion_body_url: str = Field(
+        description="The URL to the discussion where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationDiscussionComment(GitHubRestModel):
+    """SecretScanningLocationDiscussionComment
+
+    Represents a 'discussion_comment' secret scanning location type. This location
+    type shows that a secret was detected in a comment on a discussion.
+    """
+
+    discussion_comment_url: str = Field(
+        description="The API URL to get the discussion comment where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationPullRequestTitle(GitHubRestModel):
+    """SecretScanningLocationPullRequestTitle
+
+    Represents a 'pull_request_title' secret scanning location type. This location
+    type shows that a secret was detected in the title of a pull request.
+    """
+
+    pull_request_title_url: str = Field(
+        description="The API URL to get the pull request where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationPullRequestBody(GitHubRestModel):
+    """SecretScanningLocationPullRequestBody
+
+    Represents a 'pull_request_body' secret scanning location type. This location
+    type shows that a secret was detected in the body of a pull request.
+    """
+
+    pull_request_body_url: str = Field(
+        description="The API URL to get the pull request where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationPullRequestComment(GitHubRestModel):
+    """SecretScanningLocationPullRequestComment
+
+    Represents a 'pull_request_comment' secret scanning location type. This location
+    type shows that a secret was detected in a comment on a pull request.
+    """
+
+    pull_request_comment_url: str = Field(
+        description="The API URL to get the pull request comment where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationPullRequestReview(GitHubRestModel):
+    """SecretScanningLocationPullRequestReview
+
+    Represents a 'pull_request_review' secret scanning location type. This location
+    type shows that a secret was detected in a review on a pull request.
+    """
+
+    pull_request_review_url: str = Field(
+        description="The API URL to get the pull request review where the secret was detected.",
+        default=...,
+    )
+
+
+class SecretScanningLocationPullRequestReviewComment(GitHubRestModel):
+    """SecretScanningLocationPullRequestReviewComment
+
+    Represents a 'pull_request_review_comment' secret scanning location type. This
+    location type shows that a secret was detected in a review comment on a pull
+    request.
+    """
+
+    pull_request_review_comment_url: str = Field(
+        description="The API URL to get the pull request review comment where the secret was detected.",
+        default=...,
+    )
+
+
 class SecretScanningLocation(GitHubRestModel):
     """SecretScanningLocation"""
 
-    type: Literal["commit", "issue_title", "issue_body", "issue_comment"] = Field(
-        description="The location type. Because secrets may be found in different types of resources (ie. code, comments, issues), this field identifies the type of resource where the secret was found.",
+    type: Literal[
+        "commit",
+        "issue_title",
+        "issue_body",
+        "issue_comment",
+        "discussion_title",
+        "discussion_body",
+        "discussion_comment",
+        "pull_request_title",
+        "pull_request_body",
+        "pull_request_comment",
+        "pull_request_review",
+        "pull_request_review_comment",
+    ] = Field(
+        description="The location type. Because secrets may be found in different types of resources (ie. code, comments, issues, pull requests, discussions), this field identifies the type of resource where the secret was found.",
         default=...,
     )
     details: Union[
@@ -11919,8 +12390,16 @@ class SecretScanningLocation(GitHubRestModel):
         SecretScanningLocationIssueTitle,
         SecretScanningLocationIssueBody,
         SecretScanningLocationIssueComment,
+        SecretScanningLocationDiscussionTitle,
+        SecretScanningLocationDiscussionBody,
+        SecretScanningLocationDiscussionComment,
+        SecretScanningLocationPullRequestTitle,
+        SecretScanningLocationPullRequestBody,
+        SecretScanningLocationPullRequestComment,
+        SecretScanningLocationPullRequestReview,
+        SecretScanningLocationPullRequestReviewComment,
     ] = Field(
-        description="Represents an 'issue_comment' secret scanning location type. This location type shows that a secret was detected in a comment on an issue.",
+        description="Represents a 'pull_request_review_comment' secret scanning location type. This location type shows that a secret was detected in a review comment on a pull request.",
         default=...,
     )
 
@@ -11962,6 +12441,10 @@ class RepositoryAdvisoryCreate(GitHubRestModel):
     cvss_vector_string: Missing[Union[str, None]] = Field(
         description="The CVSS vector that calculates the severity of the advisory. You must choose between setting this field or `severity`.",
         default=UNSET,
+    )
+    start_private_fork: Missing[bool] = Field(
+        description="Whether to create a temporary private fork of the repository to collaborate on a fix.",
+        default=False,
     )
 
 
@@ -12061,6 +12544,10 @@ class PrivateVulnerabilityReportCreate(GitHubRestModel):
     cvss_vector_string: Missing[Union[str, None]] = Field(
         description="The CVSS vector that calculates the severity of the advisory. You must choose between setting this field or `severity`.",
         default=UNSET,
+    )
+    start_private_fork: Missing[bool] = Field(
+        description="Whether to create a temporary private fork of the repository to collaborate on a fix.",
+        default=False,
     )
 
 
@@ -13454,7 +13941,7 @@ class RepositoryWebhooks(GitHubRestModel):
     stargazers_count: int = Field(default=...)
     watchers_count: int = Field(default=...)
     size: int = Field(
-        description="The size of the repository. Size is calculated hourly. When a repository is initially created, the size is 0.",
+        description="The size of the repository, in kilobytes. Size is calculated hourly. When a repository is initially created, the size is 0.",
         default=...,
     )
     default_branch: str = Field(
@@ -13466,6 +13953,10 @@ class RepositoryWebhooks(GitHubRestModel):
         default=False,
     )
     topics: Missing[List[str]] = Field(default=UNSET)
+    custom_properties: Missing[RepositoryWebhooksPropCustomProperties] = Field(
+        description="The custom properties that were defined for the repository. The keys are the custom property names, and the values are the corresponding custom property values.",
+        default=UNSET,
+    )
     has_issues: bool = Field(description="Whether issues are enabled.", default=True)
     has_projects: bool = Field(
         description="Whether projects are enabled.", default=True
@@ -13567,6 +14058,15 @@ class RepositoryWebhooksPropPermissions(GitHubRestModel):
     triage: Missing[bool] = Field(default=UNSET)
     push: bool = Field(default=...)
     maintain: Missing[bool] = Field(default=UNSET)
+
+
+class RepositoryWebhooksPropCustomProperties(GitHubRestModel, extra=Extra.allow):
+    """RepositoryWebhooksPropCustomProperties
+
+    The custom properties that were defined for the repository. The keys are the
+    custom property names, and the values are the corresponding custom property
+    values.
+    """
 
 
 class RepositoryWebhooksPropTemplateRepositoryPropOwner(GitHubRestModel):
@@ -15272,8 +15772,10 @@ class OrgsOrgInvitationsPostBody(GitHubRestModel):
         description="**Required unless you provide `invitee_id`**. Email address of the person you are inviting, which can be an existing GitHub user.",
         default=UNSET,
     )
-    role: Missing[Literal["admin", "direct_member", "billing_manager"]] = Field(
-        description="The role for the new member. \n * `admin` - Organization owners with full administrative rights to the organization and complete access to all repositories and teams.  \n * `direct_member` - Non-owner organization members with ability to see other members and join teams by invitation.  \n * `billing_manager` - Non-owner organization members with ability to manage the billing settings of your organization.",
+    role: Missing[
+        Literal["admin", "direct_member", "billing_manager", "reinstate"]
+    ] = Field(
+        description="The role for the new member. \n * `admin` - Organization owners with full administrative rights to the organization and complete access to all repositories and teams.  \n * `direct_member` - Non-owner organization members with ability to see other members and join teams by invitation.  \n * `billing_manager` - Non-owner organization members with ability to manage the billing settings of your organization. \n * `reinstate` - The previous role assigned to the invitee before they were removed from your organization. Can be one of the roles listed above. Only works if the invitee was previously part of your organization.",
         default="direct_member",
     )
     team_ids: Missing[List[int]] = Field(
@@ -15334,7 +15836,50 @@ class OrgsOrgMigrationsPostBody(GitHubRestModel):
         default=False,
     )
     exclude: Missing[List[Literal["repositories"]]] = Field(
-        description='Exclude related items from being returned in the response in order to improve performance of the request. The array can include any of: `"repositories"`.',
+        description="Exclude related items from being returned in the response in order to improve performance of the request.",
+        default=UNSET,
+    )
+
+
+class OrgsOrgOrganizationRolesGetResponse200(GitHubRestModel):
+    """OrgsOrgOrganizationRolesGetResponse200"""
+
+    total_count: Missing[int] = Field(
+        description="The total number of organization roles available to the organization.",
+        default=UNSET,
+    )
+    roles: Missing[List[OrganizationRole]] = Field(
+        description="The list of organization roles available to the organization.",
+        default=UNSET,
+    )
+
+
+class OrgsOrgOrganizationRolesPostBody(GitHubRestModel):
+    """OrgsOrgOrganizationRolesPostBody"""
+
+    name: str = Field(description="The name of the custom role.", default=...)
+    description: Missing[str] = Field(
+        description="A short description about the intended usage of this role or what permissions it grants.",
+        default=UNSET,
+    )
+    permissions: List[str] = Field(
+        description="A list of additional permissions included in this role.",
+        default=...,
+    )
+
+
+class OrgsOrgOrganizationRolesRoleIdPatchBody(GitHubRestModel):
+    """OrgsOrgOrganizationRolesRoleIdPatchBody"""
+
+    name: Missing[str] = Field(
+        description="The name of the custom role.", default=UNSET
+    )
+    description: Missing[str] = Field(
+        description="A short description about the intended usage of this role or what permissions it grants.",
+        default=UNSET,
+    )
+    permissions: Missing[List[str]] = Field(
+        description="A list of additional permissions included in this role.",
         default=UNSET,
     )
 
@@ -15420,6 +15965,49 @@ class OrgsOrgProjectsPostBody(GitHubRestModel):
     name: str = Field(description="The name of the project.", default=...)
     body: Missing[str] = Field(
         description="The description of the project.", default=UNSET
+    )
+
+
+class OrgsOrgPropertiesSchemaPatchBody(GitHubRestModel):
+    """OrgsOrgPropertiesSchemaPatchBody"""
+
+    properties: List[OrgCustomProperty] = Field(
+        description="The array of custom properties to create or update.", default=...
+    )
+
+
+class OrgsOrgPropertiesSchemaCustomPropertyNamePutBody(GitHubRestModel):
+    """OrgsOrgPropertiesSchemaCustomPropertyNamePutBody"""
+
+    value_type: Literal["string", "single_select"] = Field(
+        description="The type of the value for the property", default=...
+    )
+    required: Missing[bool] = Field(
+        description="Whether the property is required.", default=UNSET
+    )
+    default_value: Missing[Union[str, None]] = Field(
+        description="Default value of the property", default=UNSET
+    )
+    description: Missing[Union[str, None]] = Field(
+        description="Short description of the property", default=UNSET
+    )
+    allowed_values: Missing[Union[List[str], None]] = Field(
+        description="Ordered list of allowed values of the property", default=UNSET
+    )
+
+
+class OrgsOrgPropertiesValuesPatchBody(GitHubRestModel):
+    """OrgsOrgPropertiesValuesPatchBody"""
+
+    repository_names: List[str] = Field(
+        description="The names of repositories that the custom property values will be applied to.",
+        max_length=30,
+        min_length=1,
+        default=...,
+    )
+    properties: List[CustomPropertyValue] = Field(
+        description="List of custom property names and associated values to apply to the repositories.",
+        default=...,
     )
 
 
@@ -15518,6 +16106,18 @@ class OrgsOrgReposPostBody(GitHubRestModel):
         description="The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
         default=UNSET,
     )
+    custom_properties: Missing[OrgsOrgReposPostBodyPropCustomProperties] = Field(
+        description="The custom properties for the new repository. The keys are the custom property names, and the values are the corresponding custom property values.",
+        default=UNSET,
+    )
+
+
+class OrgsOrgReposPostBodyPropCustomProperties(GitHubRestModel, extra=Extra.allow):
+    """OrgsOrgReposPostBodyPropCustomProperties
+
+    The custom properties for the new repository. The keys are the custom property
+    names, and the values are the corresponding custom property values.
+    """
 
 
 class OrgsOrgRulesetsPostBody(GitHubRestModel):
@@ -15559,6 +16159,7 @@ class OrgsOrgRulesetsPostBody(GitHubRestModel):
                 RepositoryRuleCommitterEmailPattern,
                 RepositoryRuleBranchNamePattern,
                 RepositoryRuleTagNamePattern,
+                RepositoryRuleWorkflows,
             ]
         ]
     ] = Field(description="An array of rules within the ruleset.", default=UNSET)
@@ -15603,6 +16204,7 @@ class OrgsOrgRulesetsRulesetIdPutBody(GitHubRestModel):
                 RepositoryRuleCommitterEmailPattern,
                 RepositoryRuleBranchNamePattern,
                 RepositoryRuleTagNamePattern,
+                RepositoryRuleWorkflows,
             ]
         ]
     ] = Field(description="An array of rules within the ruleset.", default=UNSET)
@@ -15742,7 +16344,7 @@ class OrgsOrgTeamsTeamSlugProjectsProjectIdPutBody(GitHubRestModel):
     """OrgsOrgTeamsTeamSlugProjectsProjectIdPutBody"""
 
     permission: Missing[Literal["read", "write", "admin"]] = Field(
-        description="The permission to grant to the team for this project. Default: the team's `permission` attribute will be used to determine what permission to grant the team on this project. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling this endpoint. For more information, see \"[HTTP verbs](https://docs.github.com/rest/overview/resources-in-the-rest-api#http-verbs).\"",
+        description="The permission to grant to the team for this project. Default: the team's `permission` attribute will be used to determine what permission to grant the team on this project. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling this endpoint. For more information, see \"[HTTP method](https://docs.github.com/rest/guides/getting-started-with-the-rest-api#http-method).\"",
         default=UNSET,
     )
 
@@ -17362,7 +17964,8 @@ class ReposOwnerRepoCodeScanningSarifsPostBody(GitHubRestModel):
         default=...,
     )
     ref: str = Field(
-        description="The full Git reference, formatted as `refs/heads/<branch name>`,\n`refs/pull/<number>/merge`, or `refs/pull/<number>/head`.",
+        description="The full Git reference, formatted as `refs/heads/<branch name>`,\n`refs/tags/<tag>`, `refs/pull/<number>/merge`, or `refs/pull/<number>/head`.",
+        pattern="^refs/(heads|tags|pull)/.*$",
         default=...,
     )
     sarif: str = Field(
@@ -17879,6 +18482,10 @@ class ReposOwnerRepoEnvironmentsEnvironmentNamePutBody(GitHubRestModel):
 
     wait_timer: Missing[int] = Field(
         description="The amount of time to delay a job after the job is initially triggered. The time (in minutes) must be an integer between 0 and 43,200 (30 days).",
+        default=UNSET,
+    )
+    prevent_self_review: Missing[bool] = Field(
+        description="Whether or not a user who created the job is prevented from approving their own job.",
         default=UNSET,
     )
     reviewers: Missing[
@@ -19341,6 +19948,7 @@ class ReposOwnerRepoRulesetsPostBody(GitHubRestModel):
                 RepositoryRuleCommitterEmailPattern,
                 RepositoryRuleBranchNamePattern,
                 RepositoryRuleTagNamePattern,
+                RepositoryRuleWorkflows,
             ]
         ]
     ] = Field(description="An array of rules within the ruleset.", default=UNSET)
@@ -19383,6 +19991,7 @@ class ReposOwnerRepoRulesetsRulesetIdPutBody(GitHubRestModel):
                 RepositoryRuleCommitterEmailPattern,
                 RepositoryRuleBranchNamePattern,
                 RepositoryRuleTagNamePattern,
+                RepositoryRuleWorkflows,
             ]
         ]
     ] = Field(description="An array of rules within the ruleset.", default=UNSET)
@@ -19699,7 +20308,7 @@ class TeamsTeamIdProjectsProjectIdPutBody(GitHubRestModel):
     """TeamsTeamIdProjectsProjectIdPutBody"""
 
     permission: Missing[Literal["read", "write", "admin"]] = Field(
-        description="The permission to grant to the team for this project. Default: the team's `permission` attribute will be used to determine what permission to grant the team on this project. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling this endpoint. For more information, see \"[HTTP verbs](https://docs.github.com/rest/overview/resources-in-the-rest-api#http-verbs).\"",
+        description="The permission to grant to the team for this project. Default: the team's `permission` attribute will be used to determine what permission to grant the team on this project. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling this endpoint. For more information, see \"[HTTP method](https://docs.github.com/rest/guides/getting-started-with-the-rest-api#http-method).\"",
         default=UNSET,
     )
 
@@ -20313,7 +20922,7 @@ AuthenticationTokenPropPermissions.update_forward_refs()
 OrganizationActionsSecret.update_forward_refs()
 ActionsPublicKey.update_forward_refs()
 OrganizationActionsVariable.update_forward_refs()
-CodeScanningAlertRule.update_forward_refs()
+CodeScanningAlertRuleSummary.update_forward_refs()
 CodeScanningAnalysisTool.update_forward_refs()
 CodeScanningAlertLocation.update_forward_refs()
 CodeScanningAlertInstance.update_forward_refs()
@@ -20344,6 +20953,8 @@ InteractionLimit.update_forward_refs()
 OrgMembership.update_forward_refs()
 OrgMembershipPropPermissions.update_forward_refs()
 Migration.update_forward_refs()
+OrganizationFineGrainedPermission.update_forward_refs()
+OrganizationRole.update_forward_refs()
 PackageVersion.update_forward_refs()
 PackageVersionPropMetadata.update_forward_refs()
 PackageVersionPropMetadataPropContainer.update_forward_refs()
@@ -20359,6 +20970,12 @@ OrganizationProgrammaticAccessGrantPropPermissionsPropOrganization.update_forwar
 OrganizationProgrammaticAccessGrantPropPermissionsPropRepository.update_forward_refs()
 OrganizationProgrammaticAccessGrantPropPermissionsPropOther.update_forward_refs()
 Project.update_forward_refs()
+OrgCustomProperty.update_forward_refs()
+CustomPropertyValue.update_forward_refs()
+OrgRepoCustomPropertyValues.update_forward_refs()
+CodeOfConductSimple.update_forward_refs()
+FullRepository.update_forward_refs()
+FullRepositoryPropPermissions.update_forward_refs()
 RepositoryRulesetBypassActor.update_forward_refs()
 RepositoryRulesetConditions.update_forward_refs()
 RepositoryRulesetConditionsPropRefName.update_forward_refs()
@@ -20392,10 +21009,17 @@ RepositoryRuleBranchNamePattern.update_forward_refs()
 RepositoryRuleBranchNamePatternPropParameters.update_forward_refs()
 RepositoryRuleTagNamePattern.update_forward_refs()
 RepositoryRuleTagNamePatternPropParameters.update_forward_refs()
+RepositoryRuleParamsWorkflowFileReference.update_forward_refs()
+RepositoryRuleWorkflows.update_forward_refs()
+RepositoryRuleWorkflowsPropParameters.update_forward_refs()
 RepositoryRuleset.update_forward_refs()
 RepositoryRulesetPropLinks.update_forward_refs()
 RepositoryRulesetPropLinksPropSelf.update_forward_refs()
 RepositoryRulesetPropLinksPropHtml.update_forward_refs()
+RuleSuitesItems.update_forward_refs()
+RuleSuite.update_forward_refs()
+RuleSuitePropRuleEvaluationsItems.update_forward_refs()
+RuleSuitePropRuleEvaluationsItemsPropRuleSource.update_forward_refs()
 RepositoryAdvisoryVulnerability.update_forward_refs()
 RepositoryAdvisoryVulnerabilityPropPackage.update_forward_refs()
 RepositoryAdvisoryCredit.update_forward_refs()
@@ -20426,9 +21050,6 @@ ProjectCollaboratorPermission.update_forward_refs()
 RateLimit.update_forward_refs()
 RateLimitOverview.update_forward_refs()
 RateLimitOverviewPropResources.update_forward_refs()
-CodeOfConductSimple.update_forward_refs()
-FullRepository.update_forward_refs()
-FullRepositoryPropPermissions.update_forward_refs()
 Artifact.update_forward_refs()
 ArtifactPropWorkflowRun.update_forward_refs()
 ActionsCacheList.update_forward_refs()
@@ -20533,8 +21154,8 @@ CheckSuite.update_forward_refs()
 CheckSuitePreference.update_forward_refs()
 CheckSuitePreferencePropPreferences.update_forward_refs()
 CheckSuitePreferencePropPreferencesPropAutoTriggerChecksItems.update_forward_refs()
-CodeScanningAlertRuleSummary.update_forward_refs()
 CodeScanningAlertItems.update_forward_refs()
+CodeScanningAlertRule.update_forward_refs()
 CodeScanningAlert.update_forward_refs()
 CodeScanningAnalysis.update_forward_refs()
 CodeScanningAnalysisDeletion.update_forward_refs()
@@ -20546,6 +21167,7 @@ CodeScanningSarifsReceipt.update_forward_refs()
 CodeScanningSarifsStatus.update_forward_refs()
 CodeownersErrors.update_forward_refs()
 CodeownersErrorsPropErrorsItems.update_forward_refs()
+CodespacesPermissionsCheckForDevcontainer.update_forward_refs()
 RepoCodespacesSecret.update_forward_refs()
 Collaborator.update_forward_refs()
 CollaboratorPropPermissions.update_forward_refs()
@@ -20617,6 +21239,7 @@ EnvironmentPropProtectionRulesItemsAnyof1.update_forward_refs()
 EnvironmentPropProtectionRulesItemsAnyof1PropReviewersItems.update_forward_refs()
 EnvironmentPropProtectionRulesItemsAnyof2.update_forward_refs()
 DeploymentBranchPolicy.update_forward_refs()
+DeploymentBranchPolicyNamePatternWithType.update_forward_refs()
 DeploymentBranchPolicyNamePattern.update_forward_refs()
 CustomDeploymentRuleApp.update_forward_refs()
 DeploymentProtectionRule.update_forward_refs()
@@ -20752,11 +21375,20 @@ RepositoryRuleDetailedOneof10.update_forward_refs()
 RepositoryRuleDetailedOneof11.update_forward_refs()
 RepositoryRuleDetailedOneof12.update_forward_refs()
 RepositoryRuleDetailedOneof13.update_forward_refs()
+RepositoryRuleDetailedOneof14.update_forward_refs()
 SecretScanningAlert.update_forward_refs()
 SecretScanningLocationCommit.update_forward_refs()
 SecretScanningLocationIssueTitle.update_forward_refs()
 SecretScanningLocationIssueBody.update_forward_refs()
 SecretScanningLocationIssueComment.update_forward_refs()
+SecretScanningLocationDiscussionTitle.update_forward_refs()
+SecretScanningLocationDiscussionBody.update_forward_refs()
+SecretScanningLocationDiscussionComment.update_forward_refs()
+SecretScanningLocationPullRequestTitle.update_forward_refs()
+SecretScanningLocationPullRequestBody.update_forward_refs()
+SecretScanningLocationPullRequestComment.update_forward_refs()
+SecretScanningLocationPullRequestReview.update_forward_refs()
+SecretScanningLocationPullRequestReviewComment.update_forward_refs()
 SecretScanningLocation.update_forward_refs()
 RepositoryAdvisoryCreate.update_forward_refs()
 RepositoryAdvisoryCreatePropVulnerabilitiesItems.update_forward_refs()
@@ -20831,6 +21463,7 @@ SimpleInstallation.update_forward_refs()
 OrganizationSimpleWebhooks.update_forward_refs()
 RepositoryWebhooks.update_forward_refs()
 RepositoryWebhooksPropPermissions.update_forward_refs()
+RepositoryWebhooksPropCustomProperties.update_forward_refs()
 RepositoryWebhooksPropTemplateRepositoryPropOwner.update_forward_refs()
 RepositoryWebhooksPropTemplateRepositoryPropPermissions.update_forward_refs()
 RepositoryWebhooksPropTemplateRepository.update_forward_refs()
@@ -20940,6 +21573,9 @@ OrgsOrgInvitationsPostBody.update_forward_refs()
 OrgsOrgMembersUsernameCodespacesGetResponse200.update_forward_refs()
 OrgsOrgMembershipsUsernamePutBody.update_forward_refs()
 OrgsOrgMigrationsPostBody.update_forward_refs()
+OrgsOrgOrganizationRolesGetResponse200.update_forward_refs()
+OrgsOrgOrganizationRolesPostBody.update_forward_refs()
+OrgsOrgOrganizationRolesRoleIdPatchBody.update_forward_refs()
 OrgsOrgOutsideCollaboratorsUsernamePutBody.update_forward_refs()
 OrgsOrgOutsideCollaboratorsUsernamePutResponse202.update_forward_refs()
 OrgsOrgOutsideCollaboratorsUsernameDeleteResponse422.update_forward_refs()
@@ -20948,7 +21584,11 @@ OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBody.update_forward_refs()
 OrgsOrgPersonalAccessTokensPostBody.update_forward_refs()
 OrgsOrgPersonalAccessTokensPatIdPostBody.update_forward_refs()
 OrgsOrgProjectsPostBody.update_forward_refs()
+OrgsOrgPropertiesSchemaPatchBody.update_forward_refs()
+OrgsOrgPropertiesSchemaCustomPropertyNamePutBody.update_forward_refs()
+OrgsOrgPropertiesValuesPatchBody.update_forward_refs()
 OrgsOrgReposPostBody.update_forward_refs()
+OrgsOrgReposPostBodyPropCustomProperties.update_forward_refs()
 OrgsOrgRulesetsPostBody.update_forward_refs()
 OrgsOrgRulesetsRulesetIdPutBody.update_forward_refs()
 OrgsOrgTeamsPostBody.update_forward_refs()
@@ -21373,7 +22013,7 @@ __all__ = [
     "OrganizationActionsSecret",
     "ActionsPublicKey",
     "OrganizationActionsVariable",
-    "CodeScanningAlertRule",
+    "CodeScanningAlertRuleSummary",
     "CodeScanningAnalysisTool",
     "CodeScanningAlertLocation",
     "CodeScanningAlertInstance",
@@ -21404,6 +22044,8 @@ __all__ = [
     "OrgMembership",
     "OrgMembershipPropPermissions",
     "Migration",
+    "OrganizationFineGrainedPermission",
+    "OrganizationRole",
     "PackageVersion",
     "PackageVersionPropMetadata",
     "PackageVersionPropMetadataPropContainer",
@@ -21419,6 +22061,12 @@ __all__ = [
     "OrganizationProgrammaticAccessGrantPropPermissionsPropRepository",
     "OrganizationProgrammaticAccessGrantPropPermissionsPropOther",
     "Project",
+    "OrgCustomProperty",
+    "CustomPropertyValue",
+    "OrgRepoCustomPropertyValues",
+    "CodeOfConductSimple",
+    "FullRepository",
+    "FullRepositoryPropPermissions",
     "RepositoryRulesetBypassActor",
     "RepositoryRulesetConditions",
     "RepositoryRulesetConditionsPropRefName",
@@ -21452,10 +22100,17 @@ __all__ = [
     "RepositoryRuleBranchNamePatternPropParameters",
     "RepositoryRuleTagNamePattern",
     "RepositoryRuleTagNamePatternPropParameters",
+    "RepositoryRuleParamsWorkflowFileReference",
+    "RepositoryRuleWorkflows",
+    "RepositoryRuleWorkflowsPropParameters",
     "RepositoryRuleset",
     "RepositoryRulesetPropLinks",
     "RepositoryRulesetPropLinksPropSelf",
     "RepositoryRulesetPropLinksPropHtml",
+    "RuleSuitesItems",
+    "RuleSuite",
+    "RuleSuitePropRuleEvaluationsItems",
+    "RuleSuitePropRuleEvaluationsItemsPropRuleSource",
     "RepositoryAdvisoryVulnerability",
     "RepositoryAdvisoryVulnerabilityPropPackage",
     "RepositoryAdvisoryCredit",
@@ -21486,9 +22141,6 @@ __all__ = [
     "RateLimit",
     "RateLimitOverview",
     "RateLimitOverviewPropResources",
-    "CodeOfConductSimple",
-    "FullRepository",
-    "FullRepositoryPropPermissions",
     "Artifact",
     "ArtifactPropWorkflowRun",
     "ActionsCacheList",
@@ -21593,8 +22245,8 @@ __all__ = [
     "CheckSuitePreference",
     "CheckSuitePreferencePropPreferences",
     "CheckSuitePreferencePropPreferencesPropAutoTriggerChecksItems",
-    "CodeScanningAlertRuleSummary",
     "CodeScanningAlertItems",
+    "CodeScanningAlertRule",
     "CodeScanningAlert",
     "CodeScanningAnalysis",
     "CodeScanningAnalysisDeletion",
@@ -21606,6 +22258,7 @@ __all__ = [
     "CodeScanningSarifsStatus",
     "CodeownersErrors",
     "CodeownersErrorsPropErrorsItems",
+    "CodespacesPermissionsCheckForDevcontainer",
     "RepoCodespacesSecret",
     "Collaborator",
     "CollaboratorPropPermissions",
@@ -21677,6 +22330,7 @@ __all__ = [
     "EnvironmentPropProtectionRulesItemsAnyof1PropReviewersItems",
     "EnvironmentPropProtectionRulesItemsAnyof2",
     "DeploymentBranchPolicy",
+    "DeploymentBranchPolicyNamePatternWithType",
     "DeploymentBranchPolicyNamePattern",
     "CustomDeploymentRuleApp",
     "DeploymentProtectionRule",
@@ -21812,11 +22466,20 @@ __all__ = [
     "RepositoryRuleDetailedOneof11",
     "RepositoryRuleDetailedOneof12",
     "RepositoryRuleDetailedOneof13",
+    "RepositoryRuleDetailedOneof14",
     "SecretScanningAlert",
     "SecretScanningLocationCommit",
     "SecretScanningLocationIssueTitle",
     "SecretScanningLocationIssueBody",
     "SecretScanningLocationIssueComment",
+    "SecretScanningLocationDiscussionTitle",
+    "SecretScanningLocationDiscussionBody",
+    "SecretScanningLocationDiscussionComment",
+    "SecretScanningLocationPullRequestTitle",
+    "SecretScanningLocationPullRequestBody",
+    "SecretScanningLocationPullRequestComment",
+    "SecretScanningLocationPullRequestReview",
+    "SecretScanningLocationPullRequestReviewComment",
     "SecretScanningLocation",
     "RepositoryAdvisoryCreate",
     "RepositoryAdvisoryCreatePropVulnerabilitiesItems",
@@ -21891,6 +22554,7 @@ __all__ = [
     "OrganizationSimpleWebhooks",
     "RepositoryWebhooks",
     "RepositoryWebhooksPropPermissions",
+    "RepositoryWebhooksPropCustomProperties",
     "RepositoryWebhooksPropTemplateRepositoryPropOwner",
     "RepositoryWebhooksPropTemplateRepositoryPropPermissions",
     "RepositoryWebhooksPropTemplateRepository",
@@ -22000,6 +22664,9 @@ __all__ = [
     "OrgsOrgMembersUsernameCodespacesGetResponse200",
     "OrgsOrgMembershipsUsernamePutBody",
     "OrgsOrgMigrationsPostBody",
+    "OrgsOrgOrganizationRolesGetResponse200",
+    "OrgsOrgOrganizationRolesPostBody",
+    "OrgsOrgOrganizationRolesRoleIdPatchBody",
     "OrgsOrgOutsideCollaboratorsUsernamePutBody",
     "OrgsOrgOutsideCollaboratorsUsernamePutResponse202",
     "OrgsOrgOutsideCollaboratorsUsernameDeleteResponse422",
@@ -22008,7 +22675,11 @@ __all__ = [
     "OrgsOrgPersonalAccessTokensPostBody",
     "OrgsOrgPersonalAccessTokensPatIdPostBody",
     "OrgsOrgProjectsPostBody",
+    "OrgsOrgPropertiesSchemaPatchBody",
+    "OrgsOrgPropertiesSchemaCustomPropertyNamePutBody",
+    "OrgsOrgPropertiesValuesPatchBody",
     "OrgsOrgReposPostBody",
+    "OrgsOrgReposPostBodyPropCustomProperties",
     "OrgsOrgRulesetsPostBody",
     "OrgsOrgRulesetsRulesetIdPutBody",
     "OrgsOrgTeamsPostBody",

--- a/githubkit/rest/orgs.py
+++ b/githubkit/rest/orgs.py
@@ -17,19 +17,26 @@ from githubkit.utils import UNSET, Missing, exclude_unset
 
 from .types import (
     OrgsOrgPatchBodyType,
+    OrgCustomPropertyType,
+    CustomPropertyValueType,
     OrgsOrgHooksPostBodyType,
     OrgsOrgInvitationsPostBodyType,
     OrgsOrgHooksHookIdPatchBodyType,
     OrgsOrgHooksPostBodyPropConfigType,
     UserMembershipsOrgsOrgPatchBodyType,
+    OrgsOrgOrganizationRolesPostBodyType,
+    OrgsOrgPropertiesSchemaPatchBodyType,
+    OrgsOrgPropertiesValuesPatchBodyType,
     OrgsOrgHooksHookIdConfigPatchBodyType,
     OrgsOrgMembershipsUsernamePutBodyType,
     OrgsOrgPersonalAccessTokensPostBodyType,
     OrgsOrgHooksHookIdPatchBodyPropConfigType,
+    OrgsOrgOrganizationRolesRoleIdPatchBodyType,
     OrgsOrgPersonalAccessTokensPatIdPostBodyType,
     OrgsOrgSecurityProductEnablementPostBodyType,
     OrgsOrgOutsideCollaboratorsUsernamePutBodyType,
     OrgsOrgPersonalAccessTokenRequestsPostBodyType,
+    OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
     OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
 )
 from .models import (
@@ -44,25 +51,35 @@ from .models import (
     ValidationError,
     HookDeliveryItem,
     OrganizationFull,
+    OrganizationRole,
     OrgsOrgPatchBody,
     MinimalRepository,
+    OrgCustomProperty,
     OrganizationSimple,
     OrgsOrgHooksPostBody,
     ValidationErrorSimple,
     OrganizationInvitation,
     OrgsOrgInvitationsPostBody,
+    OrgRepoCustomPropertyValues,
     OrgsOrgHooksHookIdPatchBody,
     UserMembershipsOrgsOrgPatchBody,
+    OrgsOrgOrganizationRolesPostBody,
+    OrgsOrgPropertiesSchemaPatchBody,
+    OrgsOrgPropertiesValuesPatchBody,
+    OrganizationFineGrainedPermission,
     OrgsOrgHooksHookIdConfigPatchBody,
     OrgsOrgMembershipsUsernamePutBody,
     OrgsOrgInstallationsGetResponse200,
     OrganizationProgrammaticAccessGrant,
     OrgsOrgPersonalAccessTokensPostBody,
+    OrgsOrgOrganizationRolesGetResponse200,
+    OrgsOrgOrganizationRolesRoleIdPatchBody,
     OrgsOrgPersonalAccessTokensPatIdPostBody,
     OrgsOrgSecurityProductEnablementPostBody,
     OrganizationProgrammaticAccessGrantRequest,
     OrgsOrgOutsideCollaboratorsUsernamePutBody,
     OrgsOrgPersonalAccessTokenRequestsPostBody,
+    OrgsOrgPropertiesSchemaCustomPropertyNamePutBody,
     OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
     AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
     OrgsOrgOutsideCollaboratorsUsernameDeleteResponse422,
@@ -1448,7 +1465,7 @@ class OrgsClient:
         invitee_id: Missing[int] = UNSET,
         email: Missing[str] = UNSET,
         role: Missing[
-            Literal["admin", "direct_member", "billing_manager"]
+            Literal["admin", "direct_member", "billing_manager", "reinstate"]
         ] = "direct_member",
         team_ids: Missing[List[int]] = UNSET,
     ) -> "Response[OrganizationInvitation]":
@@ -1505,7 +1522,7 @@ class OrgsClient:
         invitee_id: Missing[int] = UNSET,
         email: Missing[str] = UNSET,
         role: Missing[
-            Literal["admin", "direct_member", "billing_manager"]
+            Literal["admin", "direct_member", "billing_manager", "reinstate"]
         ] = "direct_member",
         team_ids: Missing[List[int]] = UNSET,
     ) -> "Response[OrganizationInvitation]":
@@ -1976,6 +1993,722 @@ class OrgsClient:
                 "403": BasicError,
                 "404": BasicError,
             },
+        )
+
+    def list_organization_fine_grained_permissions(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[OrganizationFineGrainedPermission]]":
+        url = f"/orgs/{org}/organization-fine-grained-permissions"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=List[OrganizationFineGrainedPermission],
+            error_models={
+                "404": BasicError,
+                "422": ValidationError,
+            },
+        )
+
+    async def async_list_organization_fine_grained_permissions(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[OrganizationFineGrainedPermission]]":
+        url = f"/orgs/{org}/organization-fine-grained-permissions"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=List[OrganizationFineGrainedPermission],
+            error_models={
+                "404": BasicError,
+                "422": ValidationError,
+            },
+        )
+
+    def list_org_roles(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[OrgsOrgOrganizationRolesGetResponse200]":
+        url = f"/orgs/{org}/organization-roles"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=OrgsOrgOrganizationRolesGetResponse200,
+            error_models={
+                "404": BasicError,
+                "422": ValidationError,
+            },
+        )
+
+    async def async_list_org_roles(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[OrgsOrgOrganizationRolesGetResponse200]":
+        url = f"/orgs/{org}/organization-roles"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=OrgsOrgOrganizationRolesGetResponse200,
+            error_models={
+                "404": BasicError,
+                "422": ValidationError,
+            },
+        )
+
+    @overload
+    def create_custom_organization_role(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgOrganizationRolesPostBodyType,
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    @overload
+    def create_custom_organization_role(
+        self,
+        org: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        name: str,
+        description: Missing[str] = UNSET,
+        permissions: List[str],
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    def create_custom_organization_role(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgOrganizationRolesPostBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[OrganizationRole]":
+        url = f"/orgs/{org}/organization-roles"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgOrganizationRolesPostBody).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return self._github.request(
+            "POST",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=OrganizationRole,
+            error_models={
+                "422": ValidationError,
+                "404": BasicError,
+                "409": BasicError,
+            },
+        )
+
+    @overload
+    async def async_create_custom_organization_role(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgOrganizationRolesPostBodyType,
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    @overload
+    async def async_create_custom_organization_role(
+        self,
+        org: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        name: str,
+        description: Missing[str] = UNSET,
+        permissions: List[str],
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    async def async_create_custom_organization_role(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgOrganizationRolesPostBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[OrganizationRole]":
+        url = f"/orgs/{org}/organization-roles"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgOrganizationRolesPostBody).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return await self._github.arequest(
+            "POST",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=OrganizationRole,
+            error_models={
+                "422": ValidationError,
+                "404": BasicError,
+                "409": BasicError,
+            },
+        )
+
+    def revoke_all_org_roles_team(
+        self,
+        org: str,
+        team_slug: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/teams/{team_slug}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    async def async_revoke_all_org_roles_team(
+        self,
+        org: str,
+        team_slug: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/teams/{team_slug}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    def assign_team_to_org_role(
+        self,
+        org: str,
+        team_slug: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/teams/{team_slug}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "PUT",
+            url,
+            headers=exclude_unset(headers),
+            error_models={},
+        )
+
+    async def async_assign_team_to_org_role(
+        self,
+        org: str,
+        team_slug: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/teams/{team_slug}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "PUT",
+            url,
+            headers=exclude_unset(headers),
+            error_models={},
+        )
+
+    def revoke_org_role_team(
+        self,
+        org: str,
+        team_slug: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/teams/{team_slug}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    async def async_revoke_org_role_team(
+        self,
+        org: str,
+        team_slug: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/teams/{team_slug}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    def revoke_all_org_roles_user(
+        self,
+        org: str,
+        username: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/users/{username}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    async def async_revoke_all_org_roles_user(
+        self,
+        org: str,
+        username: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/users/{username}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    def assign_user_to_org_role(
+        self,
+        org: str,
+        username: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/users/{username}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "PUT",
+            url,
+            headers=exclude_unset(headers),
+            error_models={},
+        )
+
+    async def async_assign_user_to_org_role(
+        self,
+        org: str,
+        username: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/users/{username}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "PUT",
+            url,
+            headers=exclude_unset(headers),
+            error_models={},
+        )
+
+    def revoke_org_role_user(
+        self,
+        org: str,
+        username: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/users/{username}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    async def async_revoke_org_role_user(
+        self,
+        org: str,
+        username: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/users/{username}/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    def get_org_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[OrganizationRole]":
+        url = f"/orgs/{org}/organization-roles/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=OrganizationRole,
+            error_models={
+                "404": BasicError,
+                "422": ValidationError,
+            },
+        )
+
+    async def async_get_org_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[OrganizationRole]":
+        url = f"/orgs/{org}/organization-roles/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=OrganizationRole,
+            error_models={
+                "404": BasicError,
+                "422": ValidationError,
+            },
+        )
+
+    def delete_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    async def async_delete_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/organization-roles/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+        )
+
+    @overload
+    def patch_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgOrganizationRolesRoleIdPatchBodyType,
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    @overload
+    def patch_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        name: Missing[str] = UNSET,
+        description: Missing[str] = UNSET,
+        permissions: Missing[List[str]] = UNSET,
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    def patch_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgOrganizationRolesRoleIdPatchBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[OrganizationRole]":
+        url = f"/orgs/{org}/organization-roles/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgOrganizationRolesRoleIdPatchBody).validate_python(
+            json
+        )
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return self._github.request(
+            "PATCH",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=OrganizationRole,
+            error_models={
+                "422": ValidationError,
+                "409": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    async def async_patch_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgOrganizationRolesRoleIdPatchBodyType,
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    @overload
+    async def async_patch_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        name: Missing[str] = UNSET,
+        description: Missing[str] = UNSET,
+        permissions: Missing[List[str]] = UNSET,
+    ) -> "Response[OrganizationRole]":
+        ...
+
+    async def async_patch_custom_organization_role(
+        self,
+        org: str,
+        role_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgOrganizationRolesRoleIdPatchBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[OrganizationRole]":
+        url = f"/orgs/{org}/organization-roles/{role_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgOrganizationRolesRoleIdPatchBody).validate_python(
+            json
+        )
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return await self._github.arequest(
+            "PATCH",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=OrganizationRole,
+            error_models={
+                "422": ValidationError,
+                "409": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    def list_org_role_teams(
+        self,
+        org: str,
+        role_id: int,
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[Team]]":
+        url = f"/orgs/{org}/organization-roles/{role_id}/teams"
+
+        params = {
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[Team],
+            error_models={},
+        )
+
+    async def async_list_org_role_teams(
+        self,
+        org: str,
+        role_id: int,
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[Team]]":
+        url = f"/orgs/{org}/organization-roles/{role_id}/teams"
+
+        params = {
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[Team],
+            error_models={},
+        )
+
+    def list_org_role_users(
+        self,
+        org: str,
+        role_id: int,
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[SimpleUser]]":
+        url = f"/orgs/{org}/organization-roles/{role_id}/users"
+
+        params = {
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[SimpleUser],
+            error_models={},
+        )
+
+    async def async_list_org_role_users(
+        self,
+        org: str,
+        role_id: int,
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[SimpleUser]]":
+        url = f"/orgs/{org}/organization-roles/{role_id}/users"
+
+        params = {
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[SimpleUser],
+            error_models={},
         )
 
     def list_outside_collaborators(
@@ -2953,6 +3686,526 @@ class OrgsClient:
                 "500": BasicError,
                 "404": BasicError,
                 "403": BasicError,
+            },
+        )
+
+    def get_all_custom_properties(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[OrgCustomProperty]]":
+        url = f"/orgs/{org}/properties/schema"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=List[OrgCustomProperty],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    async def async_get_all_custom_properties(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[OrgCustomProperty]]":
+        url = f"/orgs/{org}/properties/schema"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=List[OrgCustomProperty],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    def create_or_update_custom_properties(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgPropertiesSchemaPatchBodyType,
+    ) -> "Response[List[OrgCustomProperty]]":
+        ...
+
+    @overload
+    def create_or_update_custom_properties(
+        self,
+        org: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        properties: List[OrgCustomPropertyType],
+    ) -> "Response[List[OrgCustomProperty]]":
+        ...
+
+    def create_or_update_custom_properties(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[List[OrgCustomProperty]]":
+        url = f"/orgs/{org}/properties/schema"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgPropertiesSchemaPatchBody).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return self._github.request(
+            "PATCH",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=List[OrgCustomProperty],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    async def async_create_or_update_custom_properties(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgPropertiesSchemaPatchBodyType,
+    ) -> "Response[List[OrgCustomProperty]]":
+        ...
+
+    @overload
+    async def async_create_or_update_custom_properties(
+        self,
+        org: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        properties: List[OrgCustomPropertyType],
+    ) -> "Response[List[OrgCustomProperty]]":
+        ...
+
+    async def async_create_or_update_custom_properties(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[List[OrgCustomProperty]]":
+        url = f"/orgs/{org}/properties/schema"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgPropertiesSchemaPatchBody).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return await self._github.arequest(
+            "PATCH",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=List[OrgCustomProperty],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    def get_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[OrgCustomProperty]":
+        url = f"/orgs/{org}/properties/schema/{custom_property_name}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=OrgCustomProperty,
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    async def async_get_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[OrgCustomProperty]":
+        url = f"/orgs/{org}/properties/schema/{custom_property_name}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=OrgCustomProperty,
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    def create_or_update_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
+    ) -> "Response[OrgCustomProperty]":
+        ...
+
+    @overload
+    def create_or_update_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        value_type: Literal["string", "single_select"],
+        required: Missing[bool] = UNSET,
+        default_value: Missing[Union[str, None]] = UNSET,
+        description: Missing[Union[str, None]] = UNSET,
+        allowed_values: Missing[Union[List[str], None]] = UNSET,
+    ) -> "Response[OrgCustomProperty]":
+        ...
+
+    def create_or_update_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[OrgCustomProperty]":
+        url = f"/orgs/{org}/properties/schema/{custom_property_name}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(
+            OrgsOrgPropertiesSchemaCustomPropertyNamePutBody
+        ).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return self._github.request(
+            "PUT",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=OrgCustomProperty,
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    async def async_create_or_update_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
+    ) -> "Response[OrgCustomProperty]":
+        ...
+
+    @overload
+    async def async_create_or_update_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        value_type: Literal["string", "single_select"],
+        required: Missing[bool] = UNSET,
+        default_value: Missing[Union[str, None]] = UNSET,
+        description: Missing[Union[str, None]] = UNSET,
+        allowed_values: Missing[Union[List[str], None]] = UNSET,
+    ) -> "Response[OrgCustomProperty]":
+        ...
+
+    async def async_create_or_update_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response[OrgCustomProperty]":
+        url = f"/orgs/{org}/properties/schema/{custom_property_name}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(
+            OrgsOrgPropertiesSchemaCustomPropertyNamePutBody
+        ).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return await self._github.arequest(
+            "PUT",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            response_model=OrgCustomProperty,
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    def remove_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/properties/schema/{custom_property_name}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    async def async_remove_custom_property(
+        self,
+        org: str,
+        custom_property_name: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response":
+        url = f"/orgs/{org}/properties/schema/{custom_property_name}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "DELETE",
+            url,
+            headers=exclude_unset(headers),
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    def list_custom_properties_values_for_repos(
+        self,
+        org: str,
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        repository_query: Missing[str] = UNSET,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[OrgRepoCustomPropertyValues]]":
+        url = f"/orgs/{org}/properties/values"
+
+        params = {
+            "per_page": per_page,
+            "page": page,
+            "repository_query": repository_query,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[OrgRepoCustomPropertyValues],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    async def async_list_custom_properties_values_for_repos(
+        self,
+        org: str,
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        repository_query: Missing[str] = UNSET,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[OrgRepoCustomPropertyValues]]":
+        url = f"/orgs/{org}/properties/values"
+
+        params = {
+            "per_page": per_page,
+            "page": page,
+            "repository_query": repository_query,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[OrgRepoCustomPropertyValues],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    def create_or_update_custom_properties_values_for_repos(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgPropertiesValuesPatchBodyType,
+    ) -> "Response":
+        ...
+
+    @overload
+    def create_or_update_custom_properties_values_for_repos(
+        self,
+        org: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        repository_names: List[str],
+        properties: List[CustomPropertyValueType],
+    ) -> "Response":
+        ...
+
+    def create_or_update_custom_properties_values_for_repos(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgPropertiesValuesPatchBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response":
+        url = f"/orgs/{org}/properties/values"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgPropertiesValuesPatchBody).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return self._github.request(
+            "PATCH",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    @overload
+    async def async_create_or_update_custom_properties_values_for_repos(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: OrgsOrgPropertiesValuesPatchBodyType,
+    ) -> "Response":
+        ...
+
+    @overload
+    async def async_create_or_update_custom_properties_values_for_repos(
+        self,
+        org: str,
+        *,
+        data: Literal[UNSET] = UNSET,
+        headers: Optional[Dict[str, str]] = None,
+        repository_names: List[str],
+        properties: List[CustomPropertyValueType],
+    ) -> "Response":
+        ...
+
+    async def async_create_or_update_custom_properties_values_for_repos(
+        self,
+        org: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        data: Missing[OrgsOrgPropertiesValuesPatchBodyType] = UNSET,
+        **kwargs,
+    ) -> "Response":
+        url = f"/orgs/{org}/properties/values"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        if not kwargs:
+            kwargs = UNSET
+
+        json = kwargs if data is UNSET else data
+        json = TypeAdapter(OrgsOrgPropertiesValuesPatchBody).validate_python(json)
+        json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
+
+        return await self._github.arequest(
+            "PATCH",
+            url,
+            json=exclude_unset(json),
+            headers=exclude_unset(headers),
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
             },
         )
 

--- a/githubkit/rest/repos.py
+++ b/githubkit/rest/repos.py
@@ -23,6 +23,7 @@ from .types import (
     RepositoryRuleCreationType,
     RepositoryRuleDeletionType,
     OrgsOrgRulesetsPostBodyType,
+    RepositoryRuleWorkflowsType,
     ReposOwnerRepoPatchBodyType,
     RepositoryRulePullRequestType,
     OrgRulesetConditionsOneof0Type,
@@ -70,9 +71,11 @@ from .types import (
     ReposOwnerRepoPagesPostBodyPropSourceType,
     RepositoryRuleCommitAuthorEmailPatternType,
     ReposOwnerRepoRulesetsRulesetIdPutBodyType,
+    OrgsOrgReposPostBodyPropCustomPropertiesType,
     ReposOwnerRepoCommentsCommentIdPatchBodyType,
     ReposOwnerRepoHooksHookIdConfigPatchBodyType,
     ReposOwnerRepoReleasesReleaseIdPatchBodyType,
+    DeploymentBranchPolicyNamePatternWithTypeType,
     ReposOwnerRepoBranchesBranchRenamePostBodyType,
     ReposOwnerRepoCollaboratorsUsernamePutBodyType,
     ReposOwnerRepoPagesPutBodyPropSourceAnyof1Type,
@@ -129,6 +132,7 @@ from .models import (
     Language,
     DeployKey,
     PageBuild,
+    RuleSuite,
     BasicError,
     Deployment,
     FileCommit,
@@ -157,6 +161,7 @@ from .models import (
     PageBuildStatus,
     ProtectedBranch,
     ReferrerTraffic,
+    RuleSuitesItems,
     ValidationError,
     BranchProtection,
     CodeownersErrors,
@@ -173,6 +178,7 @@ from .models import (
     UserReposPostBody,
     ParticipationStats,
     ContributorActivity,
+    CustomPropertyValue,
     ReleaseNotesContent,
     BranchWithProtection,
     CombinedCommitStatus,
@@ -206,6 +212,7 @@ from .models import (
     RepositoryRuleDetailedOneof11,
     RepositoryRuleDetailedOneof12,
     RepositoryRuleDetailedOneof13,
+    RepositoryRuleDetailedOneof14,
     ReposOwnerRepoReleasesPostBody,
     ReposOwnerRepoRulesetsPostBody,
     ReposOwnerRepoTransferPostBody,
@@ -236,6 +243,7 @@ from .models import (
     ReposOwnerRepoEnvironmentsGetResponse200,
     ReposOwnerRepoHooksHookIdConfigPatchBody,
     ReposOwnerRepoReleasesReleaseIdPatchBody,
+    DeploymentBranchPolicyNamePatternWithType,
     ReposOwnerRepoBranchesBranchRenamePostBody,
     ReposOwnerRepoCollaboratorsUsernamePutBody,
     ReposOwnerRepoReleasesGenerateNotesPostBody,
@@ -352,7 +360,7 @@ class ReposClient:
         *,
         headers: Optional[Dict[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     @overload
@@ -390,7 +398,10 @@ class ReposClient:
         ] = UNSET,
         merge_commit_title: Missing[Literal["PR_TITLE", "MERGE_MESSAGE"]] = UNSET,
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
-    ) -> "Response[Repository]":
+        custom_properties: Missing[
+            OrgsOrgReposPostBodyPropCustomPropertiesType
+        ] = UNSET,
+    ) -> "Response[FullRepository]":
         ...
 
     def create_in_org(
@@ -400,7 +411,7 @@ class ReposClient:
         headers: Optional[Dict[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         url = f"/orgs/{org}/repos"
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -417,7 +428,7 @@ class ReposClient:
             url,
             json=exclude_unset(json),
             headers=exclude_unset(headers),
-            response_model=Repository,
+            response_model=FullRepository,
             error_models={
                 "403": BasicError,
                 "422": ValidationError,
@@ -431,7 +442,7 @@ class ReposClient:
         *,
         headers: Optional[Dict[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     @overload
@@ -469,7 +480,10 @@ class ReposClient:
         ] = UNSET,
         merge_commit_title: Missing[Literal["PR_TITLE", "MERGE_MESSAGE"]] = UNSET,
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
-    ) -> "Response[Repository]":
+        custom_properties: Missing[
+            OrgsOrgReposPostBodyPropCustomPropertiesType
+        ] = UNSET,
+    ) -> "Response[FullRepository]":
         ...
 
     async def async_create_in_org(
@@ -479,7 +493,7 @@ class ReposClient:
         headers: Optional[Dict[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         url = f"/orgs/{org}/repos"
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -496,7 +510,7 @@ class ReposClient:
             url,
             json=exclude_unset(json),
             headers=exclude_unset(headers),
-            response_model=Repository,
+            response_model=FullRepository,
             error_models={
                 "403": BasicError,
                 "422": ValidationError,
@@ -602,6 +616,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -680,6 +695,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -711,6 +727,124 @@ class ReposClient:
             json=exclude_unset(json),
             headers=exclude_unset(headers),
             response_model=RepositoryRuleset,
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    def get_org_rule_suites(
+        self,
+        org: str,
+        repository_name: Missing[int] = UNSET,
+        time_period: Missing[Literal["hour", "day", "week", "month"]] = "day",
+        actor_name: Missing[str] = UNSET,
+        rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = "all",
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[RuleSuitesItems]]":
+        url = f"/orgs/{org}/rulesets/rule-suites"
+
+        params = {
+            "repository_name": repository_name,
+            "time_period": time_period,
+            "actor_name": actor_name,
+            "rule_suite_result": rule_suite_result,
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[RuleSuitesItems],
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    async def async_get_org_rule_suites(
+        self,
+        org: str,
+        repository_name: Missing[int] = UNSET,
+        time_period: Missing[Literal["hour", "day", "week", "month"]] = "day",
+        actor_name: Missing[str] = UNSET,
+        rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = "all",
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[RuleSuitesItems]]":
+        url = f"/orgs/{org}/rulesets/rule-suites"
+
+        params = {
+            "repository_name": repository_name,
+            "time_period": time_period,
+            "actor_name": actor_name,
+            "rule_suite_result": rule_suite_result,
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[RuleSuitesItems],
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    def get_org_rule_suite(
+        self,
+        org: str,
+        rule_suite_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[RuleSuite]":
+        url = f"/orgs/{org}/rulesets/rule-suites/{rule_suite_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=RuleSuite,
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    async def async_get_org_rule_suite(
+        self,
+        org: str,
+        rule_suite_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[RuleSuite]":
+        url = f"/orgs/{org}/rulesets/rule-suites/{rule_suite_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=RuleSuite,
             error_models={
                 "404": BasicError,
                 "500": BasicError,
@@ -804,6 +938,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -885,6 +1020,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -7273,6 +7409,7 @@ class ReposClient:
         data: Literal[UNSET] = UNSET,
         headers: Optional[Dict[str, str]] = None,
         wait_timer: Missing[int] = UNSET,
+        prevent_self_review: Missing[bool] = UNSET,
         reviewers: Missing[
             Union[
                 List[
@@ -7347,6 +7484,7 @@ class ReposClient:
         data: Literal[UNSET] = UNSET,
         headers: Optional[Dict[str, str]] = None,
         wait_timer: Missing[int] = UNSET,
+        prevent_self_review: Missing[bool] = UNSET,
         reviewers: Missing[
             Union[
                 List[
@@ -7495,7 +7633,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[Dict[str, str]] = None,
-        data: DeploymentBranchPolicyNamePatternType,
+        data: DeploymentBranchPolicyNamePatternWithTypeType,
     ) -> "Response[DeploymentBranchPolicy]":
         ...
 
@@ -7509,6 +7647,7 @@ class ReposClient:
         data: Literal[UNSET] = UNSET,
         headers: Optional[Dict[str, str]] = None,
         name: str,
+        type: Missing[Literal["branch", "tag"]] = UNSET,
     ) -> "Response[DeploymentBranchPolicy]":
         ...
 
@@ -7519,7 +7658,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[Dict[str, str]] = None,
-        data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
+        data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
     ) -> "Response[DeploymentBranchPolicy]":
         url = f"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies"
@@ -7530,7 +7669,9 @@ class ReposClient:
             kwargs = UNSET
 
         json = kwargs if data is UNSET else data
-        json = TypeAdapter(DeploymentBranchPolicyNamePattern).validate_python(json)
+        json = TypeAdapter(DeploymentBranchPolicyNamePatternWithType).validate_python(
+            json
+        )
         json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
 
         return self._github.request(
@@ -7550,7 +7691,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[Dict[str, str]] = None,
-        data: DeploymentBranchPolicyNamePatternType,
+        data: DeploymentBranchPolicyNamePatternWithTypeType,
     ) -> "Response[DeploymentBranchPolicy]":
         ...
 
@@ -7564,6 +7705,7 @@ class ReposClient:
         data: Literal[UNSET] = UNSET,
         headers: Optional[Dict[str, str]] = None,
         name: str,
+        type: Missing[Literal["branch", "tag"]] = UNSET,
     ) -> "Response[DeploymentBranchPolicy]":
         ...
 
@@ -7574,7 +7716,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[Dict[str, str]] = None,
-        data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
+        data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
     ) -> "Response[DeploymentBranchPolicy]":
         url = f"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies"
@@ -7585,7 +7727,9 @@ class ReposClient:
             kwargs = UNSET
 
         json = kwargs if data is UNSET else data
-        json = TypeAdapter(DeploymentBranchPolicyNamePattern).validate_python(json)
+        json = TypeAdapter(DeploymentBranchPolicyNamePatternWithType).validate_python(
+            json
+        )
         json = json.model_dump(by_alias=True) if isinstance(json, BaseModel) else json
 
         return await self._github.arequest(
@@ -10743,6 +10887,50 @@ class ReposClient:
             },
         )
 
+    def get_custom_properties_values(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[CustomPropertyValue]]":
+        url = f"/repos/{owner}/{repo}/properties/values"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=List[CustomPropertyValue],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    async def async_get_custom_properties_values(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[CustomPropertyValue]]":
+        url = f"/repos/{owner}/{repo}/properties/values"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=List[CustomPropertyValue],
+            error_models={
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
     def get_readme(
         self,
         owner: str,
@@ -11790,7 +11978,7 @@ class ReposClient:
         page: Missing[int] = 1,
         *,
         headers: Optional[Dict[str, str]] = None,
-    ) -> "Response[List[Union[RepositoryRuleDetailedOneof0, RepositoryRuleDetailedOneof1, RepositoryRuleDetailedOneof2, RepositoryRuleDetailedOneof3, RepositoryRuleDetailedOneof4, RepositoryRuleDetailedOneof5, RepositoryRuleDetailedOneof6, RepositoryRuleDetailedOneof7, RepositoryRuleDetailedOneof8, RepositoryRuleDetailedOneof9, RepositoryRuleDetailedOneof10, RepositoryRuleDetailedOneof11, RepositoryRuleDetailedOneof12, RepositoryRuleDetailedOneof13]]]":
+    ) -> "Response[List[Union[RepositoryRuleDetailedOneof0, RepositoryRuleDetailedOneof1, RepositoryRuleDetailedOneof2, RepositoryRuleDetailedOneof3, RepositoryRuleDetailedOneof4, RepositoryRuleDetailedOneof5, RepositoryRuleDetailedOneof6, RepositoryRuleDetailedOneof7, RepositoryRuleDetailedOneof8, RepositoryRuleDetailedOneof9, RepositoryRuleDetailedOneof10, RepositoryRuleDetailedOneof11, RepositoryRuleDetailedOneof12, RepositoryRuleDetailedOneof13, RepositoryRuleDetailedOneof14]]]":
         url = f"/repos/{owner}/{repo}/rules/branches/{branch}"
 
         params = {
@@ -11821,6 +12009,7 @@ class ReposClient:
                     RepositoryRuleDetailedOneof11,
                     RepositoryRuleDetailedOneof12,
                     RepositoryRuleDetailedOneof13,
+                    RepositoryRuleDetailedOneof14,
                 ]
             ],
         )
@@ -11834,7 +12023,7 @@ class ReposClient:
         page: Missing[int] = 1,
         *,
         headers: Optional[Dict[str, str]] = None,
-    ) -> "Response[List[Union[RepositoryRuleDetailedOneof0, RepositoryRuleDetailedOneof1, RepositoryRuleDetailedOneof2, RepositoryRuleDetailedOneof3, RepositoryRuleDetailedOneof4, RepositoryRuleDetailedOneof5, RepositoryRuleDetailedOneof6, RepositoryRuleDetailedOneof7, RepositoryRuleDetailedOneof8, RepositoryRuleDetailedOneof9, RepositoryRuleDetailedOneof10, RepositoryRuleDetailedOneof11, RepositoryRuleDetailedOneof12, RepositoryRuleDetailedOneof13]]]":
+    ) -> "Response[List[Union[RepositoryRuleDetailedOneof0, RepositoryRuleDetailedOneof1, RepositoryRuleDetailedOneof2, RepositoryRuleDetailedOneof3, RepositoryRuleDetailedOneof4, RepositoryRuleDetailedOneof5, RepositoryRuleDetailedOneof6, RepositoryRuleDetailedOneof7, RepositoryRuleDetailedOneof8, RepositoryRuleDetailedOneof9, RepositoryRuleDetailedOneof10, RepositoryRuleDetailedOneof11, RepositoryRuleDetailedOneof12, RepositoryRuleDetailedOneof13, RepositoryRuleDetailedOneof14]]]":
         url = f"/repos/{owner}/{repo}/rules/branches/{branch}"
 
         params = {
@@ -11865,6 +12054,7 @@ class ReposClient:
                     RepositoryRuleDetailedOneof11,
                     RepositoryRuleDetailedOneof12,
                     RepositoryRuleDetailedOneof13,
+                    RepositoryRuleDetailedOneof14,
                 ]
             ],
         )
@@ -11974,6 +12164,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -12053,6 +12244,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -12085,6 +12277,128 @@ class ReposClient:
             json=exclude_unset(json),
             headers=exclude_unset(headers),
             response_model=RepositoryRuleset,
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    def get_repo_rule_suites(
+        self,
+        owner: str,
+        repo: str,
+        ref: Missing[str] = UNSET,
+        time_period: Missing[Literal["hour", "day", "week", "month"]] = "day",
+        actor_name: Missing[str] = UNSET,
+        rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = "all",
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[RuleSuitesItems]]":
+        url = f"/repos/{owner}/{repo}/rulesets/rule-suites"
+
+        params = {
+            "ref": ref,
+            "time_period": time_period,
+            "actor_name": actor_name,
+            "rule_suite_result": rule_suite_result,
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[RuleSuitesItems],
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    async def async_get_repo_rule_suites(
+        self,
+        owner: str,
+        repo: str,
+        ref: Missing[str] = UNSET,
+        time_period: Missing[Literal["hour", "day", "week", "month"]] = "day",
+        actor_name: Missing[str] = UNSET,
+        rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = "all",
+        per_page: Missing[int] = 30,
+        page: Missing[int] = 1,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[List[RuleSuitesItems]]":
+        url = f"/repos/{owner}/{repo}/rulesets/rule-suites"
+
+        params = {
+            "ref": ref,
+            "time_period": time_period,
+            "actor_name": actor_name,
+            "rule_suite_result": rule_suite_result,
+            "per_page": per_page,
+            "page": page,
+        }
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            params=exclude_unset(params),
+            headers=exclude_unset(headers),
+            response_model=List[RuleSuitesItems],
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    def get_repo_rule_suite(
+        self,
+        owner: str,
+        repo: str,
+        rule_suite_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[RuleSuite]":
+        url = f"/repos/{owner}/{repo}/rulesets/rule-suites/{rule_suite_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=RuleSuite,
+            error_models={
+                "404": BasicError,
+                "500": BasicError,
+            },
+        )
+
+    async def async_get_repo_rule_suite(
+        self,
+        owner: str,
+        repo: str,
+        rule_suite_id: int,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[RuleSuite]":
+        url = f"/repos/{owner}/{repo}/rulesets/rule-suites/{rule_suite_id}"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "GET",
+            url,
+            headers=exclude_unset(headers),
+            response_model=RuleSuite,
             error_models={
                 "404": BasicError,
                 "500": BasicError,
@@ -12192,6 +12506,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -12274,6 +12589,7 @@ class ReposClient:
                     RepositoryRuleCommitterEmailPatternType,
                     RepositoryRuleBranchNamePatternType,
                     RepositoryRuleTagNamePatternType,
+                    RepositoryRuleWorkflowsType,
                 ]
             ]
         ] = UNSET,
@@ -13615,7 +13931,7 @@ class ReposClient:
         *,
         headers: Optional[Dict[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     @overload
@@ -13631,7 +13947,7 @@ class ReposClient:
         description: Missing[str] = UNSET,
         include_all_branches: Missing[bool] = False,
         private: Missing[bool] = False,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     def create_using_template(
@@ -13642,7 +13958,7 @@ class ReposClient:
         headers: Optional[Dict[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         url = f"/repos/{template_owner}/{template_repo}/generate"
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -13661,7 +13977,7 @@ class ReposClient:
             url,
             json=exclude_unset(json),
             headers=exclude_unset(headers),
-            response_model=Repository,
+            response_model=FullRepository,
         )
 
     @overload
@@ -13672,7 +13988,7 @@ class ReposClient:
         *,
         headers: Optional[Dict[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     @overload
@@ -13688,7 +14004,7 @@ class ReposClient:
         description: Missing[str] = UNSET,
         include_all_branches: Missing[bool] = False,
         private: Missing[bool] = False,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     async def async_create_using_template(
@@ -13699,7 +14015,7 @@ class ReposClient:
         headers: Optional[Dict[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         url = f"/repos/{template_owner}/{template_repo}/generate"
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -13718,7 +14034,7 @@ class ReposClient:
             url,
             json=exclude_unset(json),
             headers=exclude_unset(headers),
-            response_model=Repository,
+            response_model=FullRepository,
         )
 
     def list_public(
@@ -13864,7 +14180,7 @@ class ReposClient:
     @overload
     def create_for_authenticated_user(
         self, *, headers: Optional[Dict[str, str]] = None, data: UserReposPostBodyType
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     @overload
@@ -13900,7 +14216,7 @@ class ReposClient:
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
         has_downloads: Missing[bool] = True,
         is_template: Missing[bool] = False,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     def create_for_authenticated_user(
@@ -13909,7 +14225,7 @@ class ReposClient:
         headers: Optional[Dict[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         url = "/user/repos"
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -13926,7 +14242,7 @@ class ReposClient:
             url,
             json=exclude_unset(json),
             headers=exclude_unset(headers),
-            response_model=Repository,
+            response_model=FullRepository,
             error_models={
                 "401": BasicError,
                 "404": BasicError,
@@ -13939,7 +14255,7 @@ class ReposClient:
     @overload
     async def async_create_for_authenticated_user(
         self, *, headers: Optional[Dict[str, str]] = None, data: UserReposPostBodyType
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     @overload
@@ -13975,7 +14291,7 @@ class ReposClient:
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
         has_downloads: Missing[bool] = True,
         is_template: Missing[bool] = False,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         ...
 
     async def async_create_for_authenticated_user(
@@ -13984,7 +14300,7 @@ class ReposClient:
         headers: Optional[Dict[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> "Response[Repository]":
+    ) -> "Response[FullRepository]":
         url = "/user/repos"
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -14001,7 +14317,7 @@ class ReposClient:
             url,
             json=exclude_unset(json),
             headers=exclude_unset(headers),
-            response_model=Repository,
+            response_model=FullRepository,
             error_models={
                 "401": BasicError,
                 "404": BasicError,

--- a/githubkit/rest/secret_scanning.py
+++ b/githubkit/rest/secret_scanning.py
@@ -46,6 +46,7 @@ class SecretScanningClient:
         per_page: Missing[int] = 30,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
+        validity: Missing[str] = UNSET,
         *,
         headers: Optional[Dict[str, str]] = None,
     ) -> "Response[List[OrganizationSecretScanningAlert]]":
@@ -60,6 +61,7 @@ class SecretScanningClient:
             "per_page": per_page,
             "before": before,
             "after": after,
+            "validity": validity,
         }
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -87,6 +89,7 @@ class SecretScanningClient:
         per_page: Missing[int] = 30,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
+        validity: Missing[str] = UNSET,
         *,
         headers: Optional[Dict[str, str]] = None,
     ) -> "Response[List[OrganizationSecretScanningAlert]]":
@@ -101,6 +104,7 @@ class SecretScanningClient:
             "per_page": per_page,
             "before": before,
             "after": after,
+            "validity": validity,
         }
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -129,6 +133,7 @@ class SecretScanningClient:
         per_page: Missing[int] = 30,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
+        validity: Missing[str] = UNSET,
         *,
         headers: Optional[Dict[str, str]] = None,
     ) -> "Response[List[OrganizationSecretScanningAlert]]":
@@ -144,6 +149,7 @@ class SecretScanningClient:
             "per_page": per_page,
             "before": before,
             "after": after,
+            "validity": validity,
         }
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -172,6 +178,7 @@ class SecretScanningClient:
         per_page: Missing[int] = 30,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
+        validity: Missing[str] = UNSET,
         *,
         headers: Optional[Dict[str, str]] = None,
     ) -> "Response[List[OrganizationSecretScanningAlert]]":
@@ -187,6 +194,7 @@ class SecretScanningClient:
             "per_page": per_page,
             "before": before,
             "after": after,
+            "validity": validity,
         }
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -216,6 +224,7 @@ class SecretScanningClient:
         per_page: Missing[int] = 30,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
+        validity: Missing[str] = UNSET,
         *,
         headers: Optional[Dict[str, str]] = None,
     ) -> "Response[List[SecretScanningAlert]]":
@@ -231,6 +240,7 @@ class SecretScanningClient:
             "per_page": per_page,
             "before": before,
             "after": after,
+            "validity": validity,
         }
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
@@ -259,6 +269,7 @@ class SecretScanningClient:
         per_page: Missing[int] = 30,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
+        validity: Missing[str] = UNSET,
         *,
         headers: Optional[Dict[str, str]] = None,
     ) -> "Response[List[SecretScanningAlert]]":
@@ -274,6 +285,7 @@ class SecretScanningClient:
             "per_page": per_page,
             "before": before,
             "after": after,
+            "validity": validity,
         }
 
         headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}

--- a/githubkit/rest/security_advisories.py
+++ b/githubkit/rest/security_advisories.py
@@ -16,6 +16,7 @@ from githubkit.utils import UNSET, Missing, exclude_unset
 
 from .models import (
     BasicError,
+    FullRepository,
     GlobalAdvisory,
     ValidationError,
     RepositoryAdvisory,
@@ -414,6 +415,7 @@ class SecurityAdvisoriesClient:
             Union[None, Literal["critical", "high", "medium", "low"]]
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
+        start_private_fork: Missing[bool] = False,
     ) -> "Response[RepositoryAdvisory]":
         ...
 
@@ -481,6 +483,7 @@ class SecurityAdvisoriesClient:
             Union[None, Literal["critical", "high", "medium", "low"]]
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
+        start_private_fork: Missing[bool] = False,
     ) -> "Response[RepositoryAdvisory]":
         ...
 
@@ -548,6 +551,7 @@ class SecurityAdvisoriesClient:
             Union[None, Literal["critical", "high", "medium", "low"]]
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
+        start_private_fork: Missing[bool] = False,
     ) -> "Response[RepositoryAdvisory]":
         ...
 
@@ -615,6 +619,7 @@ class SecurityAdvisoriesClient:
             Union[None, Literal["critical", "high", "medium", "low"]]
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
+        start_private_fork: Missing[bool] = False,
     ) -> "Response[RepositoryAdvisory]":
         ...
 
@@ -894,5 +899,55 @@ class SecurityAdvisoriesClient:
                 "403": BasicError,
                 "404": BasicError,
                 "422": ValidationError,
+            },
+        )
+
+    def create_fork(
+        self,
+        owner: str,
+        repo: str,
+        ghsa_id: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[FullRepository]":
+        url = f"/repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return self._github.request(
+            "POST",
+            url,
+            headers=exclude_unset(headers),
+            response_model=FullRepository,
+            error_models={
+                "400": BasicError,
+                "422": ValidationError,
+                "403": BasicError,
+                "404": BasicError,
+            },
+        )
+
+    async def async_create_fork(
+        self,
+        owner: str,
+        repo: str,
+        ghsa_id: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> "Response[FullRepository]":
+        url = f"/repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks"
+
+        headers = {"X-GitHub-Api-Version": self._REST_API_VERSION, **(headers or {})}
+
+        return await self._github.arequest(
+            "POST",
+            url,
+            headers=exclude_unset(headers),
+            response_model=FullRepository,
+            error_models={
+                "400": BasicError,
+                "422": ValidationError,
+                "403": BasicError,
+                "404": BasicError,
             },
         )

--- a/githubkit/rest/types.py
+++ b/githubkit/rest/types.py
@@ -418,7 +418,9 @@ class AppPermissionsType(TypedDict):
     actions: NotRequired[Literal["read", "write"]]
     administration: NotRequired[Literal["read", "write"]]
     checks: NotRequired[Literal["read", "write"]]
+    codespaces: NotRequired[Literal["read", "write"]]
     contents: NotRequired[Literal["read", "write"]]
+    dependabot_secrets: NotRequired[Literal["read", "write"]]
     deployments: NotRequired[Literal["read", "write"]]
     environments: NotRequired[Literal["read", "write"]]
     issues: NotRequired[Literal["read", "write"]]
@@ -426,6 +428,7 @@ class AppPermissionsType(TypedDict):
     packages: NotRequired[Literal["read", "write"]]
     pages: NotRequired[Literal["read", "write"]]
     pull_requests: NotRequired[Literal["read", "write"]]
+    repository_custom_properties: NotRequired[Literal["read", "write"]]
     repository_hooks: NotRequired[Literal["read", "write"]]
     repository_projects: NotRequired[Literal["read", "write", "admin"]]
     secret_scanning_alerts: NotRequired[Literal["read", "write"]]
@@ -438,7 +441,11 @@ class AppPermissionsType(TypedDict):
     members: NotRequired[Literal["read", "write"]]
     organization_administration: NotRequired[Literal["read", "write"]]
     organization_custom_roles: NotRequired[Literal["read", "write"]]
+    organization_custom_org_roles: NotRequired[Literal["read", "write"]]
+    organization_custom_properties: NotRequired[Literal["read", "write", "admin"]]
+    organization_copilot_seat_management: NotRequired[Literal["write"]]
     organization_announcement_banners: NotRequired[Literal["read", "write"]]
+    organization_events: NotRequired[Literal["read"]]
     organization_hooks: NotRequired[Literal["read", "write"]]
     organization_personal_access_tokens: NotRequired[Literal["read", "write"]]
     organization_personal_access_token_requests: NotRequired[Literal["read", "write"]]
@@ -449,6 +456,13 @@ class AppPermissionsType(TypedDict):
     organization_self_hosted_runners: NotRequired[Literal["read", "write"]]
     organization_user_blocking: NotRequired[Literal["read", "write"]]
     team_discussions: NotRequired[Literal["read", "write"]]
+    email_addresses: NotRequired[Literal["read", "write"]]
+    followers: NotRequired[Literal["read", "write"]]
+    git_ssh_keys: NotRequired[Literal["read", "write"]]
+    gpg_keys: NotRequired[Literal["read", "write"]]
+    interaction_limits: NotRequired[Literal["read", "write"]]
+    profile: NotRequired[Literal["write"]]
+    starring: NotRequired[Literal["read", "write"]]
 
 
 class InstallationType(TypedDict):
@@ -1174,6 +1188,7 @@ class OrganizationSecretScanningAlertType(TypedDict):
     push_protection_bypassed_by: NotRequired[Union[None, SimpleUserType]]
     push_protection_bypassed_at: NotRequired[Union[datetime, None]]
     resolution_comment: NotRequired[Union[str, None]]
+    validity: NotRequired[Literal["active", "inactive", "unknown"]]
 
 
 class ActorType(TypedDict):
@@ -1785,6 +1800,7 @@ class ApiOverviewPropDomainsType(TypedDict):
     codespaces: NotRequired[List[str]]
     copilot: NotRequired[List[str]]
     packages: NotRequired[List[str]]
+    actions: NotRequired[List[str]]
 
 
 class SecurityAndAnalysisPropAdvancedSecurityType(TypedDict):
@@ -2246,20 +2262,17 @@ class OrganizationActionsVariableType(TypedDict):
     selected_repositories_url: NotRequired[str]
 
 
-class CodeScanningAlertRuleType(TypedDict):
-    """CodeScanningAlertRule"""
+class CodeScanningAlertRuleSummaryType(TypedDict):
+    """CodeScanningAlertRuleSummary"""
 
     id: NotRequired[Union[str, None]]
     name: NotRequired[str]
+    tags: NotRequired[Union[List[str], None]]
     severity: NotRequired[Union[None, Literal["none", "note", "warning", "error"]]]
     security_severity_level: NotRequired[
         Union[None, Literal["low", "medium", "high", "critical"]]
     ]
     description: NotRequired[str]
-    full_description: NotRequired[str]
-    tags: NotRequired[Union[List[str], None]]
-    help_: NotRequired[Union[str, None]]
-    help_uri: NotRequired[Union[str, None]]
 
 
 class CodeScanningAnalysisToolType(TypedDict):
@@ -2323,7 +2336,7 @@ class CodeScanningOrganizationAlertItemsType(TypedDict):
         None, Literal["false positive", "won't fix", "used in tests"]
     ]
     dismissed_comment: NotRequired[Union[str, None]]
-    rule: CodeScanningAlertRuleType
+    rule: CodeScanningAlertRuleSummaryType
     tool: CodeScanningAnalysisToolType
     most_recent_instance: CodeScanningAlertInstanceType
     repository: SimpleRepositoryType
@@ -2449,9 +2462,9 @@ class CodespacesPublicKeyType(TypedDict):
 
 
 class CopilotSeatBreakdownType(TypedDict):
-    """Copilot for Business Seat Breakdown
+    """Copilot Business Seat Breakdown
 
-    The breakdown of Copilot for Business seats for the organization.
+    The breakdown of Copilot Business seats for the organization.
     """
 
     total: NotRequired[int]
@@ -2463,14 +2476,15 @@ class CopilotSeatBreakdownType(TypedDict):
 
 
 class CopilotOrganizationDetailsType(TypedDict):
-    """Copilot for Business Organization Details
+    """Copilot Business Organization Details
 
     Information about the seat breakdown and policies set for an organization with a
-    Copilot for Business subscription.
+    Copilot Business subscription.
     """
 
     seat_breakdown: CopilotSeatBreakdownType
     public_code_suggestions: Literal["allow", "block", "unconfigured", "unknown"]
+    copilot_chat: NotRequired[Literal["enabled", "disabled", "unconfigured"]]
     seat_management_setting: Literal[
         "assign_all", "assign_selected", "disabled", "unconfigured"
     ]
@@ -2577,9 +2591,9 @@ class OrganizationPropPlanType(TypedDict):
 
 
 class CopilotSeatDetailsType(TypedDict):
-    """Copilot for Business Seat Detail
+    """Copilot Business Seat Detail
 
-    Information about a Copilot for Business seat assignment for a user, team, or
+    Information about a Copilot Business seat assignment for a user, team, or
     organization.
     """
 
@@ -2752,6 +2766,31 @@ class MigrationType(TypedDict):
     exclude: NotRequired[List[str]]
 
 
+class OrganizationFineGrainedPermissionType(TypedDict):
+    """Organization Fine-Grained Permission
+
+    A fine-grained permission that protects organization resources.
+    """
+
+    name: str
+    description: str
+
+
+class OrganizationRoleType(TypedDict):
+    """Organization Role
+
+    Organization roles
+    """
+
+    id: int
+    name: str
+    description: NotRequired[Union[str, None]]
+    permissions: List[str]
+    organization: Union[None, SimpleUserType]
+    created_at: datetime
+    updated_at: datetime
+
+
 class PackageVersionType(TypedDict):
     """Package Version
 
@@ -2911,6 +2950,176 @@ class ProjectType(TypedDict):
     private: NotRequired[bool]
 
 
+class OrgCustomPropertyType(TypedDict):
+    """Organization Custom Property
+
+    Custom property defined on an organization
+    """
+
+    property_name: str
+    value_type: Literal["string", "single_select"]
+    required: NotRequired[bool]
+    default_value: NotRequired[Union[str, None]]
+    description: NotRequired[Union[str, None]]
+    allowed_values: NotRequired[Union[List[str], None]]
+
+
+class CustomPropertyValueType(TypedDict):
+    """Custom Property Value
+
+    Custom property name and associated value
+    """
+
+    property_name: str
+    value: Union[str, None]
+
+
+class OrgRepoCustomPropertyValuesType(TypedDict):
+    """Organization Repository Custom Property Values
+
+    List of custom property values for a repository
+    """
+
+    repository_id: int
+    repository_name: str
+    repository_full_name: str
+    properties: List[CustomPropertyValueType]
+
+
+class CodeOfConductSimpleType(TypedDict):
+    """Code Of Conduct Simple
+
+    Code of Conduct Simple
+    """
+
+    url: str
+    key: str
+    name: str
+    html_url: Union[str, None]
+
+
+class FullRepositoryType(TypedDict):
+    """Full Repository
+
+    Full Repository
+    """
+
+    id: int
+    node_id: str
+    name: str
+    full_name: str
+    owner: SimpleUserType
+    private: bool
+    html_url: str
+    description: Union[str, None]
+    fork: bool
+    url: str
+    archive_url: str
+    assignees_url: str
+    blobs_url: str
+    branches_url: str
+    collaborators_url: str
+    comments_url: str
+    commits_url: str
+    compare_url: str
+    contents_url: str
+    contributors_url: str
+    deployments_url: str
+    downloads_url: str
+    events_url: str
+    forks_url: str
+    git_commits_url: str
+    git_refs_url: str
+    git_tags_url: str
+    git_url: str
+    issue_comment_url: str
+    issue_events_url: str
+    issues_url: str
+    keys_url: str
+    labels_url: str
+    languages_url: str
+    merges_url: str
+    milestones_url: str
+    notifications_url: str
+    pulls_url: str
+    releases_url: str
+    ssh_url: str
+    stargazers_url: str
+    statuses_url: str
+    subscribers_url: str
+    subscription_url: str
+    tags_url: str
+    teams_url: str
+    trees_url: str
+    clone_url: str
+    mirror_url: Union[str, None]
+    hooks_url: str
+    svn_url: str
+    homepage: Union[str, None]
+    language: Union[str, None]
+    forks_count: int
+    stargazers_count: int
+    watchers_count: int
+    size: int
+    default_branch: str
+    open_issues_count: int
+    is_template: NotRequired[bool]
+    topics: NotRequired[List[str]]
+    has_issues: bool
+    has_projects: bool
+    has_wiki: bool
+    has_pages: bool
+    has_downloads: NotRequired[bool]
+    has_discussions: bool
+    archived: bool
+    disabled: bool
+    visibility: NotRequired[str]
+    pushed_at: datetime
+    created_at: datetime
+    updated_at: datetime
+    permissions: NotRequired[FullRepositoryPropPermissionsType]
+    allow_rebase_merge: NotRequired[bool]
+    template_repository: NotRequired[Union[None, RepositoryType]]
+    temp_clone_token: NotRequired[Union[str, None]]
+    allow_squash_merge: NotRequired[bool]
+    allow_auto_merge: NotRequired[bool]
+    delete_branch_on_merge: NotRequired[bool]
+    allow_merge_commit: NotRequired[bool]
+    allow_update_branch: NotRequired[bool]
+    use_squash_pr_title_as_default: NotRequired[bool]
+    squash_merge_commit_title: NotRequired[Literal["PR_TITLE", "COMMIT_OR_PR_TITLE"]]
+    squash_merge_commit_message: NotRequired[
+        Literal["PR_BODY", "COMMIT_MESSAGES", "BLANK"]
+    ]
+    merge_commit_title: NotRequired[Literal["PR_TITLE", "MERGE_MESSAGE"]]
+    merge_commit_message: NotRequired[Literal["PR_BODY", "PR_TITLE", "BLANK"]]
+    allow_forking: NotRequired[bool]
+    web_commit_signoff_required: NotRequired[bool]
+    subscribers_count: int
+    network_count: int
+    license_: Union[None, LicenseSimpleType]
+    organization: NotRequired[Union[None, SimpleUserType]]
+    parent: NotRequired[RepositoryType]
+    source: NotRequired[RepositoryType]
+    forks: int
+    master_branch: NotRequired[str]
+    open_issues: int
+    watchers: int
+    anonymous_access_enabled: NotRequired[bool]
+    code_of_conduct: NotRequired[CodeOfConductSimpleType]
+    security_and_analysis: NotRequired[Union[SecurityAndAnalysisType, None]]
+
+
+class FullRepositoryPropPermissionsType(TypedDict):
+    """FullRepositoryPropPermissions"""
+
+    admin: bool
+    maintain: NotRequired[bool]
+    push: bool
+    triage: NotRequired[bool]
+    pull: bool
+
+
 class RepositoryRulesetBypassActorType(TypedDict):
     """Repository Ruleset Bypass Actor
 
@@ -3037,7 +3246,7 @@ class RepositoryRuleRequiredDeploymentsType(TypedDict):
     """required_deployments
 
     Choose which environments must be successfully deployed to before refs can be
-    merged into a branch that matches this rule.
+    pushed into a ref that matches this rule.
     """
 
     type: Literal["required_deployments"]
@@ -3093,10 +3302,8 @@ class RepositoryRuleParamsStatusCheckConfigurationType(TypedDict):
 class RepositoryRuleRequiredStatusChecksType(TypedDict):
     """required_status_checks
 
-    Choose which status checks must pass before branches can be merged into a branch
-    that matches this rule. When enabled, commits must first be pushed to another
-    branch, then merged or pushed directly to a ref that matches this rule after
-    status checks have passed.
+    Choose which status checks must pass before the ref is updated. When enabled,
+    commits must first be pushed to another ref where the checks pass.
     """
 
     type: Literal["required_status_checks"]
@@ -3214,6 +3421,35 @@ class RepositoryRuleTagNamePatternPropParametersType(TypedDict):
     pattern: str
 
 
+class RepositoryRuleParamsWorkflowFileReferenceType(TypedDict):
+    """WorkflowFileReference
+
+    A workflow that must run for this rule to pass
+    """
+
+    path: str
+    ref: NotRequired[str]
+    repository_id: int
+    sha: NotRequired[str]
+
+
+class RepositoryRuleWorkflowsType(TypedDict):
+    """workflows
+
+    Require all changes made to a targeted branch to pass the specified workflows
+    before they can be merged.
+    """
+
+    type: Literal["workflows"]
+    parameters: NotRequired[RepositoryRuleWorkflowsPropParametersType]
+
+
+class RepositoryRuleWorkflowsPropParametersType(TypedDict):
+    """RepositoryRuleWorkflowsPropParameters"""
+
+    workflows: List[RepositoryRuleParamsWorkflowFileReferenceType]
+
+
 class RepositoryRulesetType(TypedDict):
     """Repository ruleset
 
@@ -3256,6 +3492,7 @@ class RepositoryRulesetType(TypedDict):
                 RepositoryRuleCommitterEmailPatternType,
                 RepositoryRuleBranchNamePatternType,
                 RepositoryRuleTagNamePatternType,
+                RepositoryRuleWorkflowsType,
             ]
         ]
     ]
@@ -3280,6 +3517,60 @@ class RepositoryRulesetPropLinksPropHtmlType(TypedDict):
     """RepositoryRulesetPropLinksPropHtml"""
 
     href: NotRequired[str]
+
+
+class RuleSuitesItemsType(TypedDict):
+    """RuleSuitesItems"""
+
+    id: NotRequired[int]
+    actor_id: NotRequired[int]
+    actor_name: NotRequired[str]
+    before_sha: NotRequired[str]
+    after_sha: NotRequired[str]
+    ref: NotRequired[str]
+    repository_id: NotRequired[int]
+    repository_name: NotRequired[str]
+    pushed_at: NotRequired[datetime]
+    result: NotRequired[Literal["pass", "fail", "bypass"]]
+    evaluation_result: NotRequired[Literal["pass", "fail"]]
+
+
+class RuleSuiteType(TypedDict):
+    """Rule Suite
+
+    Response
+    """
+
+    id: NotRequired[int]
+    actor_id: NotRequired[int]
+    actor_name: NotRequired[str]
+    before_sha: NotRequired[str]
+    after_sha: NotRequired[str]
+    ref: NotRequired[str]
+    repository_id: NotRequired[int]
+    repository_name: NotRequired[str]
+    pushed_at: NotRequired[datetime]
+    result: NotRequired[Literal["pass", "fail", "bypass"]]
+    evaluation_result: NotRequired[Literal["pass", "fail"]]
+    rule_evaluations: NotRequired[List[RuleSuitePropRuleEvaluationsItemsType]]
+
+
+class RuleSuitePropRuleEvaluationsItemsType(TypedDict):
+    """RuleSuitePropRuleEvaluationsItems"""
+
+    rule_source: NotRequired[RuleSuitePropRuleEvaluationsItemsPropRuleSourceType]
+    enforcement: NotRequired[Literal["active", "evaluate", "deleted ruleset"]]
+    result: NotRequired[Literal["pass", "fail"]]
+    rule_type: NotRequired[str]
+    details: NotRequired[str]
+
+
+class RuleSuitePropRuleEvaluationsItemsPropRuleSourceType(TypedDict):
+    """RuleSuitePropRuleEvaluationsItemsPropRuleSource"""
+
+    type: NotRequired[str]
+    id: NotRequired[Union[int, None]]
+    name: NotRequired[Union[str, None]]
 
 
 class RepositoryAdvisoryVulnerabilityType(TypedDict):
@@ -3753,7 +4044,6 @@ class TeamRepositoryType(TypedDict):
     created_at: Union[datetime, None]
     updated_at: Union[datetime, None]
     allow_rebase_merge: NotRequired[bool]
-    template_repository: NotRequired[Union[None, RepositoryType]]
     temp_clone_token: NotRequired[Union[str, None]]
     allow_squash_merge: NotRequired[bool]
     allow_auto_merge: NotRequired[bool]
@@ -3859,140 +4149,6 @@ class RateLimitOverviewPropResourcesType(TypedDict):
     dependency_snapshots: NotRequired[RateLimitType]
 
 
-class CodeOfConductSimpleType(TypedDict):
-    """Code Of Conduct Simple
-
-    Code of Conduct Simple
-    """
-
-    url: str
-    key: str
-    name: str
-    html_url: Union[str, None]
-
-
-class FullRepositoryType(TypedDict):
-    """Full Repository
-
-    Full Repository
-    """
-
-    id: int
-    node_id: str
-    name: str
-    full_name: str
-    owner: SimpleUserType
-    private: bool
-    html_url: str
-    description: Union[str, None]
-    fork: bool
-    url: str
-    archive_url: str
-    assignees_url: str
-    blobs_url: str
-    branches_url: str
-    collaborators_url: str
-    comments_url: str
-    commits_url: str
-    compare_url: str
-    contents_url: str
-    contributors_url: str
-    deployments_url: str
-    downloads_url: str
-    events_url: str
-    forks_url: str
-    git_commits_url: str
-    git_refs_url: str
-    git_tags_url: str
-    git_url: str
-    issue_comment_url: str
-    issue_events_url: str
-    issues_url: str
-    keys_url: str
-    labels_url: str
-    languages_url: str
-    merges_url: str
-    milestones_url: str
-    notifications_url: str
-    pulls_url: str
-    releases_url: str
-    ssh_url: str
-    stargazers_url: str
-    statuses_url: str
-    subscribers_url: str
-    subscription_url: str
-    tags_url: str
-    teams_url: str
-    trees_url: str
-    clone_url: str
-    mirror_url: Union[str, None]
-    hooks_url: str
-    svn_url: str
-    homepage: Union[str, None]
-    language: Union[str, None]
-    forks_count: int
-    stargazers_count: int
-    watchers_count: int
-    size: int
-    default_branch: str
-    open_issues_count: int
-    is_template: NotRequired[bool]
-    topics: NotRequired[List[str]]
-    has_issues: bool
-    has_projects: bool
-    has_wiki: bool
-    has_pages: bool
-    has_downloads: bool
-    has_discussions: bool
-    archived: bool
-    disabled: bool
-    visibility: NotRequired[str]
-    pushed_at: datetime
-    created_at: datetime
-    updated_at: datetime
-    permissions: NotRequired[FullRepositoryPropPermissionsType]
-    allow_rebase_merge: NotRequired[bool]
-    template_repository: NotRequired[Union[None, RepositoryType]]
-    temp_clone_token: NotRequired[Union[str, None]]
-    allow_squash_merge: NotRequired[bool]
-    allow_auto_merge: NotRequired[bool]
-    delete_branch_on_merge: NotRequired[bool]
-    allow_merge_commit: NotRequired[bool]
-    allow_update_branch: NotRequired[bool]
-    use_squash_pr_title_as_default: NotRequired[bool]
-    squash_merge_commit_title: NotRequired[Literal["PR_TITLE", "COMMIT_OR_PR_TITLE"]]
-    squash_merge_commit_message: NotRequired[
-        Literal["PR_BODY", "COMMIT_MESSAGES", "BLANK"]
-    ]
-    merge_commit_title: NotRequired[Literal["PR_TITLE", "MERGE_MESSAGE"]]
-    merge_commit_message: NotRequired[Literal["PR_BODY", "PR_TITLE", "BLANK"]]
-    allow_forking: NotRequired[bool]
-    web_commit_signoff_required: NotRequired[bool]
-    subscribers_count: int
-    network_count: int
-    license_: Union[None, LicenseSimpleType]
-    organization: NotRequired[Union[None, SimpleUserType]]
-    parent: NotRequired[RepositoryType]
-    source: NotRequired[RepositoryType]
-    forks: int
-    master_branch: NotRequired[str]
-    open_issues: int
-    watchers: int
-    anonymous_access_enabled: NotRequired[bool]
-    code_of_conduct: NotRequired[CodeOfConductSimpleType]
-    security_and_analysis: NotRequired[Union[SecurityAndAnalysisType, None]]
-
-
-class FullRepositoryPropPermissionsType(TypedDict):
-    """FullRepositoryPropPermissions"""
-
-    admin: bool
-    maintain: NotRequired[bool]
-    push: bool
-    triage: NotRequired[bool]
-    pull: bool
-
-
 class ArtifactType(TypedDict):
     """Artifact
 
@@ -4058,7 +4214,7 @@ class JobType(TypedDict):
     head_sha: str
     url: str
     html_url: Union[str, None]
-    status: Literal["queued", "in_progress", "completed"]
+    status: Literal["queued", "in_progress", "completed", "waiting"]
     conclusion: Union[
         None,
         Literal[
@@ -5250,16 +5406,6 @@ class CheckSuitePreferencePropPreferencesPropAutoTriggerChecksItemsType(TypedDic
     setting: bool
 
 
-class CodeScanningAlertRuleSummaryType(TypedDict):
-    """CodeScanningAlertRuleSummary"""
-
-    id: NotRequired[Union[str, None]]
-    name: NotRequired[str]
-    tags: NotRequired[Union[List[str], None]]
-    severity: NotRequired[Union[None, Literal["none", "note", "warning", "error"]]]
-    description: NotRequired[str]
-
-
 class CodeScanningAlertItemsType(TypedDict):
     """CodeScanningAlertItems"""
 
@@ -5280,6 +5426,22 @@ class CodeScanningAlertItemsType(TypedDict):
     rule: CodeScanningAlertRuleSummaryType
     tool: CodeScanningAnalysisToolType
     most_recent_instance: CodeScanningAlertInstanceType
+
+
+class CodeScanningAlertRuleType(TypedDict):
+    """CodeScanningAlertRule"""
+
+    id: NotRequired[Union[str, None]]
+    name: NotRequired[str]
+    severity: NotRequired[Union[None, Literal["none", "note", "warning", "error"]]]
+    security_severity_level: NotRequired[
+        Union[None, Literal["low", "medium", "high", "critical"]]
+    ]
+    description: NotRequired[str]
+    full_description: NotRequired[str]
+    tags: NotRequired[Union[List[str], None]]
+    help_: NotRequired[Union[str, None]]
+    help_uri: NotRequired[Union[str, None]]
 
 
 class CodeScanningAlertType(TypedDict):
@@ -5349,6 +5511,7 @@ class CodeScanningCodeqlDatabaseType(TypedDict):
     created_at: datetime
     updated_at: datetime
     url: str
+    commit_oid: NotRequired[Union[str, None]]
 
 
 class CodeScanningDefaultSetupType(TypedDict):
@@ -5385,7 +5548,7 @@ class CodeScanningDefaultSetupUpdateType(TypedDict):
     Configuration for code scanning default setup.
     """
 
-    state: Literal["configured", "not-configured"]
+    state: NotRequired[Literal["configured", "not-configured"]]
     query_suite: NotRequired[Literal["default", "extended"]]
     languages: NotRequired[
         List[
@@ -5449,6 +5612,15 @@ class CodeownersErrorsPropErrorsItemsType(TypedDict):
     suggestion: NotRequired[Union[str, None]]
     message: str
     path: str
+
+
+class CodespacesPermissionsCheckForDevcontainerType(TypedDict):
+    """Codespaces Permissions Check
+
+    Permission check result for a given devcontainer config.
+    """
+
+    accepted: bool
 
 
 class RepoCodespacesSecretType(TypedDict):
@@ -6393,12 +6565,20 @@ class EnvironmentPropProtectionRulesItemsAnyof2Type(TypedDict):
 class DeploymentBranchPolicyType(TypedDict):
     """Deployment branch policy
 
-    Details of a deployment branch policy.
+    Details of a deployment branch or tag policy.
     """
 
     id: NotRequired[int]
     node_id: NotRequired[str]
     name: NotRequired[str]
+    type: NotRequired[Literal["branch", "tag"]]
+
+
+class DeploymentBranchPolicyNamePatternWithTypeType(TypedDict):
+    """Deployment branch and tag policy name pattern"""
+
+    name: str
+    type: NotRequired[Literal["branch", "tag"]]
 
 
 class DeploymentBranchPolicyNamePatternType(TypedDict):
@@ -8492,6 +8672,16 @@ class RepositoryRuleDetailedOneof13Type(TypedDict):
     ruleset_id: NotRequired[int]
 
 
+class RepositoryRuleDetailedOneof14Type(TypedDict):
+    """RepositoryRuleDetailedOneof14"""
+
+    type: Literal["workflows"]
+    parameters: NotRequired[RepositoryRuleWorkflowsPropParametersType]
+    ruleset_source_type: NotRequired[Literal["Repository", "Organization"]]
+    ruleset_source: NotRequired[str]
+    ruleset_id: NotRequired[int]
+
+
 class SecretScanningAlertType(TypedDict):
     """SecretScanningAlert"""
 
@@ -8514,6 +8704,7 @@ class SecretScanningAlertType(TypedDict):
     push_protection_bypassed: NotRequired[Union[bool, None]]
     push_protection_bypassed_by: NotRequired[Union[None, SimpleUserType]]
     push_protection_bypassed_at: NotRequired[Union[datetime, None]]
+    validity: NotRequired[Literal["active", "inactive", "unknown"]]
 
 
 class SecretScanningLocationCommitType(TypedDict):
@@ -8564,15 +8755,117 @@ class SecretScanningLocationIssueCommentType(TypedDict):
     issue_comment_url: str
 
 
+class SecretScanningLocationDiscussionTitleType(TypedDict):
+    """SecretScanningLocationDiscussionTitle
+
+    Represents a 'discussion_title' secret scanning location type. This location
+    type shows that a secret was detected in the title of a discussion.
+    """
+
+    discussion_title_url: str
+
+
+class SecretScanningLocationDiscussionBodyType(TypedDict):
+    """SecretScanningLocationDiscussionBody
+
+    Represents a 'discussion_body' secret scanning location type. This location type
+    shows that a secret was detected in the body of a discussion.
+    """
+
+    discussion_body_url: str
+
+
+class SecretScanningLocationDiscussionCommentType(TypedDict):
+    """SecretScanningLocationDiscussionComment
+
+    Represents a 'discussion_comment' secret scanning location type. This location
+    type shows that a secret was detected in a comment on a discussion.
+    """
+
+    discussion_comment_url: str
+
+
+class SecretScanningLocationPullRequestTitleType(TypedDict):
+    """SecretScanningLocationPullRequestTitle
+
+    Represents a 'pull_request_title' secret scanning location type. This location
+    type shows that a secret was detected in the title of a pull request.
+    """
+
+    pull_request_title_url: str
+
+
+class SecretScanningLocationPullRequestBodyType(TypedDict):
+    """SecretScanningLocationPullRequestBody
+
+    Represents a 'pull_request_body' secret scanning location type. This location
+    type shows that a secret was detected in the body of a pull request.
+    """
+
+    pull_request_body_url: str
+
+
+class SecretScanningLocationPullRequestCommentType(TypedDict):
+    """SecretScanningLocationPullRequestComment
+
+    Represents a 'pull_request_comment' secret scanning location type. This location
+    type shows that a secret was detected in a comment on a pull request.
+    """
+
+    pull_request_comment_url: str
+
+
+class SecretScanningLocationPullRequestReviewType(TypedDict):
+    """SecretScanningLocationPullRequestReview
+
+    Represents a 'pull_request_review' secret scanning location type. This location
+    type shows that a secret was detected in a review on a pull request.
+    """
+
+    pull_request_review_url: str
+
+
+class SecretScanningLocationPullRequestReviewCommentType(TypedDict):
+    """SecretScanningLocationPullRequestReviewComment
+
+    Represents a 'pull_request_review_comment' secret scanning location type. This
+    location type shows that a secret was detected in a review comment on a pull
+    request.
+    """
+
+    pull_request_review_comment_url: str
+
+
 class SecretScanningLocationType(TypedDict):
     """SecretScanningLocation"""
 
-    type: Literal["commit", "issue_title", "issue_body", "issue_comment"]
+    type: Literal[
+        "commit",
+        "issue_title",
+        "issue_body",
+        "issue_comment",
+        "discussion_title",
+        "discussion_body",
+        "discussion_comment",
+        "pull_request_title",
+        "pull_request_body",
+        "pull_request_comment",
+        "pull_request_review",
+        "pull_request_review_comment",
+    ]
     details: Union[
         SecretScanningLocationCommitType,
         SecretScanningLocationIssueTitleType,
         SecretScanningLocationIssueBodyType,
         SecretScanningLocationIssueCommentType,
+        SecretScanningLocationDiscussionTitleType,
+        SecretScanningLocationDiscussionBodyType,
+        SecretScanningLocationDiscussionCommentType,
+        SecretScanningLocationPullRequestTitleType,
+        SecretScanningLocationPullRequestBodyType,
+        SecretScanningLocationPullRequestCommentType,
+        SecretScanningLocationPullRequestReviewType,
+        SecretScanningLocationPullRequestReviewCommentType,
     ]
 
 
@@ -8589,6 +8882,7 @@ class RepositoryAdvisoryCreateType(TypedDict):
     ]
     severity: NotRequired[Union[None, Literal["critical", "high", "medium", "low"]]]
     cvss_vector_string: NotRequired[Union[str, None]]
+    start_private_fork: NotRequired[bool]
 
 
 class RepositoryAdvisoryCreatePropVulnerabilitiesItemsType(TypedDict):
@@ -8653,6 +8947,7 @@ class PrivateVulnerabilityReportCreateType(TypedDict):
     cwe_ids: NotRequired[Union[List[str], None]]
     severity: NotRequired[Union[None, Literal["critical", "high", "medium", "low"]]]
     cvss_vector_string: NotRequired[Union[str, None]]
+    start_private_fork: NotRequired[bool]
 
 
 class PrivateVulnerabilityReportCreatePropVulnerabilitiesItemsType(TypedDict):
@@ -9787,6 +10082,7 @@ class RepositoryWebhooksType(TypedDict):
     open_issues_count: int
     is_template: NotRequired[bool]
     topics: NotRequired[List[str]]
+    custom_properties: NotRequired[RepositoryWebhooksPropCustomPropertiesType]
     has_issues: bool
     has_projects: bool
     has_wiki: bool
@@ -9835,6 +10131,15 @@ class RepositoryWebhooksPropPermissionsType(TypedDict):
     triage: NotRequired[bool]
     push: bool
     maintain: NotRequired[bool]
+
+
+class RepositoryWebhooksPropCustomPropertiesType(TypedDict):
+    """RepositoryWebhooksPropCustomProperties
+
+    The custom properties that were defined for the repository. The keys are the
+    custom property names, and the values are the corresponding custom property
+    values.
+    """
 
 
 class RepositoryWebhooksPropTemplateRepositoryPropOwnerType(TypedDict):
@@ -11016,7 +11321,7 @@ class OrgsOrgInvitationsPostBodyType(TypedDict):
 
     invitee_id: NotRequired[int]
     email: NotRequired[str]
-    role: NotRequired[Literal["admin", "direct_member", "billing_manager"]]
+    role: NotRequired[Literal["admin", "direct_member", "billing_manager", "reinstate"]]
     team_ids: NotRequired[List[int]]
 
 
@@ -11045,6 +11350,29 @@ class OrgsOrgMigrationsPostBodyType(TypedDict):
     exclude_owner_projects: NotRequired[bool]
     org_metadata_only: NotRequired[bool]
     exclude: NotRequired[List[Literal["repositories"]]]
+
+
+class OrgsOrgOrganizationRolesGetResponse200Type(TypedDict):
+    """OrgsOrgOrganizationRolesGetResponse200"""
+
+    total_count: NotRequired[int]
+    roles: NotRequired[List[OrganizationRoleType]]
+
+
+class OrgsOrgOrganizationRolesPostBodyType(TypedDict):
+    """OrgsOrgOrganizationRolesPostBody"""
+
+    name: str
+    description: NotRequired[str]
+    permissions: List[str]
+
+
+class OrgsOrgOrganizationRolesRoleIdPatchBodyType(TypedDict):
+    """OrgsOrgOrganizationRolesRoleIdPatchBody"""
+
+    name: NotRequired[str]
+    description: NotRequired[str]
+    permissions: NotRequired[List[str]]
 
 
 class OrgsOrgOutsideCollaboratorsUsernamePutBodyType(TypedDict):
@@ -11099,6 +11427,29 @@ class OrgsOrgProjectsPostBodyType(TypedDict):
     body: NotRequired[str]
 
 
+class OrgsOrgPropertiesSchemaPatchBodyType(TypedDict):
+    """OrgsOrgPropertiesSchemaPatchBody"""
+
+    properties: List[OrgCustomPropertyType]
+
+
+class OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType(TypedDict):
+    """OrgsOrgPropertiesSchemaCustomPropertyNamePutBody"""
+
+    value_type: Literal["string", "single_select"]
+    required: NotRequired[bool]
+    default_value: NotRequired[Union[str, None]]
+    description: NotRequired[Union[str, None]]
+    allowed_values: NotRequired[Union[List[str], None]]
+
+
+class OrgsOrgPropertiesValuesPatchBodyType(TypedDict):
+    """OrgsOrgPropertiesValuesPatchBody"""
+
+    repository_names: List[str]
+    properties: List[CustomPropertyValueType]
+
+
 class OrgsOrgReposPostBodyType(TypedDict):
     """OrgsOrgReposPostBody"""
 
@@ -11128,6 +11479,15 @@ class OrgsOrgReposPostBodyType(TypedDict):
     ]
     merge_commit_title: NotRequired[Literal["PR_TITLE", "MERGE_MESSAGE"]]
     merge_commit_message: NotRequired[Literal["PR_BODY", "PR_TITLE", "BLANK"]]
+    custom_properties: NotRequired[OrgsOrgReposPostBodyPropCustomPropertiesType]
+
+
+class OrgsOrgReposPostBodyPropCustomPropertiesType(TypedDict):
+    """OrgsOrgReposPostBodyPropCustomProperties
+
+    The custom properties for the new repository. The keys are the custom property
+    names, and the values are the corresponding custom property values.
+    """
 
 
 class OrgsOrgRulesetsPostBodyType(TypedDict):
@@ -11157,6 +11517,7 @@ class OrgsOrgRulesetsPostBodyType(TypedDict):
                 RepositoryRuleCommitterEmailPatternType,
                 RepositoryRuleBranchNamePatternType,
                 RepositoryRuleTagNamePatternType,
+                RepositoryRuleWorkflowsType,
             ]
         ]
     ]
@@ -11189,6 +11550,7 @@ class OrgsOrgRulesetsRulesetIdPutBodyType(TypedDict):
                 RepositoryRuleCommitterEmailPatternType,
                 RepositoryRuleBranchNamePatternType,
                 RepositoryRuleTagNamePatternType,
+                RepositoryRuleWorkflowsType,
             ]
         ]
     ]
@@ -12650,6 +13012,7 @@ class ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType(TypedDict):
     """ReposOwnerRepoEnvironmentsEnvironmentNamePutBody"""
 
     wait_timer: NotRequired[int]
+    prevent_self_review: NotRequired[bool]
     reviewers: NotRequired[
         Union[
             List[
@@ -13496,6 +13859,7 @@ class ReposOwnerRepoRulesetsPostBodyType(TypedDict):
                 RepositoryRuleCommitterEmailPatternType,
                 RepositoryRuleBranchNamePatternType,
                 RepositoryRuleTagNamePatternType,
+                RepositoryRuleWorkflowsType,
             ]
         ]
     ]
@@ -13526,6 +13890,7 @@ class ReposOwnerRepoRulesetsRulesetIdPutBodyType(TypedDict):
                 RepositoryRuleCommitterEmailPatternType,
                 RepositoryRuleBranchNamePatternType,
                 RepositoryRuleTagNamePatternType,
+                RepositoryRuleWorkflowsType,
             ]
         ]
     ]
@@ -14160,7 +14525,7 @@ __all__ = [
     "OrganizationActionsSecretType",
     "ActionsPublicKeyType",
     "OrganizationActionsVariableType",
-    "CodeScanningAlertRuleType",
+    "CodeScanningAlertRuleSummaryType",
     "CodeScanningAnalysisToolType",
     "CodeScanningAlertLocationType",
     "CodeScanningAlertInstanceType",
@@ -14191,6 +14556,8 @@ __all__ = [
     "OrgMembershipType",
     "OrgMembershipPropPermissionsType",
     "MigrationType",
+    "OrganizationFineGrainedPermissionType",
+    "OrganizationRoleType",
     "PackageVersionType",
     "PackageVersionPropMetadataType",
     "PackageVersionPropMetadataPropContainerType",
@@ -14206,6 +14573,12 @@ __all__ = [
     "OrganizationProgrammaticAccessGrantPropPermissionsPropRepositoryType",
     "OrganizationProgrammaticAccessGrantPropPermissionsPropOtherType",
     "ProjectType",
+    "OrgCustomPropertyType",
+    "CustomPropertyValueType",
+    "OrgRepoCustomPropertyValuesType",
+    "CodeOfConductSimpleType",
+    "FullRepositoryType",
+    "FullRepositoryPropPermissionsType",
     "RepositoryRulesetBypassActorType",
     "RepositoryRulesetConditionsType",
     "RepositoryRulesetConditionsPropRefNameType",
@@ -14239,10 +14612,17 @@ __all__ = [
     "RepositoryRuleBranchNamePatternPropParametersType",
     "RepositoryRuleTagNamePatternType",
     "RepositoryRuleTagNamePatternPropParametersType",
+    "RepositoryRuleParamsWorkflowFileReferenceType",
+    "RepositoryRuleWorkflowsType",
+    "RepositoryRuleWorkflowsPropParametersType",
     "RepositoryRulesetType",
     "RepositoryRulesetPropLinksType",
     "RepositoryRulesetPropLinksPropSelfType",
     "RepositoryRulesetPropLinksPropHtmlType",
+    "RuleSuitesItemsType",
+    "RuleSuiteType",
+    "RuleSuitePropRuleEvaluationsItemsType",
+    "RuleSuitePropRuleEvaluationsItemsPropRuleSourceType",
     "RepositoryAdvisoryVulnerabilityType",
     "RepositoryAdvisoryVulnerabilityPropPackageType",
     "RepositoryAdvisoryCreditType",
@@ -14273,9 +14653,6 @@ __all__ = [
     "RateLimitType",
     "RateLimitOverviewType",
     "RateLimitOverviewPropResourcesType",
-    "CodeOfConductSimpleType",
-    "FullRepositoryType",
-    "FullRepositoryPropPermissionsType",
     "ArtifactType",
     "ArtifactPropWorkflowRunType",
     "ActionsCacheListType",
@@ -14380,8 +14757,8 @@ __all__ = [
     "CheckSuitePreferenceType",
     "CheckSuitePreferencePropPreferencesType",
     "CheckSuitePreferencePropPreferencesPropAutoTriggerChecksItemsType",
-    "CodeScanningAlertRuleSummaryType",
     "CodeScanningAlertItemsType",
+    "CodeScanningAlertRuleType",
     "CodeScanningAlertType",
     "CodeScanningAnalysisType",
     "CodeScanningAnalysisDeletionType",
@@ -14393,6 +14770,7 @@ __all__ = [
     "CodeScanningSarifsStatusType",
     "CodeownersErrorsType",
     "CodeownersErrorsPropErrorsItemsType",
+    "CodespacesPermissionsCheckForDevcontainerType",
     "RepoCodespacesSecretType",
     "CollaboratorType",
     "CollaboratorPropPermissionsType",
@@ -14464,6 +14842,7 @@ __all__ = [
     "EnvironmentPropProtectionRulesItemsAnyof1PropReviewersItemsType",
     "EnvironmentPropProtectionRulesItemsAnyof2Type",
     "DeploymentBranchPolicyType",
+    "DeploymentBranchPolicyNamePatternWithTypeType",
     "DeploymentBranchPolicyNamePatternType",
     "CustomDeploymentRuleAppType",
     "DeploymentProtectionRuleType",
@@ -14599,11 +14978,20 @@ __all__ = [
     "RepositoryRuleDetailedOneof11Type",
     "RepositoryRuleDetailedOneof12Type",
     "RepositoryRuleDetailedOneof13Type",
+    "RepositoryRuleDetailedOneof14Type",
     "SecretScanningAlertType",
     "SecretScanningLocationCommitType",
     "SecretScanningLocationIssueTitleType",
     "SecretScanningLocationIssueBodyType",
     "SecretScanningLocationIssueCommentType",
+    "SecretScanningLocationDiscussionTitleType",
+    "SecretScanningLocationDiscussionBodyType",
+    "SecretScanningLocationDiscussionCommentType",
+    "SecretScanningLocationPullRequestTitleType",
+    "SecretScanningLocationPullRequestBodyType",
+    "SecretScanningLocationPullRequestCommentType",
+    "SecretScanningLocationPullRequestReviewType",
+    "SecretScanningLocationPullRequestReviewCommentType",
     "SecretScanningLocationType",
     "RepositoryAdvisoryCreateType",
     "RepositoryAdvisoryCreatePropVulnerabilitiesItemsType",
@@ -14678,6 +15066,7 @@ __all__ = [
     "OrganizationSimpleWebhooksType",
     "RepositoryWebhooksType",
     "RepositoryWebhooksPropPermissionsType",
+    "RepositoryWebhooksPropCustomPropertiesType",
     "RepositoryWebhooksPropTemplateRepositoryPropOwnerType",
     "RepositoryWebhooksPropTemplateRepositoryPropPermissionsType",
     "RepositoryWebhooksPropTemplateRepositoryType",
@@ -14787,6 +15176,9 @@ __all__ = [
     "OrgsOrgMembersUsernameCodespacesGetResponse200Type",
     "OrgsOrgMembershipsUsernamePutBodyType",
     "OrgsOrgMigrationsPostBodyType",
+    "OrgsOrgOrganizationRolesGetResponse200Type",
+    "OrgsOrgOrganizationRolesPostBodyType",
+    "OrgsOrgOrganizationRolesRoleIdPatchBodyType",
     "OrgsOrgOutsideCollaboratorsUsernamePutBodyType",
     "OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type",
     "OrgsOrgOutsideCollaboratorsUsernameDeleteResponse422Type",
@@ -14795,7 +15187,11 @@ __all__ = [
     "OrgsOrgPersonalAccessTokensPostBodyType",
     "OrgsOrgPersonalAccessTokensPatIdPostBodyType",
     "OrgsOrgProjectsPostBodyType",
+    "OrgsOrgPropertiesSchemaPatchBodyType",
+    "OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType",
+    "OrgsOrgPropertiesValuesPatchBodyType",
     "OrgsOrgReposPostBodyType",
+    "OrgsOrgReposPostBodyPropCustomPropertiesType",
     "OrgsOrgRulesetsPostBodyType",
     "OrgsOrgRulesetsRulesetIdPutBodyType",
     "OrgsOrgTeamsPostBodyType",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,12 +223,12 @@ output_dir = "githubkit/rest/"
   "null",
 ] }
 
-# copilot-seat-details/assignee is not valid
-"/components/schemas/copilot-seat-details/properties/assignee" = { enum = "<unset>", oneOf = [
-  { "$ref" = "#/components/schemas/simple-user" },
-  { "$ref" = "#/components/schemas/team" },
-  { "$ref" = "#/components/schemas/organization" },
-] }
+# [FIXED] copilot-seat-details/assignee is not valid
+# "/components/schemas/copilot-seat-details/properties/assignee" = { enum = "<unset>", oneOf = [
+#   { "$ref" = "#/components/schemas/simple-user" },
+#   { "$ref" = "#/components/schemas/team" },
+#   { "$ref" = "#/components/schemas/organization" },
+# ] }
 
 [tool.codegen.webhook]
 schema_source = "https://unpkg.com/@octokit/webhooks-schemas/schema.json"


### PR DESCRIPTION
While parsing OpenAPI spec for 2022-11-28:

```
  codegen/parser/utils.py", line 105, in merge_dict
    del old[key]
        ~~~^^^^^
  KeyError: 'enum'
```

Signed-off-by: Joao Eduardo Luis \<joao@1e3ms.io>

P.S.: This was hit while running `python -m codegen` on the current master branch (620e08f26274c6fd51339078c4fbfd29c80e702f), which was surprising. I'm not ruling out this might be a problem with my environment, but I suspect this might be a corner case somewhere with the schema.