### PR TITLE
Add Sanity-Check to `TokenAuth.auth_flow`

### DIFF
--- a/githubkit/auth/token.py
+++ b/githubkit/auth/token.py
@@ -21,7 +21,10 @@ class TokenAuth(httpx.Auth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        request.headers["Authorization"] = f"token {self.token}"
+        if self.token.lower().startswith(("token", "bearer):
+            request.headers["Authorization"] = self.token
+        else:
+            request.headers["Authorization"] = f"token {self.token}"
         yield request
 
 

--- a/githubkit/auth/token.py
+++ b/githubkit/auth/token.py
@@ -21,7 +21,7 @@ class TokenAuth(httpx.Auth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        if self.token.lower().startswith(("token", "bearer):
+        if self.token.lower().startswith(("token", "bearer"):
             request.headers["Authorization"] = self.token
         else:
             request.headers["Authorization"] = f"token {self.token}"

--- a/githubkit/auth/token.py
+++ b/githubkit/auth/token.py
@@ -21,7 +21,7 @@ class TokenAuth(httpx.Auth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        if self.token.lower().startswith(("token", "bearer"):
+        if self.token.lower().startswith(("token", "bearer")):
             request.headers["Authorization"] = self.token
         else:
             request.headers["Authorization"] = f"token {self.token}"


### PR DESCRIPTION
Hi,

I've been playing around with this nice lib a bit and had issues getting it to work with token authentication.
After a bit of debugging I found out that the issue was that I had already added a "bearer" in front of my token. After removing it, everthing worked as expected. I suggest that the lib checks if a prexif is already present before adding it.

Best
Hinrich