### PR TITLE
Bug: fix cache and cycle ref issue

### DIFF
--- a/codegen/templates/rest/__init__.py.jinja
+++ b/codegen/templates/rest/__init__.py.jinja
@@ -2,6 +2,7 @@
 
 """{{ header() }}"""
 
+from weakref import ref
 from typing import TYPE_CHECKING
 from functools import cached_property
 
@@ -14,7 +15,16 @@ if TYPE_CHECKING:
 
 class RestNamespace:
     def __init__(self, github: "GitHubCore"):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> "GitHubCore":
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this namespace after the client has been collected."
+        )
 
     {% for tag in tags %}
     @cached_property

--- a/codegen/templates/rest/client.py.jinja
+++ b/codegen/templates/rest/client.py.jinja
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -56,7 +57,16 @@ class {{ pascal_case(tag) }}Client:
     _REST_API_VERSION = "{{ rest_api_version }}"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     {% for endpoint in endpoints %}
     {% if endpoint.request_body and endpoint.request_body.allowed_models %}

--- a/codegen/templates/versions/rest.py.jinja
+++ b/codegen/templates/versions/rest.py.jinja
@@ -3,6 +3,7 @@
 """{{ header() }}"""
 
 import importlib
+from weakref import WeakKeyDictionary, ref
 from typing import TYPE_CHECKING, Any, Dict, Literal, overload
 
 from . import VERSIONS, LATEST_VERSION, VERSION_TYPE
@@ -22,7 +23,7 @@ else:
     _VersionProxy = object
 
 class RestVersionSwitcher(_VersionProxy):
-    _cached_namespaces: Dict[VERSION_TYPE, Any] = {}
+    _cached_namespaces: WeakKeyDictionary["GitHubCore", Dict[VERSION_TYPE, Any]] = WeakKeyDictionary()
 
     if not TYPE_CHECKING:
         def __getattr__(self, name: str) -> Any:
@@ -34,7 +35,16 @@ class RestVersionSwitcher(_VersionProxy):
             return getattr(namespace, name)
 
     def __init__(self, github: "GitHubCore"):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> "GitHubCore":
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use the namespace after the client has been collected."
+        )
 
     {% for version, module in versions.items() %}
     @overload
@@ -47,9 +57,11 @@ class RestVersionSwitcher(_VersionProxy):
         ...
 
     def __call__(self, version: VERSION_TYPE = LATEST_VERSION) -> Any:
-        if version in self._cached_namespaces:
-            return self._cached_namespaces[version]
+        g = self._github
+        cache = self._cached_namespaces.setdefault(g, {})
+        if version in cache:
+            return cache[version]
         module = importlib.import_module(f".{VERSIONS[version]}.rest", __package__)
-        namespace = module.RestNamespace(self._github)
-        self._cached_namespaces[version] = namespace
+        namespace = module.RestNamespace(g)
+        cache[version] = namespace
         return namespace

--- a/codegen/templates/versions/rest.py.jinja
+++ b/codegen/templates/versions/rest.py.jinja
@@ -23,7 +23,7 @@ else:
     _VersionProxy = object
 
 class RestVersionSwitcher(_VersionProxy):
-    _cached_namespaces: WeakKeyDictionary["GitHubCore", Dict[VERSION_TYPE, Any]] = WeakKeyDictionary()
+    _cached_namespaces: "WeakKeyDictionary[GitHubCore, Dict[VERSION_TYPE, Any]]" = WeakKeyDictionary()
 
     if not TYPE_CHECKING:
         def __getattr__(self, name: str) -> Any:

--- a/githubkit/versions/rest.py
+++ b/githubkit/versions/rest.py
@@ -28,9 +28,9 @@ else:
 
 
 class RestVersionSwitcher(_VersionProxy):
-    _cached_namespaces: WeakKeyDictionary[
-        "GitHubCore", Dict[VERSION_TYPE, Any]
-    ] = WeakKeyDictionary()
+    _cached_namespaces: "WeakKeyDictionary[GitHubCore, Dict[VERSION_TYPE, Any]]" = (
+        WeakKeyDictionary()
+    )
 
     if not TYPE_CHECKING:
 

