### PR TITLE
Feature: auto retry when rate limit exceeded or server error encountered

### DIFF
--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, List, Union, Optional
 
 import httpx
 
+from .typing import RetryHandler
+
 
 @dataclass(frozen=True)
 class Config:
@@ -13,8 +15,7 @@ class Config:
     follow_redirects: bool
     timeout: httpx.Timeout
     http_cache: bool
-    max_nr_concurrent_requests: int
-    max_nr_rate_limit_retry_attempts: int
+    auto_retry: Union[bool, RetryHandler]
 
     def dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -69,8 +70,7 @@ def get_config(
     follow_redirects: bool = True,
     timeout: Optional[Union[float, httpx.Timeout]] = None,
     http_cache: bool = True,
-    max_nr_concurrent_requests: int = 100,
-    max_nr_rate_limit_retry_attempts: int = 3,
+    auto_retry: Union[bool, RetryHandler] = True,
 ) -> Config:
     return Config(
         build_base_url(base_url),
@@ -79,6 +79,5 @@ def get_config(
         follow_redirects,
         build_timeout(timeout),
         http_cache,
-        max_nr_concurrent_requests,
-        max_nr_rate_limit_retry_attempts,
+        auto_retry,
     )

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -13,6 +13,8 @@ class Config:
     follow_redirects: bool
     timeout: httpx.Timeout
     http_cache: bool
+    max_nr_concurrent_requests: int
+    max_nr_rate_limit_retry_attempts: int
 
     def dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -67,6 +69,8 @@ def get_config(
     follow_redirects: bool = True,
     timeout: Optional[Union[float, httpx.Timeout]] = None,
     http_cache: bool = True,
+    max_nr_concurrent_requests: int = 100,
+    max_nr_rate_limit_retry_attempts: int = 3,
 ) -> Config:
     return Config(
         build_base_url(base_url),
@@ -75,4 +79,6 @@ def get_config(
         follow_redirects,
         build_timeout(timeout),
         http_cache,
+        max_nr_concurrent_requests,
+        max_nr_rate_limit_retry_attempts
     )

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -80,5 +80,5 @@ def get_config(
         build_timeout(timeout),
         http_cache,
         max_nr_concurrent_requests,
-        max_nr_rate_limit_retry_attempts
+        max_nr_rate_limit_retry_attempts,
     )

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -1,3 +1,4 @@
+import logging
 from types import TracebackType
 from contextvars import ContextVar
 from asyncio import Event, BoundedSemaphore, sleep
@@ -478,21 +479,19 @@ class GitHubCore(Generic[A]):
                 if retry_attempt_nr > self.config.max_nr_rate_limit_retry_attempts:
                     raise error
 
-                # start_time = datetime.now()
-                # rate_limit_duration = error.retry_after
+                start_time = datetime.now()
+                rate_limit_duration = error.retry_after
 
-                # print(f"retry request for {url} after {rate_limit_duration} seconds.")
-                # print(
-                #     f"Started rate limit timer  at {start_time} for
-                #     {rate_limit_duration} seconds."
-                # )
+                logging.info(f"Encountered a rate limit for request for {url}.")
+                logging.info(
+                    f"Starting rate limit at {start_time}; not sending new request for {rate_limit_duration} seconds."
+                )
                 self.rate_limit_free.clear()
                 await sleep(error.retry_after.seconds)
                 self.rate_limit_free.set()
-                # print(
-                #     f"rate limit that started at {start_time} stopped
-                #     at {datetime.now()}"
-                # )
+                logging.info(
+                    f"Rate limit that started at {start_time} is stopped at {datetime.now()}."
+                )
 
                 return await self.arequest(
                     method,

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -160,13 +160,15 @@ class GitHubCore(Generic[A]):
             timeout,
             http_cache,
             max_nr_concurrent_requests,
-            max_nr_rate_limit_retry_attempts
+            max_nr_rate_limit_retry_attempts,
         )
 
         self.rate_limit_free = Event()
         self.rate_limit_free.set()
 
-        self.concurrent_request_semaphore = BoundedSemaphore(self.config.max_nr_concurrent_requests)
+        self.concurrent_request_semaphore = BoundedSemaphore(
+            self.config.max_nr_concurrent_requests
+        )
 
         self.__sync_client: ContextVar[Optional[httpx.Client]] = ContextVar(
             "sync_client", default=None

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -478,8 +478,8 @@ class GitHubCore(Generic[A]):
                 if retry_attempt_nr > self.config.max_nr_rate_limit_retry_attempts:
                     raise error
 
-                start_time = datetime.now()
-                rate_limit_duration = error.retry_after
+                # start_time = datetime.now()
+                # rate_limit_duration = error.retry_after
 
                 # print(f"retry request for {url} after {rate_limit_duration} seconds.")
                 # print(

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -2,8 +2,8 @@ import logging
 from time import sleep
 from types import TracebackType
 from contextvars import ContextVar
-from asyncio import Event, BoundedSemaphore
 from asyncio import sleep as asleep
+from asyncio import Event, BoundedSemaphore
 from datetime import datetime, timezone, timedelta
 from contextlib import contextmanager, asynccontextmanager
 from typing import (
@@ -450,8 +450,10 @@ class GitHubCore(Generic[A]):
 
             start_time = datetime.now()
             rate_limit_duration = error.retry_after
-            logging.warning(f"Encountered a rate limit for request for {url} at {start_time}; "
-                         f"not sending new request for {rate_limit_duration} seconds.")
+            logging.warning(
+                f"Encountered a rate limit for request for {url} at {start_time}; "
+                f"not sending new request for {rate_limit_duration} seconds."
+            )
 
             sleep(error.retry_after.seconds)
 
@@ -467,7 +469,7 @@ class GitHubCore(Generic[A]):
                 cookies=cookies,
                 response_model=response_model,
                 error_models=error_models,
-                retry_attempt_nr=retry_attempt_nr + 1
+                retry_attempt_nr=retry_attempt_nr + 1,
             )
 
     # async request and check

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -1,6 +1,6 @@
-from asyncio import Event, BoundedSemaphore, sleep
 from types import TracebackType
 from contextvars import ContextVar
+from asyncio import Event, BoundedSemaphore, sleep
 from datetime import datetime, timezone, timedelta
 from contextlib import contextmanager, asynccontextmanager
 from typing import (
@@ -34,10 +34,10 @@ from .typing import (
     QueryParamTypes,
 )
 from .exception import (
-    RateLimitExceeded,
     RequestError,
     RequestFailed,
     RequestTimeout,
+    RateLimitExceeded,
     PrimaryRateLimitExceeded,
     SecondaryRateLimitExceeded,
 )
@@ -471,11 +471,15 @@ class GitHubCore(Generic[A]):
                 rate_limit_duration = error.retry_after
 
                 # print(f"retry request for {url} after {rate_limit_duration} seconds.")
-                print(f"Started rate limit timer  at {start_time} for {rate_limit_duration} seconds.")
+                print(
+                    f"Started rate limit timer  at {start_time} for {rate_limit_duration} seconds."
+                )
                 self.rate_limit_free.clear()
                 await sleep(error.retry_after.seconds)
                 self.rate_limit_free.set()
-                print(f"rate limit that started at {start_time} stopped at {datetime.now()}")
+                print(
+                    f"rate limit that started at {start_time} stopped at {datetime.now()}"
+                )
 
                 return await self.arequest(
                     method,

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -450,7 +450,7 @@ class GitHubCore(Generic[A]):
 
             start_time = datetime.now()
             rate_limit_duration = error.retry_after
-            logging.info(f"Encountered a rate limit for request for {url} at {start_time}; "
+            logging.warning(f"Encountered a rate limit for request for {url} at {start_time}; "
                          f"not sending new request for {rate_limit_duration} seconds.")
 
             sleep(error.retry_after.seconds)
@@ -512,14 +512,14 @@ class GitHubCore(Generic[A]):
                 start_time = datetime.now()
                 rate_limit_duration = error.retry_after
 
-                logging.info(f"Encountered a rate limit for request for {url}.")
-                logging.info(
+                logging.warning(f"Encountered a rate limit for request for {url}.")
+                logging.warning(
                     f"Starting rate limit at {start_time}; not sending new request for {rate_limit_duration} seconds."
                 )
                 self.rate_limit_free.clear()
                 await asleep(error.retry_after.seconds)
                 self.rate_limit_free.set()
-                logging.info(
+                logging.warning(
                     f"Rate limit that started at {start_time} is stopped at {datetime.now()}."
                 )
 

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -16,8 +16,8 @@ from typing import (
 from .core import GitHubCore
 from .response import Response
 from .paginator import Paginator
-from .typing import RetryHandler
 from .auth import BaseAuthStrategy
+from .typing import RetryDecisionFunc
 from .versions import RestVersionSwitcher, WebhooksVersionSwitcher
 from .graphql import GraphQLResponse, build_graphql_request, parse_graphql_response
 
@@ -86,7 +86,7 @@ class GitHub(GitHubCore[A]):
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             http_cache: bool = True,
-            auto_retry: Union[bool, RetryHandler] = True,
+            auto_retry: Union[bool, RetryDecisionFunc] = True,
         ):
             ...
 
@@ -103,7 +103,7 @@ class GitHub(GitHubCore[A]):
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             http_cache: bool = True,
-            auto_retry: Union[bool, RetryHandler] = True,
+            auto_retry: Union[bool, RetryDecisionFunc] = True,
         ):
             ...
 
@@ -120,7 +120,7 @@ class GitHub(GitHubCore[A]):
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             http_cache: bool = True,
-            auto_retry: Union[bool, RetryHandler] = True,
+            auto_retry: Union[bool, RetryDecisionFunc] = True,
         ):
             ...
 

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -16,6 +16,7 @@ from typing import (
 from .core import GitHubCore
 from .response import Response
 from .paginator import Paginator
+from .typing import RetryHandler
 from .auth import BaseAuthStrategy
 from .versions import RestVersionSwitcher, WebhooksVersionSwitcher
 from .graphql import GraphQLResponse, build_graphql_request, parse_graphql_response
@@ -85,6 +86,7 @@ class GitHub(GitHubCore[A]):
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             http_cache: bool = True,
+            auto_retry: Union[bool, RetryHandler] = True,
         ):
             ...
 
@@ -101,6 +103,7 @@ class GitHub(GitHubCore[A]):
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             http_cache: bool = True,
+            auto_retry: Union[bool, RetryHandler] = True,
         ):
             ...
 
@@ -117,6 +120,7 @@ class GitHub(GitHubCore[A]):
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             http_cache: bool = True,
+            auto_retry: Union[bool, RetryHandler] = True,
         ):
             ...
 

--- a/githubkit/log.py
+++ b/githubkit/log.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("githubkit")

--- a/githubkit/retry.py
+++ b/githubkit/retry.py
@@ -1,0 +1,74 @@
+from datetime import timedelta
+
+from .log import logger
+from .typing import RetryOption as RetryOption
+from .typing import RetryDecisionFunc as RetryDecisionFunc
+from .exception import RequestFailed, GitHubException, RateLimitExceeded
+
+
+class RetryRateLimit:
+    __slots__ = ("max_retry_count",)
+
+    def __init__(self, max_retry_count: int = 1) -> None:
+        self.max_retry_count = max_retry_count
+
+    def __call__(self, exc: GitHubException, retry_count: int) -> RetryOption:
+        # retry once for rate limit exceeded
+        # https://github.com/octokit/octokit.js/blob/450c662e4f29b63a6dbe7592ba5ef53d5fa01d88/src/octokit.ts#L34-L65
+        if retry_count < self.max_retry_count and isinstance(exc, RateLimitExceeded):
+            logger.warning(
+                f"{exc.__class__.__name__} for request "
+                f"{exc.request.method} {exc.request.url}",
+                exc_info=exc,
+            )
+            return RetryOption(True, exc.retry_after)
+
+        return RetryOption(False)
+
+
+RETRY_RATE_LIMIT = RetryRateLimit()
+
+
+class RetryServerError:
+    __slots__ = ("max_retry_count",)
+
+    def __init__(self, max_retry_count: int = 3) -> None:
+        self.max_retry_count = max_retry_count
+
+    def __call__(self, exc: GitHubException, retry_count: int) -> RetryOption:
+        # retry three times for server error
+        # https://github.com/octokit/plugin-retry.js/blob/3b9897a58d8b2c37cfba6a8df78e4619d346098a/src/error-request.ts#L11-L14
+        if (
+            retry_count < self.max_retry_count
+            and isinstance(exc, RequestFailed)
+            and exc.response.status_code >= 500
+        ):
+            logger.warning(
+                f"Server error encountered for request "
+                f"{exc.request.method} {exc.request.url}",
+                exc_info=exc,
+            )
+            return RetryOption(True, timedelta(seconds=(retry_count + 1) ** 2))
+
+        return RetryOption(False)
+
+
+RETRY_SERVER_ERROR = RetryServerError()
+
+
+class RetryChainDecision:
+    __slots__ = ("decision_funcs",)
+
+    def __init__(self, *decision_funcs: RetryDecisionFunc) -> None:
+        self.decision_funcs = decision_funcs
+
+    def __call__(self, exc: GitHubException, retry_count: int) -> RetryOption:
+        for decision_func in self.decision_funcs:
+            retry_option = decision_func(exc, retry_count)
+            if retry_option.do_retry:
+                return retry_option
+
+        return RetryOption(False)
+
+
+RETRY_DEFAULT = RetryChainDecision(RETRY_RATE_LIMIT, RETRY_SERVER_ERROR)

--- a/githubkit/retry.py
+++ b/githubkit/retry.py
@@ -7,15 +7,15 @@ from .exception import RequestFailed, GitHubException, RateLimitExceeded
 
 
 class RetryRateLimit:
-    __slots__ = ("max_retry_count",)
+    __slots__ = ("max_retry",)
 
-    def __init__(self, max_retry_count: int = 1) -> None:
-        self.max_retry_count = max_retry_count
+    def __init__(self, max_retry: int = 1) -> None:
+        self.max_retry = max_retry
 
     def __call__(self, exc: GitHubException, retry_count: int) -> RetryOption:
         # retry once for rate limit exceeded
         # https://github.com/octokit/octokit.js/blob/450c662e4f29b63a6dbe7592ba5ef53d5fa01d88/src/octokit.ts#L34-L65
-        if retry_count < self.max_retry_count and isinstance(exc, RateLimitExceeded):
+        if retry_count < self.max_retry and isinstance(exc, RateLimitExceeded):
             logger.warning(
                 f"{exc.__class__.__name__} for request "
                 f"{exc.request.method} {exc.request.url}",
@@ -30,16 +30,16 @@ RETRY_RATE_LIMIT = RetryRateLimit()
 
 
 class RetryServerError:
-    __slots__ = ("max_retry_count",)
+    __slots__ = ("max_retry",)
 
-    def __init__(self, max_retry_count: int = 3) -> None:
-        self.max_retry_count = max_retry_count
+    def __init__(self, max_retry: int = 3) -> None:
+        self.max_retry = max_retry
 
     def __call__(self, exc: GitHubException, retry_count: int) -> RetryOption:
         # retry three times for server error
         # https://github.com/octokit/plugin-retry.js/blob/3b9897a58d8b2c37cfba6a8df78e4619d346098a/src/error-request.ts#L11-L14
         if (
-            retry_count < self.max_retry_count
+            retry_count < self.max_retry
             and isinstance(exc, RequestFailed)
             and exc.response.status_code >= 500
         ):

--- a/githubkit/typing.py
+++ b/githubkit/typing.py
@@ -1,11 +1,25 @@
+from datetime import timedelta
 from typing_extensions import Annotated, TypeAlias
-from typing import IO, Dict, List, Tuple, Union, Literal, TypeVar, Hashable, Optional
+from typing import (
+    IO,
+    Dict,
+    List,
+    Tuple,
+    Union,
+    Literal,
+    TypeVar,
+    Callable,
+    Hashable,
+    Optional,
+    NamedTuple,
+)
 
 import httpx
 from pydantic import Field
 
 from .utils import UNSET
 from .compat import PYDANTIC_V2
+from .exception import GitHubException
 
 T = TypeVar("T")
 H = TypeVar("H", bound=Hashable)
@@ -65,3 +79,11 @@ else:  # pragma: pydantic-v1
 # if the property is not required, we allow it to have the value null.
 # See https://github.com/yanyongyu/githubkit/issues/47
 Missing: TypeAlias = Union[Literal[UNSET], T, None]
+
+
+class RetryOption(NamedTuple):
+    do_retry: bool
+    retry_after: Optional[timedelta] = None
+
+
+RetryHandler: TypeAlias = Callable[[GitHubException, int], RetryOption]

--- a/githubkit/typing.py
+++ b/githubkit/typing.py
@@ -86,4 +86,4 @@ class RetryOption(NamedTuple):
     retry_after: Optional[timedelta] = None
 
 
-RetryHandler: TypeAlias = Callable[[GitHubException, int], RetryOption]
+RetryDecisionFunc: TypeAlias = Callable[[GitHubException, int], RetryOption]


### PR DESCRIPTION
This PR introduces a mechanism that limits the number of concurrent requests.
Additionally, if a `RateLimitExceeded` response is encountered, new requests are not started for a while.
I'm not sure if halting the new requests is really needed, but it seems the right thing to do.

The print statements are there currently for seeing that the mechanism works.
Should they be replace with a logger? or removed entirely?

Related to #66