### PR TITLE
Feature: allow parsing webhook with event name of type str

### DIFF
--- a/codegen/templates/webhooks/_namespace.py.jinja
+++ b/codegen/templates/webhooks/_namespace.py.jinja
@@ -61,8 +61,13 @@ class WebhookNamespace:
     def parse(name: EventNameType, payload: Union[str, bytes]) -> "WebhookEvent":
         ...
 
+    @overload
     @staticmethod
-    def parse(name: EventNameType, payload: Union[str, bytes]) -> "WebhookEvent":
+    def parse(name: str, payload: Union[str, bytes]) -> "WebhookEvent":
+        ...
+
+    @staticmethod
+    def parse(name: Union[EventNameType, str], payload: Union[str, bytes]) -> "WebhookEvent":
         """Parse the webhook payload with event name.
 
         Args:
@@ -105,8 +110,13 @@ class WebhookNamespace:
     def parse_obj(name: EventNameType, payload: Dict[str, Any]) -> "WebhookEvent":
         ...
 
+    @overload
     @staticmethod
-    def parse_obj(name: EventNameType, payload: Dict[str, Any]) -> "WebhookEvent":
+    def parse_obj(name: str, payload: Dict[str, Any]) -> "WebhookEvent":
+        ...
+
+    @staticmethod
+    def parse_obj(name: Union[EventNameType, str], payload: Dict[str, Any]) -> "WebhookEvent":
         """Parse the webhook payload dict with event name.
 
         Args:

--- a/githubkit/versions/ghec_v2022_11_28/webhooks/_namespace.py
+++ b/githubkit/versions/ghec_v2022_11_28/webhooks/_namespace.py
@@ -616,8 +616,14 @@ class WebhookNamespace:
     @staticmethod
     def parse(name: EventNameType, payload: Union[str, bytes]) -> "WebhookEvent": ...
 
+    @overload
     @staticmethod
-    def parse(name: EventNameType, payload: Union[str, bytes]) -> "WebhookEvent":
+    def parse(name: str, payload: Union[str, bytes]) -> "WebhookEvent": ...
+
+    @staticmethod
+    def parse(
+        name: Union[EventNameType, str], payload: Union[str, bytes]
+    ) -> "WebhookEvent":
         """Parse the webhook payload with event name.
 
         Args:
@@ -1007,8 +1013,14 @@ class WebhookNamespace:
     @staticmethod
     def parse_obj(name: EventNameType, payload: Dict[str, Any]) -> "WebhookEvent": ...
 
+    @overload
     @staticmethod
-    def parse_obj(name: EventNameType, payload: Dict[str, Any]) -> "WebhookEvent":
+    def parse_obj(name: str, payload: Dict[str, Any]) -> "WebhookEvent": ...
+
+    @staticmethod
+    def parse_obj(
+        name: Union[EventNameType, str], payload: Dict[str, Any]
+    ) -> "WebhookEvent":
         """Parse the webhook payload dict with event name.
 
         Args:

--- a/githubkit/versions/v2022_11_28/webhooks/_namespace.py
+++ b/githubkit/versions/v2022_11_28/webhooks/_namespace.py
@@ -600,8 +600,14 @@ class WebhookNamespace:
     @staticmethod
     def parse(name: EventNameType, payload: Union[str, bytes]) -> "WebhookEvent": ...
 
+    @overload
     @staticmethod
-    def parse(name: EventNameType, payload: Union[str, bytes]) -> "WebhookEvent":
+    def parse(name: str, payload: Union[str, bytes]) -> "WebhookEvent": ...
+
+    @staticmethod
+    def parse(
+        name: Union[EventNameType, str], payload: Union[str, bytes]
+    ) -> "WebhookEvent":
         """Parse the webhook payload with event name.
 
         Args:
@@ -981,8 +987,14 @@ class WebhookNamespace:
     @staticmethod
     def parse_obj(name: EventNameType, payload: Dict[str, Any]) -> "WebhookEvent": ...
 
+    @overload
     @staticmethod
-    def parse_obj(name: EventNameType, payload: Dict[str, Any]) -> "WebhookEvent":
+    def parse_obj(name: str, payload: Dict[str, Any]) -> "WebhookEvent": ...
+
+    @staticmethod
+    def parse_obj(
+        name: Union[EventNameType, str], payload: Dict[str, Any]
+    ) -> "WebhookEvent":
         """Parse the webhook payload dict with event name.
 
         Args:


### PR DESCRIPTION
When calling the `parse` functions for webhooks, we don't always control where the `name` parameter comes from.
In my case, I retrieve it from a HTTP request's header and the type is simply `str`:

```python
name: str = headers['X-GitHub-Event']
event = parse(name, b"")
```

And pyright complains with the following:
`error: Type of "event" is unknown (reportUnknownVariableType)`
`error: No overloads for "parse" match the provided arguments (reportCallIssue)`

However, since `parse` and `parse_obj` check for `name` to be part of `VALID_EVENT_NAMES` it looks safe to me to allow for plain `str` to be passed.

Let me know what you think.