--- a/githubkit/versions/rest.py
+++ b/githubkit/versions/rest.py
@@ -8,6 +8,7 @@ See https://github.com/github/rest-api-description for more information.
 """
 
 import importlib
+from weakref import WeakKeyDictionary, ref
 from typing import TYPE_CHECKING, Any, Dict, Literal, overload
 
 from . import VERSIONS, VERSION_TYPE, LATEST_VERSION
@@ -27,7 +28,9 @@ else:
 
 
 class RestVersionSwitcher(_VersionProxy):
-    _cached_namespaces: Dict[VERSION_TYPE, Any] = {}
+    _cached_namespaces: WeakKeyDictionary[
+        "GitHubCore", Dict[VERSION_TYPE, Any]
+    ] = WeakKeyDictionary()
 
     if not TYPE_CHECKING:
 
@@ -40,7 +43,16 @@ class RestVersionSwitcher(_VersionProxy):
             return getattr(namespace, name)
 
     def __init__(self, github: "GitHubCore"):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> "GitHubCore":
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use the namespace after the client has been collected."
+        )
 
     @overload
     def __call__(self, version: Literal["2022-11-28"]) -> "V20221128RestNamespace":
@@ -51,9 +63,11 @@ class RestVersionSwitcher(_VersionProxy):
         ...
 
     def __call__(self, version: VERSION_TYPE = LATEST_VERSION) -> Any:
-        if version in self._cached_namespaces:
-            return self._cached_namespaces[version]
+        g = self._github
+        cache = self._cached_namespaces.setdefault(g, {})
+        if version in cache:
+            return cache[version]
         module = importlib.import_module(f".{VERSIONS[version]}.rest", __package__)
-        namespace = module.RestNamespace(self._github)
-        self._cached_namespaces[version] = namespace
+        namespace = module.RestNamespace(g)
+        cache[version] = namespace
         return namespace

--- a/githubkit/versions/v2022_11_28/rest/__init__.py
+++ b/githubkit/versions/v2022_11_28/rest/__init__.py
@@ -7,6 +7,7 @@ python -m codegen && isort . && black .
 See https://github.com/github/rest-api-description for more information.
 """
 
+from weakref import ref
 from typing import TYPE_CHECKING
 from functools import cached_property
 
@@ -52,7 +53,16 @@ if TYPE_CHECKING:
 
 class RestNamespace:
     def __init__(self, github: "GitHubCore"):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> "GitHubCore":
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this namespace after the client has been collected."
+        )
 
     @cached_property
     def meta(self) -> "MetaClient":

