### PR TITLE
Fix: model list schema constraints error when using Pydantic V1

### DIFF
--- a/codegen/parser/schemas/schema.py
+++ b/codegen/parser/schemas/schema.py
@@ -399,7 +399,7 @@ class ListSchema(SchemaData):
     def _get_field_args(self) -> dict[str, str]:
         args = super()._get_field_args()
         # pydantic v1 uses min_items/max_items list constraints
-        # but this will cause error when using forwardref 
+        # but this will cause error when using forwardref
         # See https://github.com/samuelcolvin/pydantic/issues/3745
         # So remove constraints when using pydantic v1
         if self.max_length is not None:

--- a/codegen/parser/schemas/schema.py
+++ b/codegen/parser/schemas/schema.py
@@ -403,11 +403,11 @@ class ListSchema(SchemaData):
         # See https://github.com/samuelcolvin/pydantic/issues/3745
         # So remove constraints when using pydantic v1
         if self.max_length is not None:
-            # args["max_items"] = repr(self.max_length) + " if not PYDANTIC_V2 else None"
-            args["max_length"] = repr(self.max_length) + " if PYDANTIC_V2 else None"
+            # args["max_items"] = f"{self.max_length!r} if not PYDANTIC_V2 else None"
+            args["max_length"] = f"{self.max_length!r} if PYDANTIC_V2 else None"
         if self.min_length is not None:
-            # args["min_items"] = repr(self.min_length) + " if not PYDANTIC_V2 else None"
-            args["min_length"] = repr(self.min_length) + " if PYDANTIC_V2 else None"
+            # args["min_items"] = f"{self.min_length!r} if not PYDANTIC_V2 else None"
+            args["min_length"] = f"{self.min_length!r} if PYDANTIC_V2 else None"
         return args
 
     @override
@@ -473,11 +473,11 @@ class UniqueListSchema(SchemaData):
         # See https://github.com/samuelcolvin/pydantic/issues/3745
         # So remove constraints when using pydantic v1
         if self.max_length is not None:
-            # args["max_items"] = repr(self.max_length) + " if not PYDANTIC_V2 else None"
-            args["max_length"] = repr(self.max_length) + " if PYDANTIC_V2 else None"
+            # args["max_items"] = f"{self.max_length!r} if not PYDANTIC_V2 else None"
+            args["max_length"] = f"{self.max_length!r} if PYDANTIC_V2 else None"
         if self.min_length is not None:
-            # args["min_items"] = repr(self.min_length) + " if not PYDANTIC_V2 else None"
-            args["min_length"] = repr(self.min_length) + " if PYDANTIC_V2 else None"
+            # args["min_items"] = f"{self.min_length!r} if not PYDANTIC_V2 else None"
+            args["min_length"] = f"{self.min_length!r} if PYDANTIC_V2 else None"
         return args
 
     @override

--- a/codegen/parser/schemas/schema.py
+++ b/codegen/parser/schemas/schema.py
@@ -377,44 +377,36 @@ class ListSchema(SchemaData):
     @override
     def get_type_imports(self) -> set[str]:
         imports = super().get_type_imports()
-        imports = {
-            "from typing import List",
-            "from githubkit.compat import PYDANTIC_V2",
-        }
+        imports.add("from typing import List")
         imports.update(self.item_schema.get_type_imports())
         return imports
 
     @override
     def get_param_imports(self) -> set[str]:
         imports = super().get_param_imports()
-        imports = {
-            "from typing import List",
-            "from githubkit.compat import PYDANTIC_V2",
-        }
+        imports.add("from typing import List")
         imports.update(self.item_schema.get_param_imports())
         return imports
 
     @override
     def get_using_imports(self) -> set[str]:
         imports = super().get_using_imports()
-        imports = {
-            "from typing import List",
-            "from githubkit.compat import PYDANTIC_V2",
-        }
+        imports.add("from typing import List")
         imports.update(self.item_schema.get_using_imports())
         return imports
 
     @override
     def _get_field_args(self) -> dict[str, str]:
         args = super()._get_field_args()
-        # [FIXED] in pydantic v2:
-        # remove list constraints due to forwardref not supported
+        # pydantic v1 uses min_items/max_items list constraints
+        # but this will cause error when using forwardref 
         # See https://github.com/samuelcolvin/pydantic/issues/3745
-        # if isinstance(self.item_schema, ModelSchema | UnionSchema):
-        #     return args
+        # So remove constraints when using pydantic v1
         if self.max_length is not None:
+            # args["max_items"] = repr(self.max_length) + " if not PYDANTIC_V2 else None"
             args["max_length"] = repr(self.max_length) + " if PYDANTIC_V2 else None"
         if self.min_length is not None:
+            # args["min_items"] = repr(self.min_length) + " if not PYDANTIC_V2 else None"
             args["min_length"] = repr(self.min_length) + " if PYDANTIC_V2 else None"
         return args
 
@@ -455,44 +447,36 @@ class UniqueListSchema(SchemaData):
     @override
     def get_type_imports(self) -> set[str]:
         imports = super().get_type_imports()
