### PR TITLE
Fix: diff-entry's blob_url and raw_url may be null

### DIFF
--- a/githubkit/versions/ghec_v2022_11_28/models/group_0213.py
+++ b/githubkit/versions/ghec_v2022_11_28/models/group_0213.py
@@ -9,7 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Union, Literal
 
 from pydantic import Field
 
@@ -32,8 +32,8 @@ class DiffEntry(GitHubModel):
     additions: int = Field()
     deletions: int = Field()
     changes: int = Field()
-    blob_url: str = Field()
-    raw_url: str = Field()
+    blob_url: Union[str, None] = Field()
+    raw_url: Union[str, None] = Field()
     contents_url: str = Field()
     patch: Missing[str] = Field(default=UNSET)
     previous_filename: Missing[str] = Field(default=UNSET)

--- a/githubkit/versions/ghec_v2022_11_28/types/group_0213.py
+++ b/githubkit/versions/ghec_v2022_11_28/types/group_0213.py
@@ -9,7 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Union, Literal
 from typing_extensions import TypedDict, NotRequired
 
 
@@ -27,8 +27,8 @@ class DiffEntryType(TypedDict):
     additions: int
     deletions: int
     changes: int
-    blob_url: str
-    raw_url: str
+    blob_url: Union[str, None]
+    raw_url: Union[str, None]
     contents_url: str
     patch: NotRequired[str]
     previous_filename: NotRequired[str]

--- a/githubkit/versions/v2022_11_28/models/group_0190.py
+++ b/githubkit/versions/v2022_11_28/models/group_0190.py
@@ -9,7 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Union, Literal
 
 from pydantic import Field
 
@@ -32,8 +32,8 @@ class DiffEntry(GitHubModel):
     additions: int = Field()
     deletions: int = Field()
     changes: int = Field()
-    blob_url: str = Field()
-    raw_url: str = Field()
+    blob_url: Union[str, None] = Field()
+    raw_url: Union[str, None] = Field()
     contents_url: str = Field()
     patch: Missing[str] = Field(default=UNSET)
     previous_filename: Missing[str] = Field(default=UNSET)

--- a/githubkit/versions/v2022_11_28/types/group_0190.py
+++ b/githubkit/versions/v2022_11_28/types/group_0190.py
@@ -9,7 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Union, Literal
 from typing_extensions import TypedDict, NotRequired
 
 
@@ -27,8 +27,8 @@ class DiffEntryType(TypedDict):
     additions: int
     deletions: int
     changes: int
-    blob_url: str
-    raw_url: str
+    blob_url: Union[str, None]
+    raw_url: Union[str, None]
     contents_url: str
     patch: NotRequired[str]
     previous_filename: NotRequired[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,8 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
   "null",
 ] }
 
+# https://github.com/yanyongyu/githubkit/pull/134
+# blob_url and raw_url may be null when the diff file is submodule's file
 "/components/schemas/diff-entry/properties/blob_url" = { type = [
   "string",
   "null",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,15 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
   "null",
 ] }
 
+"/components/schemas/diff-entry/properties/blob_url" = { type = [
+  "string",
+  "null",
+] }
+"/components/schemas/diff-entry/properties/raw_url" = { type = [
+  "string",
+  "null",
+] }
+
 # [FIXED] copilot-seat-details/assignee is not valid
 # "/components/schemas/copilot-seat-details/properties/assignee" = { enum = "<unset>", oneOf = [
 #   { "$ref" = "#/components/schemas/simple-user" },


### PR DESCRIPTION
When using `compare_commits`, a `diff-entry` listed in the `files` property might have `blob_url` and `raw_url` set to `null`

I encountered this issue when comparing commits that made a change to a submodule. It might be the only case where those two properties may be null.

### Repro

```python
gh.rest.repos.compare_commits(
    'jqlang',
    'jq',
    '481167c8f186d534b2cef0e8a7d6a4d6dbc45d6b...092fef740a0d1a0ddf61cf9e7af88915071c0705',
).parsed_data
```
:arrow_down: 
```
pydantic_core._pydantic_core.ValidationError: 3 validation errors for CommitComparison
files.literal[<UNSET>]
  Input should be <UNSET> [type=literal_error, input_value=[{'sha': 'cca857c64d3d678... --leak-check=full \\'}], input_type=list]
    For further information visit https://errors.pydantic.dev/2.8/v/literal_error
files.list[DiffEntry].2.blob_url
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.8/v/string_type
files.list[DiffEntry].2.raw_url
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.8/v/string_type
```