--- a/githubkit/versions/v2022_11_28/rest/actions.py
+++ b/githubkit/versions/v2022_11_28/rest/actions.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -121,7 +122,16 @@ class ActionsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_actions_cache_usage_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/activity.py
+++ b/githubkit/versions/v2022_11_28/rest/activity.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -54,7 +55,16 @@ class ActivityClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_public_events(
         self,

--- a/githubkit/versions/v2022_11_28/rest/apps.py
+++ b/githubkit/versions/v2022_11_28/rest/apps.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -62,7 +63,16 @@ class AppsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_authenticated(
         self,

--- a/githubkit/versions/v2022_11_28/rest/billing.py
+++ b/githubkit/versions/v2022_11_28/rest/billing.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -30,7 +31,16 @@ class BillingClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_github_actions_billing_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/checks.py
+++ b/githubkit/versions/v2022_11_28/rest/checks.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -57,7 +58,16 @@ class ChecksClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     @overload
     def create(

--- a/githubkit/versions/v2022_11_28/rest/classroom.py
+++ b/githubkit/versions/v2022_11_28/rest/classroom.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -41,7 +42,16 @@ class ClassroomClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_an_assignment(
         self,

--- a/githubkit/versions/v2022_11_28/rest/code_scanning.py
+++ b/githubkit/versions/v2022_11_28/rest/code_scanning.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -52,7 +53,16 @@ class CodeScanningClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_alerts_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/codes_of_conduct.py
+++ b/githubkit/versions/v2022_11_28/rest/codes_of_conduct.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -32,7 +33,16 @@ class CodesOfConductClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_all_codes_of_conduct(
         self,

--- a/githubkit/versions/v2022_11_28/rest/codespaces.py
+++ b/githubkit/versions/v2022_11_28/rest/codespaces.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -76,7 +77,16 @@ class CodespacesClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_in_organization(
         self,

--- a/githubkit/versions/v2022_11_28/rest/copilot.py
+++ b/githubkit/versions/v2022_11_28/rest/copilot.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -48,7 +49,16 @@ class CopilotClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_copilot_organization_details(
         self,

--- a/githubkit/versions/v2022_11_28/rest/dependabot.py
+++ b/githubkit/versions/v2022_11_28/rest/dependabot.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -50,7 +51,16 @@ class DependabotClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_alerts_for_enterprise(
         self,

--- a/githubkit/versions/v2022_11_28/rest/dependency_graph.py
+++ b/githubkit/versions/v2022_11_28/rest/dependency_graph.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -46,7 +47,16 @@ class DependencyGraphClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def diff_range(
         self,

--- a/githubkit/versions/v2022_11_28/rest/emojis.py
+++ b/githubkit/versions/v2022_11_28/rest/emojis.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -30,7 +31,16 @@ class EmojisClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get(
         self,

--- a/githubkit/versions/v2022_11_28/rest/gists.py
+++ b/githubkit/versions/v2022_11_28/rest/gists.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -43,7 +44,16 @@ class GistsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list(
         self,

--- a/githubkit/versions/v2022_11_28/rest/git.py
+++ b/githubkit/versions/v2022_11_28/rest/git.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -46,7 +47,16 @@ class GitClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     @overload
     def create_blob(

--- a/githubkit/versions/v2022_11_28/rest/gitignore.py
+++ b/githubkit/versions/v2022_11_28/rest/gitignore.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -32,7 +33,16 @@ class GitignoreClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_all_templates(
         self,

--- a/githubkit/versions/v2022_11_28/rest/interactions.py
+++ b/githubkit/versions/v2022_11_28/rest/interactions.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -40,7 +41,16 @@ class InteractionsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_restrictions_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/issues.py
+++ b/githubkit/versions/v2022_11_28/rest/issues.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -89,7 +90,16 @@ class IssuesClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list(
         self,

--- a/githubkit/versions/v2022_11_28/rest/licenses.py
+++ b/githubkit/versions/v2022_11_28/rest/licenses.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -34,7 +35,16 @@ class LicensesClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_all_commonly_used(
         self,

--- a/githubkit/versions/v2022_11_28/rest/markdown.py
+++ b/githubkit/versions/v2022_11_28/rest/markdown.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -34,7 +35,16 @@ class MarkdownClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     @overload
     def render(

--- a/githubkit/versions/v2022_11_28/rest/meta.py
+++ b/githubkit/versions/v2022_11_28/rest/meta.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -35,7 +36,16 @@ class MetaClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def root(
         self,

--- a/githubkit/versions/v2022_11_28/rest/migrations.py
+++ b/githubkit/versions/v2022_11_28/rest/migrations.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -48,7 +49,16 @@ class MigrationsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/oidc.py
+++ b/githubkit/versions/v2022_11_28/rest/oidc.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -33,7 +34,16 @@ class OidcClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_oidc_custom_sub_template_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/orgs.py
+++ b/githubkit/versions/v2022_11_28/rest/orgs.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -82,7 +83,16 @@ class OrgsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list(
         self,

--- a/githubkit/versions/v2022_11_28/rest/packages.py
+++ b/githubkit/versions/v2022_11_28/rest/packages.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -34,7 +35,16 @@ class PackagesClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_docker_migration_conflicting_packages_for_organization(
         self,

--- a/githubkit/versions/v2022_11_28/rest/projects.py
+++ b/githubkit/versions/v2022_11_28/rest/projects.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -56,7 +57,16 @@ class ProjectsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/pulls.py
+++ b/githubkit/versions/v2022_11_28/rest/pulls.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -63,7 +64,16 @@ class PullsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list(
         self,

--- a/githubkit/versions/v2022_11_28/rest/rate_limit.py
+++ b/githubkit/versions/v2022_11_28/rest/rate_limit.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -30,7 +31,16 @@ class RateLimitClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get(
         self,

--- a/githubkit/versions/v2022_11_28/rest/reactions.py
+++ b/githubkit/versions/v2022_11_28/rest/reactions.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -45,7 +46,16 @@ class ReactionsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_for_team_discussion_comment_in_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/repos.py
+++ b/githubkit/versions/v2022_11_28/rest/repos.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -227,7 +228,16 @@ class ReposClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_for_org(
         self,

--- a/githubkit/versions/v2022_11_28/rest/search.py
+++ b/githubkit/versions/v2022_11_28/rest/search.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -42,7 +43,16 @@ class SearchClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def code(
         self,

--- a/githubkit/versions/v2022_11_28/rest/secret_scanning.py
+++ b/githubkit/versions/v2022_11_28/rest/secret_scanning.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -39,7 +40,16 @@ class SecretScanningClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_alerts_for_enterprise(
         self,

--- a/githubkit/versions/v2022_11_28/rest/security_advisories.py
+++ b/githubkit/versions/v2022_11_28/rest/security_advisories.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -49,7 +50,16 @@ class SecurityAdvisoriesClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list_global_advisories(
         self,

--- a/githubkit/versions/v2022_11_28/rest/teams.py
+++ b/githubkit/versions/v2022_11_28/rest/teams.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -64,7 +65,16 @@ class TeamsClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def list(
         self,

--- a/githubkit/versions/v2022_11_28/rest/users.py
+++ b/githubkit/versions/v2022_11_28/rest/users.py
@@ -10,6 +10,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from weakref import ref
 from typing_extensions import Annotated
 from typing import TYPE_CHECKING, Dict, Literal, Optional, overload
 
@@ -56,7 +57,16 @@ class UsersClient:
     _REST_API_VERSION = "2022-11-28"
 
     def __init__(self, github: GitHubCore):
-        self._github = github
+        self._github_ref = ref(github)
+
+    @property
+    def _github(self) -> GitHubCore:
+        if g := self._github_ref():
+            return g
+        raise RuntimeError(
+            "GitHub client has already been collected. "
+            "Do not use this client after the client has been collected."
+        )
 
     def get_authenticated(
         self,

--- a/tests/test_rest/test_cache.py
+++ b/tests/test_rest/test_cache.py
@@ -1,0 +1,10 @@
+from githubkit import GitHub
+from githubkit.versions import LATEST_VERSION
+
+
+def test_cache(g: GitHub):
+    assert g.rest(LATEST_VERSION) is g.rest(LATEST_VERSION)
+    assert g.rest(LATEST_VERSION).repos is g.rest(LATEST_VERSION).repos
+
+    assert g.rest is g.rest
+    assert g.rest.repos is g.rest.repos


### PR DESCRIPTION
Use weakref to avoid cycle ref. This can improve the `gc` collection. Instance can be collected immediately after var release now.

Also fix #79 . Cache now depends on github instance weakref.