-        imports = {
-            "from githubkit.typing import UniqueList",
-            "from githubkit.compat import PYDANTIC_V2",
-        }
+        imports.add("from typing import List")
         imports.update(self.item_schema.get_type_imports())
         return imports
 
     @override
     def get_param_imports(self) -> set[str]:
         imports = super().get_param_imports()
-        imports = {
-            "from githubkit.typing import UniqueList",
-            "from githubkit.compat import PYDANTIC_V2",
-        }
+        imports.add("from typing import List")
         imports.update(self.item_schema.get_param_imports())
         return imports
 
     @override
     def get_using_imports(self) -> set[str]:
         imports = super().get_using_imports()
-        imports = {
-            "from githubkit.typing import UniqueList",
-            "from githubkit.compat import PYDANTIC_V2",
-        }
+        imports.add("from typing import List")
         imports.update(self.item_schema.get_using_imports())
         return imports
 
     @override
     def _get_field_args(self) -> dict[str, str]:
         args = super()._get_field_args()
-        # [FIXED] in pydantic v2:
-        # remove list constraints due to forwardref not supported
+        # pydantic v1 uses min_items/max_items list constraints
+        # but this will cause error when using forwardref
         # See https://github.com/samuelcolvin/pydantic/issues/3745
-        # if isinstance(self.item_schema, ModelSchema | UnionSchema):
-        #     return args
+        # So remove constraints when using pydantic v1
         if self.max_length is not None:
+            # args["max_items"] = repr(self.max_length) + " if not PYDANTIC_V2 else None"
             args["max_length"] = repr(self.max_length) + " if PYDANTIC_V2 else None"
         if self.min_length is not None:
+            # args["min_items"] = repr(self.min_length) + " if not PYDANTIC_V2 else None"
             args["min_length"] = repr(self.min_length) + " if PYDANTIC_V2 else None"
         return args
 

--- a/codegen/parser/schemas/schema.py
+++ b/codegen/parser/schemas/schema.py
@@ -446,22 +446,22 @@ class UniqueListSchema(SchemaData):
 
     @override
     def get_type_imports(self) -> set[str]:
-        imports = super().get_type_imports()
-        imports.add("from typing import List")
+        # imports = super().get_type_imports()
+        imports = {"from githubkit.typing import UniqueList"}
         imports.update(self.item_schema.get_type_imports())
         return imports
 
     @override
     def get_param_imports(self) -> set[str]:
-        imports = super().get_param_imports()
-        imports.add("from typing import List")
+        # imports = super().get_param_imports()
+        imports = {"from githubkit.typing import UniqueList"}
         imports.update(self.item_schema.get_param_imports())
         return imports
 
     @override
     def get_using_imports(self) -> set[str]:
-        imports = super().get_using_imports()
-        imports.add("from typing import List")
+        # imports = super().get_using_imports()
+        imports = {"from githubkit.typing import UniqueList"}
         imports.update(self.item_schema.get_using_imports())
         return imports
 

--- a/codegen/parser/schemas/schema.py
+++ b/codegen/parser/schemas/schema.py
@@ -370,27 +370,37 @@ class ListSchema(SchemaData):
     def get_model_imports(self) -> set[str]:
         imports = super().get_model_imports()
         imports.add("from typing import List")
+        imports.add("from githubkit.compat import PYDANTIC_V2")
         imports.update(self.item_schema.get_model_imports())
         return imports
 
     @override
     def get_type_imports(self) -> set[str]:
         imports = super().get_type_imports()
-        imports = {"from typing import List"}
+        imports = {
+            "from typing import List",
+            "from githubkit.compat import PYDANTIC_V2",
+        }
         imports.update(self.item_schema.get_type_imports())
         return imports
 
     @override
     def get_param_imports(self) -> set[str]:
         imports = super().get_param_imports()
-        imports = {"from typing import List"}
+        imports = {
+            "from typing import List",
+            "from githubkit.compat import PYDANTIC_V2",
+        }
         imports.update(self.item_schema.get_param_imports())
         return imports
 
     @override
     def get_using_imports(self) -> set[str]:
         imports = super().get_using_imports()
-        imports = {"from typing import List"}
+        imports = {
+            "from typing import List",
+            "from githubkit.compat import PYDANTIC_V2",
+        }
         imports.update(self.item_schema.get_using_imports())
         return imports
 
@@ -403,9 +413,9 @@ class ListSchema(SchemaData):
         # if isinstance(self.item_schema, ModelSchema | UnionSchema):
         #     return args
         if self.max_length is not None:
-            args["max_length"] = repr(self.max_length)
+            args["max_length"] = repr(self.max_length) + " if PYDANTIC_V2 else None"
         if self.min_length is not None:
-            args["min_length"] = repr(self.min_length)
+            args["min_length"] = repr(self.min_length) + " if PYDANTIC_V2 else None"
         return args
 
     @override
