### PR TITLE
Fix: Tolerate any string values in github app events array schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,6 +358,8 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
   "repository",
   "sender",
 ] }
+# webhook check suite completed events can be any strings
+"/components/schemas/webhook-check-suite-completed/properties/check_suite/properties/app/properties/events/items" = { enum = "<unset>" }
 # webhook deployment protection rule action is required
 "/components/schemas/webhook-deployment-protection-rule-requested" = { required = [
   "action",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,8 +358,34 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
   "repository",
   "sender",
 ] }
-# webhook check suite completed events can be any strings
+
+# webhook github app events enum schema is not always up to date
+# https://github.com/github/rest-api-description/issues/3775
+"/components/schemas/webhooks_issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhooks_issue_2/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
 "/components/schemas/webhook-check-suite-completed/properties/check_suite/properties/app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-check-suite-requested/properties/check_suite/properties/app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-check-suite-rerequested/properties/check_suite/properties/app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-deployment-created/properties/deployment/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-deployment-status-created/properties/deployment/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-deployment-status-created/properties/deployment_status/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issue-comment-created/properties/issue/allOf/0/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issue-comment-deleted/properties/issue/allOf/0/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issue-comment-edited/properties/issue/allOf/0/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-closed/properties/issue/allOf/0/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-deleted/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-demilestoned/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-edited/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-labeled/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-locked/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-milestoned/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-opened/properties/changes/properties/old_issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-opened/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-reopened/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-transferred/properties/changes/properties/new_issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-issues-unlocked/properties/issue/properties/performed_via_github_app/properties/events/items" = { enum = "<unset>" }
+"/components/schemas/webhook-meta-deleted/properties/hook/properties/events/items" = { enum = "<unset>" }
+
 # webhook deployment protection rule action is required
 "/components/schemas/webhook-deployment-protection-rule-requested" = { required = [
   "action",


### PR DESCRIPTION
GitHub generates `check_suite` webhook events with `check_suite.app.events` containing illegal event names. I filed this upstream at https://github.com/github/rest-api-description/issues/3775.

E.g., I'm seeing events like:

```json
{
  "check_suite": {
    ...
    "app": {
      ...
      "events": [
        "branch_protection_configuration",  // <-- Oops!
        "branch_protection_rule",
        "check_run",
        "check_suite",
        "issue_comment",
        "member",
        "membership",
        "merge_group",
        "organization",
        "pull_request",
        "pull_request_review",
        "pull_request_review_comment",
        "pull_request_review_thread",
        "push",
        "repository",
        "repository_ruleset",  // <-- Oops!
        "status",
        "team",
        "team_add",
        "workflow_job",
        "workflow_run"
      ]
    },
    ...
```

I believe the best course of action would be for GitHubKit to not validate the `check_suite.app.events` array element values.

Is this an appropriate change?

BTW, is it possible to disable validation in webhook event parsing? My presumption is that as long as the GitHub signature on the event checks out, then the event is trustworthy. Currently my GitHub application is unable to process critical events because GitHub started including these unspecified values in this kinda-unimportant field, and I would really like to go back to processing these events.