### PR TITLE
Fix: project v2 item field change type may be labels

### DIFF
--- a/githubkit/webhooks/models.py
+++ b/githubkit/webhooks/models.py
@@ -9862,7 +9862,7 @@ class ProjectsV2ItemEditedPropChangesPropFieldValue(GitHubWebhookModel):
     """ProjectsV2ItemEditedPropChangesPropFieldValue"""
 
     field_type: Literal[
-        "single-select", "date", "number", "text", "iteration", "labels"
+        "single_select", "date", "number", "text", "iteration", "labels"
     ] = Field(default=...)
     field_node_id: str = Field(default=...)
 

--- a/githubkit/webhooks/models.py
+++ b/githubkit/webhooks/models.py
@@ -9861,9 +9861,9 @@ class ProjectsV2ItemEditedPropChanges(GitHubWebhookModel):
 class ProjectsV2ItemEditedPropChangesPropFieldValue(GitHubWebhookModel):
     """ProjectsV2ItemEditedPropChangesPropFieldValue"""
 
-    field_type: Literal["single_select", "date", "number", "text", "iteration"] = Field(
-        default=...
-    )
+    field_type: Literal[
+        "single-select", "date", "number", "text", "iteration", "labels"
+    ] = Field(default=...)
     field_node_id: str = Field(default=...)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,8 +264,8 @@ types_output = "githubkit/webhooks/types.py"
 # [FIXED] https://github.com/octokit/webhooks/issues/806
 # "/definitions/secret_scanning_alert$resolved/properties/alert/allOf/1/properties/resolution" = { enum = ["false_positive", "wont_fix", "revoked", "used_in_tests"] }
 
-# project v2 item edit event can contain labels
-"/definitions/projects_v2_item$edited/properties/changes/properties/field_value/properties/field_type" = { enum = [ "single-select", "date", "number", "text", "iteration", "labels" ] }
+# https://github.com/yanyongyu/githubkit/pull/69
+"/definitions/projects_v2_item$edited/properties/changes/properties/field_value/properties/field_type" = { enum = [ "single_select", "date", "number", "text", "iteration", "labels" ] }
 
 [tool.codegen.field_overrides]
 "+1" = "plus_one"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,9 @@ types_output = "githubkit/webhooks/types.py"
 # [FIXED] https://github.com/octokit/webhooks/issues/806
 # "/definitions/secret_scanning_alert$resolved/properties/alert/allOf/1/properties/resolution" = { enum = ["false_positive", "wont_fix", "revoked", "used_in_tests"] }
 
+# project v2 item edit event can contain labels
+"/definitions/projects_v2_item$edited/properties/changes/properties/field_value/properties/field_type" = { enum = [ "single-select", "date", "number", "text", "iteration", "labels" ] }
+
 [tool.codegen.field_overrides]
 "+1" = "plus_one"
 "-1" = "minus_one"


### PR DESCRIPTION
According to the webhook events we're getting sent by github, the changed field_type can be "labels" as well, but this doesn't seem to be covered by the octokit schema.

As an example, take the following snippet:

```
"action": "edited",
    "projects_v2_item": {
      "id": 12345,
      "node_id": "PVTI_ASDASD",
      "project_node_id": "PVT_ASDASD",
      "content_node_id": "I_ASDASD",
      "content_type": "Issue",
      "creator": {
        "login": "jecluis",
        [...]
      },
      "created_at": "2023-12-18T06:44:23Z",
      "updated_at": "2023-12-18T16:21:38Z",
      "archived_at": null
    },
    "changes": {
      "field_value": {
        "field_node_id": "PVTF_ASDASD",
        "field_type": "labels"
      }
    },
```

Signed-off-by: Joao Eduardo Luis \<joao@1e3ms.io>