@@ -438,27 +448,37 @@ class UniqueListSchema(SchemaData):
     def get_model_imports(self) -> set[str]:
         imports = super().get_model_imports()
         imports.add("from githubkit.typing import UniqueList")
+        imports.add("from githubkit.compat import PYDANTIC_V2")
         imports.update(self.item_schema.get_model_imports())
         return imports
 
     @override
     def get_type_imports(self) -> set[str]:
         imports = super().get_type_imports()
-        imports = {"from githubkit.typing import UniqueList"}
+        imports = {
+            "from githubkit.typing import UniqueList",
+            "from githubkit.compat import PYDANTIC_V2",
+        }
         imports.update(self.item_schema.get_type_imports())
         return imports
 
     @override
     def get_param_imports(self) -> set[str]:
         imports = super().get_param_imports()
-        imports = {"from githubkit.typing import UniqueList"}
+        imports = {
+            "from githubkit.typing import UniqueList",
+            "from githubkit.compat import PYDANTIC_V2",
+        }
         imports.update(self.item_schema.get_param_imports())
         return imports
 
     @override
     def get_using_imports(self) -> set[str]:
         imports = super().get_using_imports()
-        imports = {"from githubkit.typing import UniqueList"}
+        imports = {
+            "from githubkit.typing import UniqueList",
+            "from githubkit.compat import PYDANTIC_V2",
+        }
         imports.update(self.item_schema.get_using_imports())
         return imports
 
@@ -471,9 +491,9 @@ class UniqueListSchema(SchemaData):
         # if isinstance(self.item_schema, ModelSchema | UnionSchema):
         #     return args
         if self.max_length is not None:
-            args["max_length"] = repr(self.max_length)
+            args["max_length"] = repr(self.max_length) + " if PYDANTIC_V2 else None"
         if self.min_length is not None:
-            args["min_length"] = repr(self.min_length)
+            args["min_length"] = repr(self.min_length) + " if PYDANTIC_V2 else None"
         return args
 
     @override


### PR DESCRIPTION
## What's being fixed 

As a user of Pydantic V1, there are some models that use constraints on Pydantic List fields that fail on import:

```
ValueError: On field "annotations" the following field constraints are set but not enforced: max_length. 
For more details see https://docs.pydantic.dev/usage/schema/#unenforced-field-constraints
```

## Reproduction steps

On the root of the project, with the venv populated and activated:

```
$ pip install "pydantic<2"

$ python
> import githubkit.versions.v2022_11_28.models.group_0932

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/juan/Documentos/OpenSource/githubkit/githubkit/versions/v2022_11_28/models/group_0932.py", line 21, in <module>
    class ReposOwnerRepoCheckRunsPostBodyPropOutput(GitHubModel):
  File "pydantic/main.py", line 197, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 502, in pydantic.fields.ModelField.infer
  File "pydantic/schema.py", line 1021, in pydantic.schema.get_annotation_from_field_info
ValueError: On field "annotations" the following field constraints are set but not enforced: max_length. 
For more details see https://docs.pydantic.dev/usage/schema/#unenforced-field-constraints
```

## Solution 
To palliate this issue, a ternary operator might be injected on the Pydantic `Field` constructor to disable or enable the constraints depending on the library version:

```diff
from githubkit.compat import PYDANTIC_V2
annotations: Missing[
        List[ReposOwnerRepoCheckRunsPostBodyPropOutputPropAnnotationsItems]
    ] = Field(
-        max_length=50,
        default=UNSET,
        description='Adds information from your analysis to specific lines of code. Annotations are visible on GitHub in the **Checks** and **Files changed** tab of the pull request. The Checks API limits the number of annotations to a maximum of 50 per API request. To create more than 50 annotations, you have to make multiple requests to the [Update a check run](https://docs.github.com/rest/checks/runs#update-a-check-run) endpoint. Each time you update the check run, annotations are appended to the list of annotations that already exist for the check run. GitHub Actions are limited to 10 warning annotations and 10 error annotations per step. For details about how you can view annotations on GitHub, see "[About status checks](https://docs.github.com/articles/about-status-checks#checks)".',
    )
```

```diff
from githubkit.compat import PYDANTIC_V2
annotations: Missing[
        List[ReposOwnerRepoCheckRunsPostBodyPropOutputPropAnnotationsItems]
    ] = Field(
+        max_length=50 if PYDANTIC_V2 else None,
        default=UNSET,
        description='Adds information from your analysis to specific lines of code. Annotations are visible on GitHub in the **Checks** and **Files changed** tab of the pull request. The Checks API limits the number of annotations to a maximum of 50 per API request. To create more than 50 annotations, you have to make multiple requests to the [Update a check run](https://docs.github.com/rest/checks/runs#update-a-check-run) endpoint. Each time you update the check run, annotations are appended to the list of annotations that already exist for the check run. GitHub Actions are limited to 10 warning annotations and 10 error annotations per step. For details about how you can view annotations on GitHub, see "[About status checks](https://docs.github.com/articles/about-status-checks#checks)".',
    )
```
