### PR TITLE
Feature: add type support for response json

### DIFF
--- a/codegen/templates/rest/_response.py.jinja
+++ b/codegen/templates/rest/_response.py.jinja
@@ -4,6 +4,12 @@
 {%- endif %}
 {% endmacro %}
 
+{% macro build_response_json_type(response) %}
+{% if response and response.response_schema %}
+{{ response.response_schema.get_param_type_string() }}
+{%- endif %}
+{% endmacro %}
+
 {% macro build_error_models(error_responses) %}
 {% for code, response in error_responses.items() %}
 {% if response and response.response_schema %}
@@ -14,7 +20,7 @@
 
 {% macro build_response_type(response) %}
 {% if response and response.response_schema %}
-Response[{{ build_response_model(response) }}]
+Response[{{ build_response_model(response) }}, {{ build_response_json_type(response) }}]
 {%- else %}
 Response
 {%- endif %}

--- a/codegen/templates/rest/client.py.jinja
+++ b/codegen/templates/rest/client.py.jinja
@@ -49,8 +49,13 @@ if TYPE_CHECKING:
     {% for import_ in endpoint.success_response.response_schema.get_using_imports() %}
     {{ import_ }}
     {% endfor %}
+    {# response json types #}
+    {% for import_ in endpoint.success_response.response_schema.get_param_imports() %}
+    {{ import_ }}
+    {% endfor %}
     {% endif %}
     {% endfor %}
+
 
 class {{ pascal_case(tag) }}Client:
     _REST_API_VERSION = "{{ rest_api_version }}"

--- a/envs/pydantic-v1/poetry.lock
+++ b/envs/pydantic-v1/poetry.lock
@@ -308,7 +308,7 @@ hishel = ">=0.0.21, <=0.2.0"
 httpx = ">=0.23.0, <1.0.0"
 pydantic = ">=1.9.1, <3.0.0, !=2.5.0, !=2.5.1"
 PyJWT = {version = "^2.4.0", extras = ["crypto"], optional = true}
-typing-extensions = "^4.3.0"
+typing-extensions = "^4.6.0"
 
 [package.extras]
 all = ["PyJWT[crypto] (>=2.4.0,<3.0.0)", "anyio (>=3.6.1,<5.0.0)"]

--- a/envs/pydantic-v2/poetry.lock
+++ b/envs/pydantic-v2/poetry.lock
@@ -319,7 +319,7 @@ hishel = ">=0.0.21, <=0.2.0"
 httpx = ">=0.23.0, <1.0.0"
 pydantic = ">=1.9.1, <3.0.0, !=2.5.0, !=2.5.1"
 PyJWT = {version = "^2.4.0", extras = ["crypto"], optional = true}
-typing-extensions = "^4.3.0"
+typing-extensions = "^4.6.0"
 
 [package.extras]
 all = ["PyJWT[crypto] (>=2.4.0,<3.0.0)", "anyio (>=3.6.1,<5.0.0)"]

--- a/githubkit/response.py
+++ b/githubkit/response.py
@@ -1,14 +1,16 @@
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
+from typing_extensions import TypeVar
 
 import httpx
 
 from .compat import type_validate_json
 
-RT = TypeVar("RT")
+MT = TypeVar("MT", default=Any)
+JT = TypeVar("JT", default=Any)
 
 
-class Response(Generic[RT]):
-    def __init__(self, response: httpx.Response, data_model: type[RT]):
+class Response(Generic[MT, JT]):
+    def __init__(self, response: httpx.Response, data_model: type[MT]):
         self._response = response
         self._data_model = data_model
 
@@ -55,9 +57,9 @@ class Response(Generic[RT]):
     def text(self) -> str:
         return self._response.text
 
-    def json(self, **kwargs: Any) -> Any:
+    def json(self, **kwargs: Any) -> JT:
         return self._response.json(**kwargs)
 
     @property
-    def parsed_data(self) -> RT:
+    def parsed_data(self) -> MT:
         return type_validate_json(self._data_model, self.content)

--- a/githubkit/versions/ghec_v2022_11_28/rest/actions.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/actions.py
@@ -26,46 +26,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        SelectedActionsType,
-        ReviewCustomGatesStateRequiredType,
-        OrgsOrgActionsVariablesPostBodyType,
-        OrgsOrgActionsPermissionsPutBodyType,
-        ReviewCustomGatesCommentRequiredType,
-        ActionsWorkflowAccessToRepositoryType,
-        OrgsOrgActionsRunnerGroupsPostBodyType,
-        ActionsSetDefaultWorkflowPermissionsType,
-        OrgsOrgActionsVariablesNamePatchBodyType,
-        OrgsOrgActionsSecretsSecretNamePutBodyType,
-        ReposOwnerRepoActionsVariablesPostBodyType,
-        ReposOwnerRepoActionsPermissionsPutBodyType,
-        ActionsOidcCustomIssuerPolicyForEnterpriseType,
-        OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
-        OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
-        ReposOwnerRepoActionsJobsJobIdRerunPostBodyType,
-        ReposOwnerRepoActionsRunsRunIdRerunPostBodyType,
-        ReposOwnerRepoActionsVariablesNamePatchBodyType,
-        OrgsOrgActionsPermissionsRepositoriesPutBodyType,
-        ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
-        OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
-        OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
-        OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-        ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
-        ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
-        OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
-        ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
-        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
-        ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
-        ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType,
-        ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
-        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
-        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
-        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType,
-        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
-        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
-        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType,
-    )
     from ..models import (
         Job,
         Runner,
@@ -123,6 +83,99 @@ if TYPE_CHECKING:
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
     )
+    from ..types import (
+        JobType,
+        RunnerType,
+        ArtifactType,
+        WorkflowType,
+        DeploymentType,
+        EmptyObjectType,
+        WorkflowRunType,
+        ActionsSecretType,
+        WorkflowUsageType,
+        ActionsVariableType,
+        RunnerGroupsOrgType,
+        SelectedActionsType,
+        ActionsCacheListType,
+        ActionsPublicKeyType,
+        WorkflowRunUsageType,
+        OidcCustomSubRepoType,
+        PendingDeploymentType,
+        RunnerApplicationType,
+        AuthenticationTokenType,
+        EnvironmentApprovalsType,
+        OrganizationActionsSecretType,
+        OrganizationActionsVariableType,
+        ActionsRepositoryPermissionsType,
+        ActionsCacheUsageByRepositoryType,
+        ActionsCacheUsageOrgEnterpriseType,
+        ActionsOrganizationPermissionsType,
+        ReviewCustomGatesStateRequiredType,
+        OrgsOrgActionsVariablesPostBodyType,
+        OrgsOrgActionsPermissionsPutBodyType,
+        ReviewCustomGatesCommentRequiredType,
+        ActionsWorkflowAccessToRepositoryType,
+        OrgsOrgActionsRunnerGroupsPostBodyType,
+        OrgsOrgActionsRunnersGetResponse200Type,
+        OrgsOrgActionsSecretsGetResponse200Type,
+        ActionsGetDefaultWorkflowPermissionsType,
+        ActionsSetDefaultWorkflowPermissionsType,
+        OrgsOrgActionsVariablesNamePatchBodyType,
+        OrgsOrgActionsVariablesGetResponse200Type,
+        OrgsOrgActionsSecretsSecretNamePutBodyType,
+        ReposOwnerRepoActionsVariablesPostBodyType,
+        ReposOwnerRepoActionsPermissionsPutBodyType,
+        ReposOwnerRepoActionsRunsGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsGetResponse200Type,
+        ActionsOidcCustomIssuerPolicyForEnterpriseType,
+        OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
+        ReposOwnerRepoActionsRunnersGetResponse200Type,
+        ReposOwnerRepoActionsSecretsGetResponse200Type,
+        OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
+        ReposOwnerRepoActionsJobsJobIdRerunPostBodyType,
+        ReposOwnerRepoActionsRunsRunIdRerunPostBodyType,
+        ReposOwnerRepoActionsVariablesNamePatchBodyType,
+        OrgsOrgActionsPermissionsRepositoriesPutBodyType,
+        ReposOwnerRepoActionsArtifactsGetResponse200Type,
+        ReposOwnerRepoActionsVariablesGetResponse200Type,
+        ReposOwnerRepoActionsWorkflowsGetResponse200Type,
+        ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
+        OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
+        OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
+        ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
+        ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
+        OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
+        ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
+        ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
+        ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType,
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
+        ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType,
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
+    )
 
 
 class ActionsClient:
@@ -145,7 +198,7 @@ class ActionsClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageOrgEnterprise]:
+    ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-enterprise"""
 
         from ..models import ActionsCacheUsageOrgEnterprise
@@ -166,7 +219,7 @@ class ActionsClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageOrgEnterprise]:
+    ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-enterprise"""
 
         from ..models import ActionsCacheUsageOrgEnterprise
@@ -293,7 +346,9 @@ class ActionsClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-an-enterprise"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -314,7 +369,9 @@ class ActionsClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-an-enterprise"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -442,7 +499,8 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     @overload
@@ -457,7 +515,8 @@ class ActionsClient:
         labels: list[str],
         work_folder: Missing[str] = UNSET,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     def generate_runner_jitconfig_for_enterprise(
@@ -469,7 +528,10 @@ class ActionsClient:
             EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-enterprise"""
 
         from ..models import (
@@ -514,7 +576,8 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     @overload
@@ -529,7 +592,8 @@ class ActionsClient:
         labels: list[str],
         work_folder: Missing[str] = UNSET,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     async def async_generate_runner_jitconfig_for_enterprise(
@@ -541,7 +605,10 @@ class ActionsClient:
             EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-enterprise"""
 
         from ..models import (
@@ -583,7 +650,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageOrgEnterprise]:
+    ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
         from ..models import ActionsCacheUsageOrgEnterprise
@@ -604,7 +671,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageOrgEnterprise]:
+    ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
         from ..models import ActionsCacheUsageOrgEnterprise
@@ -627,7 +694,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsCacheUsageByRepositoryGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#list-repositories-with-github-actions-cache-usage-for-an-organization"""
 
         from ..models import OrgsOrgActionsCacheUsageByRepositoryGetResponse200
@@ -656,7 +726,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsCacheUsageByRepositoryGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#list-repositories-with-github-actions-cache-usage-for-an-organization"""
 
         from ..models import OrgsOrgActionsCacheUsageByRepositoryGetResponse200
@@ -683,7 +756,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsOrganizationPermissions]:
+    ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
         from ..models import ActionsOrganizationPermissions
@@ -704,7 +777,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsOrganizationPermissions]:
+    ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
         from ..models import ActionsOrganizationPermissions
@@ -831,7 +904,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsPermissionsRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200,
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization"""
 
         from ..models import OrgsOrgActionsPermissionsRepositoriesGetResponse200
@@ -860,7 +936,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsPermissionsRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200,
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization"""
 
         from ..models import OrgsOrgActionsPermissionsRepositoriesGetResponse200
@@ -1069,7 +1148,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
         from ..models import SelectedActions
@@ -1090,7 +1169,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
         from ..models import SelectedActions
@@ -1217,7 +1296,9 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-an-organization"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -1238,7 +1319,9 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-an-organization"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -1368,7 +1451,10 @@ class ActionsClient:
         visible_to_repository: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsGetResponse200,
+        OrgsOrgActionsRunnerGroupsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnerGroupsGetResponse200
@@ -1399,7 +1485,10 @@ class ActionsClient:
         visible_to_repository: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsGetResponse200,
+        OrgsOrgActionsRunnerGroupsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnerGroupsGetResponse200
@@ -1429,7 +1518,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     def create_self_hosted_runner_group_for_org(
@@ -1445,7 +1534,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     def create_self_hosted_runner_group_for_org(
         self,
@@ -1454,7 +1543,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg, OrgsOrgActionsRunnerGroupsPostBody
@@ -1487,7 +1576,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     async def async_create_self_hosted_runner_group_for_org(
@@ -1503,7 +1592,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     async def async_create_self_hosted_runner_group_for_org(
         self,
@@ -1512,7 +1601,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg, OrgsOrgActionsRunnerGroupsPostBody
@@ -1544,7 +1633,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg
@@ -1566,7 +1655,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg
@@ -1628,7 +1717,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     def update_self_hosted_runner_group_for_org(
@@ -1643,7 +1732,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     def update_self_hosted_runner_group_for_org(
         self,
@@ -1653,7 +1742,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import (
@@ -1692,7 +1781,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     async def async_update_self_hosted_runner_group_for_org(
@@ -1707,7 +1796,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     async def async_update_self_hosted_runner_group_for_org(
         self,
@@ -1717,7 +1806,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import (
@@ -1756,7 +1845,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
         from ..models import (
@@ -1788,7 +1880,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
         from ..models import (
@@ -2016,7 +2111,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-organization"""
 
         from ..models import (
@@ -2048,7 +2146,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-organization"""
 
         from ..models import (
@@ -2276,7 +2377,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnersGetResponse200
@@ -2307,7 +2410,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnersGetResponse200
@@ -2335,7 +2440,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
         from ..models import RunnerApplication
@@ -2356,7 +2461,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
         from ..models import RunnerApplication
@@ -2380,7 +2485,8 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     @overload
@@ -2395,7 +2501,8 @@ class ActionsClient:
         labels: list[str],
         work_folder: Missing[str] = UNSET,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     def generate_runner_jitconfig_for_org(
@@ -2405,7 +2512,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-organization"""
 
         from ..models import (
@@ -2450,7 +2560,8 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     @overload
@@ -2465,7 +2576,8 @@ class ActionsClient:
         labels: list[str],
         work_folder: Missing[str] = UNSET,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     async def async_generate_runner_jitconfig_for_org(
@@ -2475,7 +2587,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-organization"""
 
         from ..models import (
@@ -2517,7 +2632,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2538,7 +2653,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2559,7 +2674,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2580,7 +2695,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2602,7 +2717,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
         from ..models import Runner
@@ -2624,7 +2739,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
         from ..models import Runner
@@ -2684,7 +2799,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2712,7 +2830,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2742,7 +2863,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def set_custom_labels_for_self_hosted_runner_for_org(
@@ -2753,7 +2877,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def set_custom_labels_for_self_hosted_runner_for_org(
         self,
@@ -2763,7 +2890,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2808,7 +2938,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_set_custom_labels_for_self_hosted_runner_for_org(
@@ -2819,7 +2952,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_set_custom_labels_for_self_hosted_runner_for_org(
         self,
@@ -2829,7 +2965,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2874,7 +3013,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def add_custom_labels_to_self_hosted_runner_for_org(
@@ -2885,7 +3027,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def add_custom_labels_to_self_hosted_runner_for_org(
         self,
@@ -2895,7 +3040,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2940,7 +3088,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_add_custom_labels_to_self_hosted_runner_for_org(
@@ -2951,7 +3102,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_add_custom_labels_to_self_hosted_runner_for_org(
         self,
@@ -2961,7 +3115,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -3004,7 +3161,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -3032,7 +3192,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -3061,7 +3224,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -3092,7 +3258,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -3123,7 +3292,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgActionsSecretsGetResponse200
@@ -3152,7 +3323,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgActionsSecretsGetResponse200
@@ -3179,7 +3352,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-public-key"""
 
         from ..models import ActionsPublicKey
@@ -3200,7 +3373,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-public-key"""
 
         from ..models import ActionsPublicKey
@@ -3222,7 +3395,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsSecret]:
+    ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationActionsSecret
@@ -3244,7 +3417,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsSecret]:
+    ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationActionsSecret
@@ -3268,7 +3441,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_org_secret(
@@ -3282,7 +3455,7 @@ class ActionsClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_org_secret(
         self,
@@ -3292,7 +3465,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgActionsSecretsSecretNamePutBody
@@ -3326,7 +3499,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_org_secret(
@@ -3340,7 +3513,7 @@ class ActionsClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_org_secret(
         self,
@@ -3350,7 +3523,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgActionsSecretsSecretNamePutBody
@@ -3422,7 +3595,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200
@@ -3452,7 +3628,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200
@@ -3677,7 +3856,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-organization-variables"""
 
         from ..models import OrgsOrgActionsVariablesGetResponse200
@@ -3706,7 +3887,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-organization-variables"""
 
         from ..models import OrgsOrgActionsVariablesGetResponse200
@@ -3735,7 +3918,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_org_variable(
@@ -3748,7 +3931,7 @@ class ActionsClient:
         value: str,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_org_variable(
         self,
@@ -3757,7 +3940,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#create-an-organization-variable"""
 
         from ..models import EmptyObject, OrgsOrgActionsVariablesPostBody
@@ -3790,7 +3973,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_org_variable(
@@ -3803,7 +3986,7 @@ class ActionsClient:
         value: str,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_org_variable(
         self,
@@ -3812,7 +3995,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#create-an-organization-variable"""
 
         from ..models import EmptyObject, OrgsOrgActionsVariablesPostBody
@@ -3844,7 +4027,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsVariable]:
+    ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-organization-variable"""
 
         from ..models import OrganizationActionsVariable
@@ -3866,7 +4049,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsVariable]:
+    ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-organization-variable"""
 
         from ..models import OrganizationActionsVariable
@@ -4040,7 +4223,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-selected-repositories-for-an-organization-variable"""
 
         from ..models import OrgsOrgActionsVariablesNameRepositoriesGetResponse200
@@ -4071,7 +4257,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-selected-repositories-for-an-organization-variable"""
 
         from ..models import OrgsOrgActionsVariablesNameRepositoriesGetResponse200
@@ -4301,7 +4490,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsArtifactsGetResponse200,
+        ReposOwnerRepoActionsArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#list-artifacts-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsArtifactsGetResponse200
@@ -4333,7 +4525,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsArtifactsGetResponse200,
+        ReposOwnerRepoActionsArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#list-artifacts-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsArtifactsGetResponse200
@@ -4363,7 +4558,7 @@ class ActionsClient:
         artifact_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Artifact]:
+    ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#get-an-artifact"""
 
         from ..models import Artifact
@@ -4386,7 +4581,7 @@ class ActionsClient:
         artifact_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Artifact]:
+    ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#get-an-artifact"""
 
         from ..models import Artifact
@@ -4500,7 +4695,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageByRepository]:
+    ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
         from ..models import ActionsCacheUsageByRepository
@@ -4522,7 +4717,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageByRepository]:
+    ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
         from ..models import ActionsCacheUsageByRepository
@@ -4552,7 +4747,7 @@ class ActionsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
         from ..models import ActionsCacheList
@@ -4592,7 +4787,7 @@ class ActionsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
         from ..models import ActionsCacheList
@@ -4626,7 +4821,7 @@ class ActionsClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
         from ..models import ActionsCacheList
@@ -4656,7 +4851,7 @@ class ActionsClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
         from ..models import ActionsCacheList
@@ -4725,7 +4920,7 @@ class ActionsClient:
         job_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Job]:
+    ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
         from ..models import Job
@@ -4748,7 +4943,7 @@ class ActionsClient:
         job_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Job]:
+    ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
         from ..models import Job
@@ -4815,7 +5010,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def re_run_job_for_workflow_run(
@@ -4827,7 +5022,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def re_run_job_for_workflow_run(
         self,
@@ -4840,7 +5035,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run"""
 
         from typing import Union
@@ -4888,7 +5083,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_re_run_job_for_workflow_run(
@@ -4900,7 +5095,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_re_run_job_for_workflow_run(
         self,
@@ -4913,7 +5108,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run"""
 
         from typing import Union
@@ -4956,7 +5151,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSubRepo]:
+    ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import BasicError, OidcCustomSubRepo
@@ -4982,7 +5177,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSubRepo]:
+    ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import BasicError, OidcCustomSubRepo
@@ -5010,7 +5205,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def set_custom_oidc_sub_claim_for_repo(
@@ -5022,7 +5217,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def set_custom_oidc_sub_claim_for_repo(
         self,
@@ -5032,7 +5227,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import (
@@ -5078,7 +5273,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_set_custom_oidc_sub_claim_for_repo(
@@ -5090,7 +5285,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_set_custom_oidc_sub_claim_for_repo(
         self,
@@ -5100,7 +5295,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import (
@@ -5146,7 +5341,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-repository-organization-secrets"""
 
         from ..models import ReposOwnerRepoActionsOrganizationSecretsGetResponse200
@@ -5176,7 +5374,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-repository-organization-secrets"""
 
         from ..models import ReposOwnerRepoActionsOrganizationSecretsGetResponse200
@@ -5206,7 +5407,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-repository-organization-variables"""
 
         from ..models import ReposOwnerRepoActionsOrganizationVariablesGetResponse200
@@ -5236,7 +5440,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-repository-organization-variables"""
 
         from ..models import ReposOwnerRepoActionsOrganizationVariablesGetResponse200
@@ -5264,7 +5471,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsRepositoryPermissions]:
+    ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
         from ..models import ActionsRepositoryPermissions
@@ -5286,7 +5493,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsRepositoryPermissions]:
+    ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
         from ..models import ActionsRepositoryPermissions
@@ -5418,7 +5625,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsWorkflowAccessToRepository]:
+    ) -> Response[
+        ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository"""
 
         from ..models import ActionsWorkflowAccessToRepository
@@ -5440,7 +5649,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsWorkflowAccessToRepository]:
+    ) -> Response[
+        ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository"""
 
         from ..models import ActionsWorkflowAccessToRepository
@@ -5570,7 +5781,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
         from ..models import SelectedActions
@@ -5592,7 +5803,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
         from ..models import SelectedActions
@@ -5726,7 +5937,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-a-repository"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -5748,7 +5961,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-default-workflow-permissions-for-a-repository"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -5885,7 +6100,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunnersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunnersGetResponse200,
+        ReposOwnerRepoActionsRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunnersGetResponse200
@@ -5917,7 +6135,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunnersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunnersGetResponse200,
+        ReposOwnerRepoActionsRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunnersGetResponse200
@@ -5946,7 +6167,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
         from ..models import RunnerApplication
@@ -5968,7 +6189,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
         from ..models import RunnerApplication
@@ -5993,7 +6214,8 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     @overload
@@ -6009,7 +6231,8 @@ class ActionsClient:
         labels: list[str],
         work_folder: Missing[str] = UNSET,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     def generate_runner_jitconfig_for_repo(
@@ -6022,7 +6245,10 @@ class ActionsClient:
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-a-repository"""
 
         from ..models import (
@@ -6068,7 +6294,8 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     @overload
@@ -6084,7 +6311,8 @@ class ActionsClient:
         labels: list[str],
         work_folder: Missing[str] = UNSET,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
     ]: ...
 
     async def async_generate_runner_jitconfig_for_repo(
@@ -6097,7 +6325,10 @@ class ActionsClient:
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
+        EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-a-repository"""
 
         from ..models import (
@@ -6140,7 +6371,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -6162,7 +6393,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -6184,7 +6415,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -6206,7 +6437,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -6229,7 +6460,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
         from ..models import Runner
@@ -6252,7 +6483,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
         from ..models import Runner
@@ -6315,7 +6546,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6344,7 +6578,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6375,7 +6612,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def set_custom_labels_for_self_hosted_runner_for_repo(
@@ -6387,7 +6627,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def set_custom_labels_for_self_hosted_runner_for_repo(
         self,
@@ -6398,7 +6641,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6444,7 +6690,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_set_custom_labels_for_self_hosted_runner_for_repo(
@@ -6456,7 +6705,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_set_custom_labels_for_self_hosted_runner_for_repo(
         self,
@@ -6467,7 +6719,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6513,7 +6768,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def add_custom_labels_to_self_hosted_runner_for_repo(
@@ -6525,7 +6783,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def add_custom_labels_to_self_hosted_runner_for_repo(
         self,
@@ -6536,7 +6797,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6582,7 +6846,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_add_custom_labels_to_self_hosted_runner_for_repo(
@@ -6594,7 +6861,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_add_custom_labels_to_self_hosted_runner_for_repo(
         self,
@@ -6605,7 +6875,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6649,7 +6922,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6678,7 +6954,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6708,7 +6987,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6740,7 +7022,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6797,7 +7082,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsGetResponse200,
+        ReposOwnerRepoActionsRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#list-workflow-runs-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunsGetResponse200
@@ -6860,7 +7148,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsGetResponse200,
+        ReposOwnerRepoActionsRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#list-workflow-runs-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunsGetResponse200
@@ -6898,7 +7189,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run"""
 
         from ..models import WorkflowRun
@@ -6927,7 +7218,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run"""
 
         from ..models import WorkflowRun
@@ -6995,7 +7286,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[EnvironmentApprovals]]:
+    ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
         from ..models import EnvironmentApprovals
@@ -7018,7 +7309,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[EnvironmentApprovals]]:
+    ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
         from ..models import EnvironmentApprovals
@@ -7041,7 +7332,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
         from ..models import BasicError, EmptyObject
@@ -7068,7 +7359,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
         from ..models import BasicError, EmptyObject
@@ -7098,7 +7389,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#list-workflow-run-artifacts"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200
@@ -7131,7 +7425,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#list-workflow-run-artifacts"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200
@@ -7163,7 +7460,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
         from ..models import WorkflowRun
@@ -7193,7 +7490,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
         from ..models import WorkflowRun
@@ -7225,7 +7522,8 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt"""
 
@@ -7265,7 +7563,8 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt"""
 
@@ -7343,7 +7642,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7369,7 +7668,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7567,7 +7866,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7593,7 +7892,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7622,7 +7921,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdJobsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#list-jobs-for-a-workflow-run"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdJobsGetResponse200
@@ -7655,7 +7957,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdJobsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#list-jobs-for-a-workflow-run"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdJobsGetResponse200
@@ -7777,7 +8082,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PendingDeployment]]:
+    ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
         from ..models import PendingDeployment
@@ -7800,7 +8105,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PendingDeployment]]:
+    ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
         from ..models import PendingDeployment
@@ -7825,7 +8130,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     @overload
     def review_pending_deployments_for_run(
@@ -7839,7 +8144,7 @@ class ActionsClient:
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     def review_pending_deployments_for_run(
         self,
@@ -7852,7 +8157,7 @@ class ActionsClient:
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run"""
 
         from ..models import (
@@ -7892,7 +8197,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     @overload
     async def async_review_pending_deployments_for_run(
@@ -7906,7 +8211,7 @@ class ActionsClient:
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     async def async_review_pending_deployments_for_run(
         self,
@@ -7919,7 +8224,7 @@ class ActionsClient:
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run"""
 
         from ..models import (
@@ -7961,7 +8266,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def re_run_workflow(
@@ -7973,7 +8278,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def re_run_workflow(
         self,
@@ -7986,7 +8291,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#re-run-a-workflow"""
 
         from typing import Union
@@ -8027,7 +8332,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_re_run_workflow(
@@ -8039,7 +8344,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_re_run_workflow(
         self,
@@ -8052,7 +8357,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#re-run-a-workflow"""
 
         from typing import Union
@@ -8093,7 +8398,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def re_run_workflow_failed_jobs(
@@ -8105,7 +8410,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def re_run_workflow_failed_jobs(
         self,
@@ -8118,7 +8423,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run"""
 
         from typing import Union
@@ -8162,7 +8467,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_re_run_workflow_failed_jobs(
@@ -8174,7 +8479,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_re_run_workflow_failed_jobs(
         self,
@@ -8187,7 +8492,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run"""
 
         from typing import Union
@@ -8227,7 +8532,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRunUsage]:
+    ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-workflow-run-usage"""
 
         from ..models import WorkflowRunUsage
@@ -8250,7 +8555,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRunUsage]:
+    ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-workflow-run-usage"""
 
         from ..models import WorkflowRunUsage
@@ -8274,7 +8579,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsSecretsGetResponse200,
+        ReposOwnerRepoActionsSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoActionsSecretsGetResponse200
@@ -8304,7 +8612,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsSecretsGetResponse200,
+        ReposOwnerRepoActionsSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoActionsSecretsGetResponse200
@@ -8332,7 +8643,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-public-key"""
 
         from ..models import ActionsPublicKey
@@ -8354,7 +8665,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-public-key"""
 
         from ..models import ActionsPublicKey
@@ -8377,7 +8688,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-secret"""
 
         from ..models import ActionsSecret
@@ -8400,7 +8711,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-secret"""
 
         from ..models import ActionsSecret
@@ -8425,7 +8736,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_repo_secret(
@@ -8438,7 +8749,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_repo_secret(
         self,
@@ -8449,7 +8760,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#create-or-update-a-repository-secret"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsSecretsSecretNamePutBody
@@ -8486,7 +8797,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_repo_secret(
@@ -8499,7 +8810,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_repo_secret(
         self,
@@ -8510,7 +8821,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#create-or-update-a-repository-secret"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsSecretsSecretNamePutBody
@@ -8586,7 +8897,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsVariablesGetResponse200,
+        ReposOwnerRepoActionsVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-repository-variables"""
 
         from ..models import ReposOwnerRepoActionsVariablesGetResponse200
@@ -8616,7 +8930,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsVariablesGetResponse200,
+        ReposOwnerRepoActionsVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-repository-variables"""
 
         from ..models import ReposOwnerRepoActionsVariablesGetResponse200
@@ -8646,7 +8963,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_repo_variable(
@@ -8658,7 +8975,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_repo_variable(
         self,
@@ -8668,7 +8985,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#create-a-repository-variable"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsVariablesPostBody
@@ -8702,7 +9019,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_repo_variable(
@@ -8714,7 +9031,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_repo_variable(
         self,
@@ -8724,7 +9041,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#create-a-repository-variable"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsVariablesPostBody
@@ -8757,7 +9074,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-a-repository-variable"""
 
         from ..models import ActionsVariable
@@ -8780,7 +9097,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-a-repository-variable"""
 
         from ..models import ActionsVariable
@@ -8962,7 +9279,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#list-repository-workflows"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsGetResponse200
@@ -8992,7 +9312,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#list-repository-workflows"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsGetResponse200
@@ -9021,7 +9344,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Workflow]:
+    ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-a-workflow"""
 
         from ..models import Workflow
@@ -9044,7 +9367,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Workflow]:
+    ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-a-workflow"""
 
         from ..models import Workflow
@@ -9302,7 +9625,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#list-workflow-runs-for-a-workflow"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200
@@ -9366,7 +9692,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#list-workflow-runs-for-a-workflow"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200
@@ -9403,7 +9732,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowUsage]:
+    ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-workflow-usage"""
 
         from ..models import WorkflowUsage
@@ -9426,7 +9755,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowUsage]:
+    ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-workflow-usage"""
 
         from ..models import WorkflowUsage
@@ -9451,7 +9780,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-environment-secrets"""
 
         from ..models import (
@@ -9484,7 +9816,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#list-environment-secrets"""
 
         from ..models import (
@@ -9515,7 +9850,7 @@ class ActionsClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-public-key"""
 
         from ..models import ActionsPublicKey
@@ -9540,7 +9875,7 @@ class ActionsClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-public-key"""
 
         from ..models import ActionsPublicKey
@@ -9566,7 +9901,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-secret"""
 
         from ..models import ActionsSecret
@@ -9590,7 +9925,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-secret"""
 
         from ..models import ActionsSecret
@@ -9616,7 +9951,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_environment_secret(
@@ -9630,7 +9965,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: str,
         key_id: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_environment_secret(
         self,
@@ -9644,7 +9979,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#create-or-update-an-environment-secret"""
 
         from ..models import (
@@ -9685,7 +10020,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_environment_secret(
@@ -9699,7 +10034,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: str,
         key_id: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_environment_secret(
         self,
@@ -9713,7 +10048,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#create-or-update-an-environment-secret"""
 
         from ..models import (
@@ -9795,7 +10130,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-environment-variables"""
 
         from ..models import (
@@ -9828,7 +10166,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#list-environment-variables"""
 
         from ..models import (
@@ -9861,7 +10202,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_environment_variable(
@@ -9874,7 +10215,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_environment_variable(
         self,
@@ -9887,7 +10228,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#create-an-environment-variable"""
 
         from ..models import (
@@ -9927,7 +10268,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_environment_variable(
@@ -9940,7 +10281,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_environment_variable(
         self,
@@ -9953,7 +10294,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#create-an-environment-variable"""
 
         from ..models import (
@@ -9992,7 +10333,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-environment-variable"""
 
         from ..models import ActionsVariable
@@ -10016,7 +10357,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-environment-variable"""
 
         from ..models import ActionsVariable

--- a/githubkit/versions/ghec_v2022_11_28/rest/activity.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/activity.py
@@ -27,12 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        NotificationsPutBodyType,
-        ReposOwnerRepoSubscriptionPutBodyType,
-        ReposOwnerRepoNotificationsPutBodyType,
-        NotificationsThreadsThreadIdSubscriptionPutBodyType,
-    )
     from ..models import (
         Feed,
         Event,
@@ -46,6 +40,24 @@ if TYPE_CHECKING:
         RepositorySubscription,
         NotificationsPutResponse202,
         ReposOwnerRepoNotificationsPutResponse202,
+    )
+    from ..types import (
+        FeedType,
+        EventType,
+        ThreadType,
+        StargazerType,
+        RepositoryType,
+        SimpleUserType,
+        MinimalRepositoryType,
+        StarredRepositoryType,
+        ThreadSubscriptionType,
+        NotificationsPutBodyType,
+        RepositorySubscriptionType,
+        NotificationsPutResponse202Type,
+        ReposOwnerRepoSubscriptionPutBodyType,
+        ReposOwnerRepoNotificationsPutBodyType,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+        NotificationsThreadsThreadIdSubscriptionPutBodyType,
     )
 
 
@@ -70,7 +82,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events"""
 
         from ..models import (
@@ -106,7 +118,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events"""
 
         from ..models import (
@@ -140,7 +152,7 @@ class ActivityClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Feed]:
+    ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/feeds#get-feeds"""
 
         from ..models import Feed
@@ -160,7 +172,7 @@ class ActivityClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Feed]:
+    ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/feeds#get-feeds"""
 
         from ..models import Feed
@@ -184,7 +196,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
         from ..models import Event, BasicError
@@ -218,7 +230,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
         from ..models import Event, BasicError
@@ -254,7 +266,7 @@ class ActivityClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
         from ..models import Thread, BasicError, ValidationError
@@ -295,7 +307,7 @@ class ActivityClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
         from ..models import Thread, BasicError, ValidationError
@@ -332,7 +344,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     @overload
     def mark_notifications_as_read(
@@ -342,7 +354,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     def mark_notifications_as_read(
         self,
@@ -350,7 +362,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[NotificationsPutResponse202]:
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-notifications-as-read"""
 
         from ..models import (
@@ -390,7 +402,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     @overload
     async def async_mark_notifications_as_read(
@@ -400,7 +412,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     async def async_mark_notifications_as_read(
         self,
@@ -408,7 +420,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[NotificationsPutResponse202]:
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-notifications-as-read"""
 
         from ..models import (
@@ -447,7 +459,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Thread]:
+    ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread"""
 
         from ..models import Thread, BasicError
@@ -472,7 +484,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Thread]:
+    ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread"""
 
         from ..models import Thread, BasicError
@@ -579,7 +591,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
         from ..models import BasicError, ThreadSubscription
@@ -604,7 +616,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
         from ..models import BasicError, ThreadSubscription
@@ -631,7 +643,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     @overload
     def set_thread_subscription(
@@ -641,7 +653,7 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     def set_thread_subscription(
         self,
@@ -650,7 +662,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#set-a-thread-subscription"""
 
         from ..models import (
@@ -693,7 +705,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     @overload
     async def async_set_thread_subscription(
@@ -703,7 +715,7 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     async def async_set_thread_subscription(
         self,
@@ -712,7 +724,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#set-a-thread-subscription"""
 
         from ..models import (
@@ -803,7 +815,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-organization-events"""
 
         from ..models import Event
@@ -832,7 +844,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-organization-events"""
 
         from ..models import Event
@@ -862,7 +874,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-repository-events"""
 
         from ..models import Event
@@ -892,7 +904,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-repository-events"""
 
         from ..models import Event
@@ -926,7 +938,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
         from ..models import Thread
@@ -964,7 +976,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
         from ..models import Thread
@@ -998,7 +1010,10 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     @overload
     def mark_repo_notifications_as_read(
@@ -1009,7 +1024,10 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     def mark_repo_notifications_as_read(
         self,
@@ -1019,7 +1037,10 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-repository-notifications-as-read"""
 
         from ..models import (
@@ -1056,7 +1077,10 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     @overload
     async def async_mark_repo_notifications_as_read(
@@ -1067,7 +1091,10 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     async def async_mark_repo_notifications_as_read(
         self,
@@ -1077,7 +1104,10 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-repository-notifications-as-read"""
 
         from ..models import (
@@ -1114,7 +1144,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[SimpleUser], list[Stargazer]]]:
+    ) -> Response[
+        Union[list[SimpleUser], list[Stargazer]],
+        Union[list[SimpleUserType], list[StargazerType]],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-stargazers"""
 
         from typing import Union
@@ -1149,7 +1182,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[SimpleUser], list[Stargazer]]]:
+    ) -> Response[
+        Union[list[SimpleUser], list[Stargazer]],
+        Union[list[SimpleUserType], list[StargazerType]],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-stargazers"""
 
         from typing import Union
@@ -1184,7 +1220,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-watchers"""
 
         from ..models import SimpleUser
@@ -1214,7 +1250,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-watchers"""
 
         from ..models import SimpleUser
@@ -1242,7 +1278,7 @@ class ActivityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#get-a-repository-subscription"""
 
         from ..models import BasicError, RepositorySubscription
@@ -1267,7 +1303,7 @@ class ActivityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#get-a-repository-subscription"""
 
         from ..models import BasicError, RepositorySubscription
@@ -1294,7 +1330,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     @overload
     def set_repo_subscription(
@@ -1306,7 +1342,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     def set_repo_subscription(
         self,
@@ -1316,7 +1352,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#set-a-repository-subscription"""
 
         from ..models import RepositorySubscription, ReposOwnerRepoSubscriptionPutBody
@@ -1350,7 +1386,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     @overload
     async def async_set_repo_subscription(
@@ -1362,7 +1398,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     async def async_set_repo_subscription(
         self,
@@ -1372,7 +1408,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#set-a-repository-subscription"""
 
         from ..models import RepositorySubscription, ReposOwnerRepoSubscriptionPutBody
@@ -1444,7 +1480,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
         from ..models import BasicError, Repository
@@ -1480,7 +1516,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
         from ..models import BasicError, Repository
@@ -1670,7 +1706,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
         from ..models import BasicError, MinimalRepository
@@ -1702,7 +1738,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
         from ..models import BasicError, MinimalRepository
@@ -1735,7 +1771,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1764,7 +1800,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1794,7 +1830,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1824,7 +1860,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1853,7 +1889,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-user"""
 
         from ..models import Event
@@ -1882,7 +1918,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-user"""
 
         from ..models import Event
@@ -1911,7 +1947,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-received-by-the-authenticated-user"""
 
         from ..models import Event
@@ -1940,7 +1976,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-received-by-the-authenticated-user"""
 
         from ..models import Event
@@ -1969,7 +2005,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-received-by-a-user"""
 
         from ..models import Event
@@ -1998,7 +2034,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-received-by-a-user"""
 
         from ..models import Event
@@ -2029,7 +2065,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[StarredRepository], list[Repository]]]:
+    ) -> Response[
+        Union[list[StarredRepository], list[Repository]],
+        Union[list[StarredRepositoryType], list[RepositoryType]],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-repositories-starred-by-a-user"""
 
         from typing import Union
@@ -2064,7 +2103,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[StarredRepository], list[Repository]]]:
+    ) -> Response[
+        Union[list[StarredRepository], list[Repository]],
+        Union[list[StarredRepositoryType], list[RepositoryType]],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-repositories-starred-by-a-user"""
 
         from typing import Union
@@ -2097,7 +2139,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-a-user"""
 
         from ..models import MinimalRepository
@@ -2126,7 +2168,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-a-user"""
 
         from ..models import MinimalRepository

--- a/githubkit/versions/ghec_v2022_11_28/rest/apps.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/apps.py
@@ -27,16 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        AppPermissionsType,
-        AppHookConfigPatchBodyType,
-        ApplicationsClientIdTokenPostBodyType,
-        ApplicationsClientIdTokenPatchBodyType,
-        ApplicationsClientIdGrantDeleteBodyType,
-        ApplicationsClientIdTokenDeleteBodyType,
-        ApplicationsClientIdTokenScopedPostBodyType,
-        AppInstallationsInstallationIdAccessTokensPostBodyType,
-    )
     from ..models import (
         Integration,
         HookDelivery,
@@ -54,6 +44,32 @@ if TYPE_CHECKING:
         AppManifestsCodeConversionsPostResponse201,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         UserInstallationsInstallationIdRepositoriesGetResponse200,
+    )
+    from ..types import (
+        IntegrationType,
+        HookDeliveryType,
+        InstallationType,
+        AuthorizationType,
+        WebhookConfigType,
+        AppPermissionsType,
+        HookDeliveryItemType,
+        InstallationTokenType,
+        MarketplacePurchaseType,
+        AppHookConfigPatchBodyType,
+        MarketplaceListingPlanType,
+        UserMarketplacePurchaseType,
+        IntegrationInstallationRequestType,
+        UserInstallationsGetResponse200Type,
+        ApplicationsClientIdTokenPostBodyType,
+        ApplicationsClientIdTokenPatchBodyType,
+        ApplicationsClientIdGrantDeleteBodyType,
+        ApplicationsClientIdTokenDeleteBodyType,
+        InstallationRepositoriesGetResponse200Type,
+        ApplicationsClientIdTokenScopedPostBodyType,
+        AppManifestsCodeConversionsPostResponse201Type,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+        AppInstallationsInstallationIdAccessTokensPostBodyType,
+        UserInstallationsInstallationIdRepositoriesGetResponse200Type,
     )
 
 
@@ -76,7 +92,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-the-authenticated-app"""
 
         from typing import Union
@@ -98,7 +114,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-the-authenticated-app"""
 
         from typing import Union
@@ -121,7 +137,10 @@ class AppsClient:
         code: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppManifestsCodeConversionsPostResponse201]:
+    ) -> Response[
+        AppManifestsCodeConversionsPostResponse201,
+        AppManifestsCodeConversionsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#create-a-github-app-from-a-manifest"""
 
         from ..models import (
@@ -150,7 +169,10 @@ class AppsClient:
         code: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppManifestsCodeConversionsPostResponse201]:
+    ) -> Response[
+        AppManifestsCodeConversionsPostResponse201,
+        AppManifestsCodeConversionsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#create-a-github-app-from-a-manifest"""
 
         from ..models import (
@@ -178,7 +200,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig
@@ -198,7 +220,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig
@@ -220,7 +242,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AppHookConfigPatchBodyType,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     def update_webhook_config_for_app(
@@ -232,7 +254,7 @@ class AppsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     def update_webhook_config_for_app(
         self,
@@ -240,7 +262,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#update-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig, AppHookConfigPatchBody
@@ -272,7 +294,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AppHookConfigPatchBodyType,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     async def async_update_webhook_config_for_app(
@@ -284,7 +306,7 @@ class AppsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     async def async_update_webhook_config_for_app(
         self,
@@ -292,7 +314,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#update-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig, AppHookConfigPatchBody
@@ -324,7 +346,7 @@ class AppsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -356,7 +378,7 @@ class AppsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -387,7 +409,7 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -412,7 +434,7 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -437,7 +459,10 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook"""
 
         from ..models import (
@@ -466,7 +491,10 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook"""
 
         from ..models import (
@@ -496,7 +524,9 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IntegrationInstallationRequest]]:
+    ) -> Response[
+        list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#list-installation-requests-for-the-authenticated-app"""
 
         from ..models import BasicError, IntegrationInstallationRequest
@@ -527,7 +557,9 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IntegrationInstallationRequest]]:
+    ) -> Response[
+        list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#list-installation-requests-for-the-authenticated-app"""
 
         from ..models import BasicError, IntegrationInstallationRequest
@@ -560,7 +592,7 @@ class AppsClient:
         outdated: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Installation]]:
+    ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#list-installations-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -592,7 +624,7 @@ class AppsClient:
         outdated: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Installation]]:
+    ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#list-installations-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -621,7 +653,7 @@ class AppsClient:
         installation_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -645,7 +677,7 @@ class AppsClient:
         installation_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -717,7 +749,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     @overload
     def create_installation_access_token(
@@ -729,7 +761,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     def create_installation_access_token(
         self,
@@ -738,7 +770,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[InstallationToken]:
+    ) -> Response[InstallationToken, InstallationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#create-an-installation-access-token-for-an-app"""
 
         from ..models import (
@@ -784,7 +816,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     @overload
     async def async_create_installation_access_token(
@@ -796,7 +828,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     async def async_create_installation_access_token(
         self,
@@ -805,7 +837,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[InstallationToken]:
+    ) -> Response[InstallationToken, InstallationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#create-an-installation-access-token-for-an-app"""
 
         from ..models import (
@@ -1051,7 +1083,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     def check_token(
@@ -1061,7 +1093,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     def check_token(
         self,
@@ -1070,7 +1102,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/oauth-applications#check-a-token"""
 
         from ..models import (
@@ -1112,7 +1144,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     async def async_check_token(
@@ -1122,7 +1154,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     async def async_check_token(
         self,
@@ -1131,7 +1163,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/oauth-applications#check-a-token"""
 
         from ..models import (
@@ -1281,7 +1313,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     def reset_token(
@@ -1291,7 +1323,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     def reset_token(
         self,
@@ -1300,7 +1332,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/oauth-applications#reset-a-token"""
 
         from ..models import (
@@ -1340,7 +1372,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     async def async_reset_token(
@@ -1350,7 +1382,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     async def async_reset_token(
         self,
@@ -1359,7 +1391,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/oauth-applications#reset-a-token"""
 
         from ..models import (
@@ -1399,7 +1431,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     def scope_token(
@@ -1414,7 +1446,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     def scope_token(
         self,
@@ -1423,7 +1455,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#create-a-scoped-access-token"""
 
         from ..models import (
@@ -1467,7 +1499,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     async def async_scope_token(
@@ -1482,7 +1514,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     async def async_scope_token(
         self,
@@ -1491,7 +1523,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#create-a-scoped-access-token"""
 
         from ..models import (
@@ -1533,7 +1565,7 @@ class AppsClient:
         app_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-app"""
 
         from typing import Union
@@ -1560,7 +1592,7 @@ class AppsClient:
         app_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-app"""
 
         from typing import Union
@@ -1588,7 +1620,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[InstallationRepositoriesGetResponse200]:
+    ) -> Response[
+        InstallationRepositoriesGetResponse200,
+        InstallationRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-repositories-accessible-to-the-app-installation"""
 
         from ..models import BasicError, InstallationRepositoriesGetResponse200
@@ -1620,7 +1655,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[InstallationRepositoriesGetResponse200]:
+    ) -> Response[
+        InstallationRepositoriesGetResponse200,
+        InstallationRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-repositories-accessible-to-the-app-installation"""
 
         from ..models import BasicError, InstallationRepositoriesGetResponse200
@@ -1685,7 +1723,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1710,7 +1748,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1736,7 +1774,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1768,7 +1806,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1803,7 +1841,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan"""
 
         from ..models import BasicError, ValidationError, MarketplacePurchase
@@ -1841,7 +1879,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan"""
 
         from ..models import BasicError, ValidationError, MarketplacePurchase
@@ -1875,7 +1913,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1899,7 +1937,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1924,7 +1962,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans-stubbed"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1955,7 +1993,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans-stubbed"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1989,7 +2027,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -2025,7 +2063,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -2057,7 +2095,7 @@ class AppsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -2078,7 +2116,7 @@ class AppsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -2100,7 +2138,7 @@ class AppsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -2125,7 +2163,7 @@ class AppsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -2150,7 +2188,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsGetResponse200]:
+    ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
         from ..models import BasicError, UserInstallationsGetResponse200
@@ -2182,7 +2220,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsGetResponse200]:
+    ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
         from ..models import BasicError, UserInstallationsGetResponse200
@@ -2215,7 +2253,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsInstallationIdRepositoriesGetResponse200]:
+    ) -> Response[
+        UserInstallationsInstallationIdRepositoriesGetResponse200,
+        UserInstallationsInstallationIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-repositories-accessible-to-the-user-access-token"""
 
         from ..models import (
@@ -2251,7 +2292,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsInstallationIdRepositoriesGetResponse200]:
+    ) -> Response[
+        UserInstallationsInstallationIdRepositoriesGetResponse200,
+        UserInstallationsInstallationIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-repositories-accessible-to-the-user-access-token"""
 
         from ..models import (
@@ -2386,7 +2430,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2418,7 +2462,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2450,7 +2494,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2481,7 +2525,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2511,7 +2555,7 @@ class AppsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -2532,7 +2576,7 @@ class AppsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 
         from ..models import Installation

--- a/githubkit/versions/ghec_v2022_11_28/rest/billing.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/billing.py
@@ -24,10 +24,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType,
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType,
-    )
     from ..models import (
         GetAllCostCenters,
         BillingUsageReport,
@@ -37,6 +33,18 @@ if TYPE_CHECKING:
         AdvancedSecurityActiveCommitters,
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+    )
+    from ..types import (
+        GetAllCostCentersType,
+        BillingUsageReportType,
+        ActionsBillingUsageType,
+        CombinedBillingUsageType,
+        PackagesBillingUsageType,
+        AdvancedSecurityActiveCommittersType,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     )
 
 
@@ -60,7 +68,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-actions-billing-for-an-enterprise"""
 
         from ..models import ActionsBillingUsage
@@ -81,7 +89,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-actions-billing-for-an-enterprise"""
 
         from ..models import ActionsBillingUsage
@@ -104,7 +112,9 @@ class BillingClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AdvancedSecurityActiveCommitters]:
+    ) -> Response[
+        AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-advanced-security-active-committers-for-an-enterprise"""
 
         from ..models import AdvancedSecurityActiveCommitters
@@ -133,7 +143,9 @@ class BillingClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AdvancedSecurityActiveCommitters]:
+    ) -> Response[
+        AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-advanced-security-active-committers-for-an-enterprise"""
 
         from ..models import AdvancedSecurityActiveCommitters
@@ -160,7 +172,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GetAllCostCenters]:
+    ) -> Response[GetAllCostCenters, GetAllCostCentersType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-all-cost-centers-for-an-enterprise"""
 
         from ..models import (
@@ -191,7 +203,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GetAllCostCenters]:
+    ) -> Response[GetAllCostCenters, GetAllCostCentersType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-all-cost-centers-for-an-enterprise"""
 
         from ..models import (
@@ -226,7 +238,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
     ]: ...
 
     @overload
@@ -239,7 +252,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         users: list[str],
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
     ]: ...
 
     def add_resource_to_cost_center(
@@ -253,7 +267,8 @@ class BillingClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#add-users-to-a-cost-center"""
 
@@ -304,7 +319,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
     ]: ...
 
     @overload
@@ -317,7 +333,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         users: list[str],
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
     ]: ...
 
     async def async_add_resource_to_cost_center(
@@ -331,7 +348,8 @@ class BillingClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#add-users-to-a-cost-center"""
 
@@ -382,7 +400,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     ]: ...
 
     @overload
@@ -395,7 +414,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         users: list[str],
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     ]: ...
 
     def remove_resource_from_cost_center(
@@ -409,7 +429,8 @@ class BillingClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#remove-users-from-a-cost-center"""
 
@@ -459,7 +480,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     ]: ...
 
     @overload
@@ -472,7 +494,8 @@ class BillingClient:
         headers: Optional[dict[str, str]] = None,
         users: list[str],
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     ]: ...
 
     async def async_remove_resource_from_cost_center(
@@ -486,7 +509,8 @@ class BillingClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
+        EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#remove-users-from-a-cost-center"""
 
@@ -532,7 +556,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-packages-billing-for-an-enterprise"""
 
         from ..models import PackagesBillingUsage
@@ -553,7 +577,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-packages-billing-for-an-enterprise"""
 
         from ..models import PackagesBillingUsage
@@ -574,7 +598,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-shared-storage-billing-for-an-enterprise"""
 
         from ..models import CombinedBillingUsage
@@ -595,7 +619,7 @@ class BillingClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-shared-storage-billing-for-an-enterprise"""
 
         from ..models import CombinedBillingUsage
@@ -621,7 +645,7 @@ class BillingClient:
         cost_center_id: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BillingUsageReport]:
+    ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-billing-usage-report-for-an-enterprise"""
 
         from ..models import (
@@ -666,7 +690,7 @@ class BillingClient:
         cost_center_id: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BillingUsageReport]:
+    ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-billing-usage-report-for-an-enterprise"""
 
         from ..models import (
@@ -706,7 +730,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
         from ..models import ActionsBillingUsage
@@ -727,7 +751,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
         from ..models import ActionsBillingUsage
@@ -750,7 +774,9 @@ class BillingClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AdvancedSecurityActiveCommitters]:
+    ) -> Response[
+        AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-advanced-security-active-committers-for-an-organization"""
 
         from ..models import AdvancedSecurityActiveCommitters
@@ -779,7 +805,9 @@ class BillingClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AdvancedSecurityActiveCommitters]:
+    ) -> Response[
+        AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-advanced-security-active-committers-for-an-organization"""
 
         from ..models import AdvancedSecurityActiveCommitters
@@ -806,7 +834,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
         from ..models import PackagesBillingUsage
@@ -827,7 +855,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
         from ..models import PackagesBillingUsage
@@ -848,7 +876,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
         from ..models import CombinedBillingUsage
@@ -869,7 +897,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
         from ..models import CombinedBillingUsage
@@ -890,7 +918,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-a-user"""
 
         from ..models import ActionsBillingUsage
@@ -911,7 +939,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-a-user"""
 
         from ..models import ActionsBillingUsage
@@ -932,7 +960,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-a-user"""
 
         from ..models import PackagesBillingUsage
@@ -953,7 +981,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-a-user"""
 
         from ..models import PackagesBillingUsage
@@ -974,7 +1002,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-a-user"""
 
         from ..models import CombinedBillingUsage
@@ -995,7 +1023,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-a-user"""
 
         from ..models import CombinedBillingUsage

--- a/githubkit/versions/ghec_v2022_11_28/rest/checks.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/checks.py
@@ -38,16 +38,24 @@ if TYPE_CHECKING:
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
     )
     from ..types import (
+        CheckRunType,
+        CheckSuiteType,
+        EmptyObjectType,
+        CheckAnnotationType,
+        CheckSuitePreferenceType,
         ReposOwnerRepoCheckSuitesPostBodyType,
         ReposOwnerRepoCheckRunsPostBodyOneof0Type,
         ReposOwnerRepoCheckRunsPostBodyOneof1Type,
         ReposOwnerRepoCheckRunsPostBodyPropOutputType,
         ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
         ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType,
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropOutputType,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType,
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
         ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType,
     )
 
@@ -78,7 +86,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def create(
@@ -109,7 +117,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def create(
@@ -144,7 +152,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     def create(
         self,
@@ -159,7 +167,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#create-a-check-run"""
 
         from typing import Union
@@ -208,7 +216,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_create(
@@ -239,7 +247,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_create(
@@ -274,7 +282,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     async def async_create(
         self,
@@ -289,7 +297,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#create-a-check-run"""
 
         from typing import Union
@@ -334,7 +342,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#get-a-check-run"""
 
         from ..models import CheckRun
@@ -357,7 +365,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#get-a-check-run"""
 
         from ..models import CheckRun
@@ -385,7 +393,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def update(
@@ -418,7 +426,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def update(
@@ -453,7 +461,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     def update(
         self,
@@ -469,7 +477,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#update-a-check-run"""
 
         from typing import Union
@@ -519,7 +527,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_update(
@@ -552,7 +560,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_update(
@@ -587,7 +595,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     async def async_update(
         self,
@@ -603,7 +611,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#update-a-check-run"""
 
         from typing import Union
@@ -650,7 +658,7 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CheckAnnotation]]:
+    ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-run-annotations"""
 
         from ..models import CheckAnnotation
@@ -681,7 +689,7 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CheckAnnotation]]:
+    ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-run-annotations"""
 
         from ..models import CheckAnnotation
@@ -710,7 +718,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#rerequest-a-check-run"""
 
         from ..models import BasicError, EmptyObject
@@ -738,7 +746,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#rerequest-a-check-run"""
 
         from ..models import BasicError, EmptyObject
@@ -767,7 +775,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     @overload
     def create_suite(
@@ -778,7 +786,7 @@ class ChecksClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         head_sha: str,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     def create_suite(
         self,
@@ -788,7 +796,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#create-a-check-suite"""
 
         from ..models import CheckSuite, ReposOwnerRepoCheckSuitesPostBody
@@ -822,7 +830,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     @overload
     async def async_create_suite(
@@ -833,7 +841,7 @@ class ChecksClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         head_sha: str,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     async def async_create_suite(
         self,
@@ -843,7 +851,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#create-a-check-suite"""
 
         from ..models import CheckSuite, ReposOwnerRepoCheckSuitesPostBody
@@ -877,7 +885,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     @overload
     def set_suites_preferences(
@@ -892,7 +900,7 @@ class ChecksClient:
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     def set_suites_preferences(
         self,
@@ -902,7 +910,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuitePreference]:
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#update-repository-preferences-for-check-suites"""
 
         from ..models import (
@@ -941,7 +949,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     @overload
     async def async_set_suites_preferences(
@@ -956,7 +964,7 @@ class ChecksClient:
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     async def async_set_suites_preferences(
         self,
@@ -966,7 +974,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuitePreference]:
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#update-repository-preferences-for-check-suites"""
 
         from ..models import (
@@ -1004,7 +1012,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#get-a-check-suite"""
 
         from ..models import CheckSuite
@@ -1027,7 +1035,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#get-a-check-suite"""
 
         from ..models import CheckSuite
@@ -1055,7 +1063,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-runs-in-a-check-suite"""
 
         from ..models import (
@@ -1094,7 +1105,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-runs-in-a-check-suite"""
 
         from ..models import (
@@ -1128,7 +1142,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#rerequest-a-check-suite"""
 
         from ..models import EmptyObject
@@ -1151,7 +1165,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#rerequest-a-check-suite"""
 
         from ..models import EmptyObject
@@ -1180,7 +1194,10 @@ class ChecksClient:
         app_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-runs-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckRunsGetResponse200
@@ -1219,7 +1236,10 @@ class ChecksClient:
         app_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-runs-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckRunsGetResponse200
@@ -1256,7 +1276,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckSuitesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#list-check-suites-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckSuitesGetResponse200
@@ -1291,7 +1314,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckSuitesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#list-check-suites-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckSuitesGetResponse200

--- a/githubkit/versions/ghec_v2022_11_28/rest/classroom.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/classroom.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
         SimpleClassroomAssignment,
         ClassroomAcceptedAssignment,
     )
+    from ..types import (
+        ClassroomType,
+        SimpleClassroomType,
+        ClassroomAssignmentType,
+        ClassroomAssignmentGradeType,
+        SimpleClassroomAssignmentType,
+        ClassroomAcceptedAssignmentType,
+    )
 
 
 class ClassroomClient:
@@ -51,7 +59,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ClassroomAssignment]:
+    ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-an-assignment"""
 
         from ..models import BasicError, ClassroomAssignment
@@ -75,7 +83,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ClassroomAssignment]:
+    ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-an-assignment"""
 
         from ..models import BasicError, ClassroomAssignment
@@ -101,7 +109,9 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAcceptedAssignment]]:
+    ) -> Response[
+        list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-accepted-assignments-for-an-assignment"""
 
         from ..models import ClassroomAcceptedAssignment
@@ -130,7 +140,9 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAcceptedAssignment]]:
+    ) -> Response[
+        list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-accepted-assignments-for-an-assignment"""
 
         from ..models import ClassroomAcceptedAssignment
@@ -157,7 +169,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAssignmentGrade]]:
+    ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-assignment-grades"""
 
         from ..models import BasicError, ClassroomAssignmentGrade
@@ -181,7 +193,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAssignmentGrade]]:
+    ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-assignment-grades"""
 
         from ..models import BasicError, ClassroomAssignmentGrade
@@ -206,7 +218,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroom]]:
+    ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-classrooms"""
 
         from ..models import SimpleClassroom
@@ -234,7 +246,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroom]]:
+    ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-classrooms"""
 
         from ..models import SimpleClassroom
@@ -261,7 +273,7 @@ class ClassroomClient:
         classroom_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Classroom]:
+    ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-a-classroom"""
 
         from ..models import Classroom, BasicError
@@ -285,7 +297,7 @@ class ClassroomClient:
         classroom_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Classroom]:
+    ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-a-classroom"""
 
         from ..models import Classroom, BasicError
@@ -311,7 +323,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroomAssignment]]:
+    ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-assignments-for-a-classroom"""
 
         from ..models import SimpleClassroomAssignment
@@ -340,7 +352,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroomAssignment]]:
+    ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-assignments-for-a-classroom"""
 
         from ..models import SimpleClassroomAssignment

--- a/githubkit/versions/ghec_v2022_11_28/rest/code_scanning.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/code_scanning.py
@@ -27,14 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        CodeScanningDefaultSetupUpdateType,
-        ReposOwnerRepoCodeScanningSarifsPostBodyType,
-        ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
-        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
-        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
-        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
-    )
     from ..models import (
         EmptyObject,
         CodeScanningAlert,
@@ -49,6 +41,27 @@ if TYPE_CHECKING:
         CodeScanningAnalysisDeletion,
         CodeScanningOrganizationAlertItems,
         CodeScanningVariantAnalysisRepoTask,
+    )
+    from ..types import (
+        EmptyObjectType,
+        CodeScanningAlertType,
+        CodeScanningAnalysisType,
+        CodeScanningAlertItemsType,
+        CodeScanningDefaultSetupType,
+        CodeScanningSarifsStatusType,
+        CodeScanningAlertInstanceType,
+        CodeScanningSarifsReceiptType,
+        CodeScanningCodeqlDatabaseType,
+        CodeScanningVariantAnalysisType,
+        CodeScanningAnalysisDeletionType,
+        CodeScanningDefaultSetupUpdateType,
+        CodeScanningOrganizationAlertItemsType,
+        CodeScanningVariantAnalysisRepoTaskType,
+        ReposOwnerRepoCodeScanningSarifsPostBodyType,
+        ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
+        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
+        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
+        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
     )
 
 
@@ -81,7 +94,10 @@ class CodeScanningClient:
         sort: Missing[Literal["created", "updated"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningOrganizationAlertItems]]:
+    ) -> Response[
+        list[CodeScanningOrganizationAlertItems],
+        list[CodeScanningOrganizationAlertItemsType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -132,7 +148,10 @@ class CodeScanningClient:
         sort: Missing[Literal["created", "updated"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningOrganizationAlertItems]]:
+    ) -> Response[
+        list[CodeScanningOrganizationAlertItems],
+        list[CodeScanningOrganizationAlertItemsType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -186,7 +205,10 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningOrganizationAlertItems]]:
+    ) -> Response[
+        list[CodeScanningOrganizationAlertItems],
+        list[CodeScanningOrganizationAlertItemsType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -241,7 +263,10 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningOrganizationAlertItems]]:
+    ) -> Response[
+        list[CodeScanningOrganizationAlertItems],
+        list[CodeScanningOrganizationAlertItemsType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -299,7 +324,7 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertItems]]:
+    ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -360,7 +385,7 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertItems]]:
+    ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -408,7 +433,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
         from ..models import (
@@ -440,7 +465,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
         from ..models import (
@@ -474,7 +499,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     @overload
     def update_alert(
@@ -490,7 +515,7 @@ class CodeScanningClient:
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
         ] = UNSET,
         dismissed_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     def update_alert(
         self,
@@ -501,7 +526,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#update-a-code-scanning-alert"""
 
         from ..models import (
@@ -548,7 +573,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     @overload
     async def async_update_alert(
@@ -564,7 +589,7 @@ class CodeScanningClient:
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
         ] = UNSET,
         dismissed_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     async def async_update_alert(
         self,
@@ -575,7 +600,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#update-a-code-scanning-alert"""
 
         from ..models import (
@@ -624,7 +649,7 @@ class CodeScanningClient:
         pr: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertInstance]]:
+    ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
         from ..models import (
@@ -668,7 +693,7 @@ class CodeScanningClient:
         pr: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertInstance]]:
+    ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
         from ..models import (
@@ -716,7 +741,7 @@ class CodeScanningClient:
         sort: Missing[Literal["created"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAnalysis]]:
+    ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
         from ..models import (
@@ -769,7 +794,7 @@ class CodeScanningClient:
         sort: Missing[Literal["created"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAnalysis]]:
+    ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
         from ..models import (
@@ -814,7 +839,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysis]:
+    ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
         from ..models import (
@@ -846,7 +871,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysis]:
+    ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
         from ..models import (
@@ -879,7 +904,7 @@ class CodeScanningClient:
         confirm_delete: Missing[Union[str, None]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysisDeletion]:
+    ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
         from ..models import (
@@ -918,7 +943,7 @@ class CodeScanningClient:
         confirm_delete: Missing[Union[str, None]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysisDeletion]:
+    ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
         from ..models import (
@@ -955,7 +980,9 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningCodeqlDatabase]]:
+    ) -> Response[
+        list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-codeql-databases-for-a-repository"""
 
         from ..models import (
@@ -986,7 +1013,9 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningCodeqlDatabase]]:
+    ) -> Response[
+        list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-codeql-databases-for-a-repository"""
 
         from ..models import (
@@ -1018,7 +1047,7 @@ class CodeScanningClient:
         language: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningCodeqlDatabase]:
+    ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
         from ..models import (
@@ -1050,7 +1079,7 @@ class CodeScanningClient:
         language: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningCodeqlDatabase]:
+    ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
         from ..models import (
@@ -1147,7 +1176,7 @@ class CodeScanningClient:
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
         ],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     def create_variant_analysis(
@@ -1164,7 +1193,7 @@ class CodeScanningClient:
         repositories: list[str],
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     def create_variant_analysis(
@@ -1181,7 +1210,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: list[str],
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     def create_variant_analysis(
@@ -1198,7 +1227,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: list[str],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     def create_variant_analysis(
         self,
@@ -1214,7 +1243,7 @@ class CodeScanningClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#create-a-codeql-variant-analysis"""
 
         from typing import Union
@@ -1273,7 +1302,7 @@ class CodeScanningClient:
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
         ],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     async def async_create_variant_analysis(
@@ -1290,7 +1319,7 @@ class CodeScanningClient:
         repositories: list[str],
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     async def async_create_variant_analysis(
@@ -1307,7 +1336,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: list[str],
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     async def async_create_variant_analysis(
@@ -1324,7 +1353,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: list[str],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     async def async_create_variant_analysis(
         self,
@@ -1340,7 +1369,7 @@ class CodeScanningClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#create-a-codeql-variant-analysis"""
 
         from typing import Union
@@ -1394,7 +1423,7 @@ class CodeScanningClient:
         codeql_variant_analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1425,7 +1454,7 @@ class CodeScanningClient:
         codeql_variant_analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1458,7 +1487,9 @@ class CodeScanningClient:
         repo_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysisRepoTask]:
+    ) -> Response[
+        CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-analysis-status-of-a-repository-in-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1491,7 +1522,9 @@ class CodeScanningClient:
         repo_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysisRepoTask]:
+    ) -> Response[
+        CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-analysis-status-of-a-repository-in-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1521,7 +1554,7 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningDefaultSetup]:
+    ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1552,7 +1585,7 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningDefaultSetup]:
+    ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1585,7 +1618,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def update_default_setup(
@@ -1611,7 +1644,7 @@ class CodeScanningClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def update_default_setup(
         self,
@@ -1621,7 +1654,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1666,7 +1699,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_update_default_setup(
@@ -1692,7 +1725,7 @@ class CodeScanningClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_update_default_setup(
         self,
@@ -1702,7 +1735,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1747,7 +1780,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     @overload
     def upload_sarif(
@@ -1764,7 +1797,7 @@ class CodeScanningClient:
         started_at: Missing[datetime] = UNSET,
         tool_name: Missing[str] = UNSET,
         validate_: Missing[bool] = UNSET,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     def upload_sarif(
         self,
@@ -1774,7 +1807,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningSarifsReceipt]:
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data"""
 
         from ..models import (
@@ -1818,7 +1851,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     @overload
     async def async_upload_sarif(
@@ -1835,7 +1868,7 @@ class CodeScanningClient:
         started_at: Missing[datetime] = UNSET,
         tool_name: Missing[str] = UNSET,
         validate_: Missing[bool] = UNSET,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     async def async_upload_sarif(
         self,
@@ -1845,7 +1878,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningSarifsReceipt]:
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data"""
 
         from ..models import (
@@ -1888,7 +1921,7 @@ class CodeScanningClient:
         sarif_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningSarifsStatus]:
+    ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 
         from ..models import (
@@ -1919,7 +1952,7 @@ class CodeScanningClient:
         sarif_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningSarifsStatus]:
+    ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/code_security.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/code_security.py
@@ -35,11 +35,17 @@ if TYPE_CHECKING:
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
     )
     from ..types import (
+        CodeSecurityConfigurationType,
+        CodeSecurityConfigurationRepositoriesType,
+        CodeSecurityConfigurationForRepositoryType,
+        CodeSecurityDefaultConfigurationsItemsType,
         OrgsOrgCodeSecurityConfigurationsPostBodyType,
         OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
         OrgsOrgCodeSecurityConfigurationsPostBodyPropSecretScanningDelegatedBypassOptionsType,
         OrgsOrgCodeSecurityConfigurationsPostBodyPropDependencyGraphAutosubmitActionOptionsType,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyPropSecretScanningDelegatedBypassOptionsType,
@@ -71,7 +77,7 @@ class CodeSecurityClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfiguration]]:
+    ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -108,7 +114,7 @@ class CodeSecurityClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfiguration]]:
+    ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -143,7 +149,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     def create_configuration(
@@ -189,7 +195,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     def create_configuration(
         self,
@@ -198,7 +204,7 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#create-a-code-security-configuration"""
 
         from ..models import (
@@ -234,7 +240,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     async def async_create_configuration(
@@ -280,7 +286,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     async def async_create_configuration(
         self,
@@ -289,7 +295,7 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#create-a-code-security-configuration"""
 
         from ..models import (
@@ -323,7 +329,10 @@ class CodeSecurityClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityDefaultConfigurationsItems]]:
+    ) -> Response[
+        list[CodeSecurityDefaultConfigurationsItems],
+        list[CodeSecurityDefaultConfigurationsItemsType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-default-code-security-configurations"""
 
         from ..models import BasicError, CodeSecurityDefaultConfigurationsItems
@@ -348,7 +357,10 @@ class CodeSecurityClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityDefaultConfigurationsItems]]:
+    ) -> Response[
+        list[CodeSecurityDefaultConfigurationsItems],
+        list[CodeSecurityDefaultConfigurationsItemsType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-default-code-security-configurations"""
 
         from ..models import BasicError, CodeSecurityDefaultConfigurationsItems
@@ -498,7 +510,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -524,7 +536,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -606,7 +618,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     def update_configuration(
@@ -653,7 +665,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     def update_configuration(
         self,
@@ -665,7 +677,7 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#update-a-code-security-configuration"""
 
         from ..models import (
@@ -704,7 +716,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     async def async_update_configuration(
@@ -751,7 +763,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     async def async_update_configuration(
         self,
@@ -763,7 +775,7 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#update-a-code-security-configuration"""
 
         from ..models import (
@@ -802,7 +814,10 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     def attach_configuration(
@@ -820,7 +835,10 @@ class CodeSecurityClient:
             "selected",
         ],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     def attach_configuration(
         self,
@@ -832,7 +850,10 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#attach-a-configuration-to-repositories"""
 
         from ..models import (
@@ -871,7 +892,10 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     async def async_attach_configuration(
@@ -889,7 +913,10 @@ class CodeSecurityClient:
             "selected",
         ],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     async def async_attach_configuration(
         self,
@@ -901,7 +928,10 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#attach-a-configuration-to-repositories"""
 
         from ..models import (
@@ -941,7 +971,8 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     @overload
@@ -956,7 +987,8 @@ class CodeSecurityClient:
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     def set_configuration_as_default(
@@ -970,7 +1002,8 @@ class CodeSecurityClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#set-a-code-security-configuration-as-a-default-for-an-organization"""
 
@@ -1016,7 +1049,8 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     @overload
@@ -1031,7 +1065,8 @@ class CodeSecurityClient:
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     async def async_set_configuration_as_default(
@@ -1045,7 +1080,8 @@ class CodeSecurityClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#set-a-code-security-configuration-as-a-default-for-an-organization"""
 
@@ -1092,7 +1128,10 @@ class CodeSecurityClient:
         status: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfigurationRepositories]]:
+    ) -> Response[
+        list[CodeSecurityConfigurationRepositories],
+        list[CodeSecurityConfigurationRepositoriesType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-repositories-associated-with-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfigurationRepositories
@@ -1132,7 +1171,10 @@ class CodeSecurityClient:
         status: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfigurationRepositories]]:
+    ) -> Response[
+        list[CodeSecurityConfigurationRepositories],
+        list[CodeSecurityConfigurationRepositoriesType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-repositories-associated-with-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfigurationRepositories
@@ -1168,7 +1210,10 @@ class CodeSecurityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfigurationForRepository]:
+    ) -> Response[
+        CodeSecurityConfigurationForRepository,
+        CodeSecurityConfigurationForRepositoryType,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-the-code-security-configuration-associated-with-a-repository"""
 
         from ..models import BasicError, CodeSecurityConfigurationForRepository
@@ -1194,7 +1239,10 @@ class CodeSecurityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfigurationForRepository]:
+    ) -> Response[
+        CodeSecurityConfigurationForRepository,
+        CodeSecurityConfigurationForRepositoryType,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-the-code-security-configuration-associated-with-a-repository"""
 
         from ..models import BasicError, CodeSecurityConfigurationForRepository

--- a/githubkit/versions/ghec_v2022_11_28/rest/codes_of_conduct.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/codes_of_conduct.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import CodeOfConduct
+    from ..types import CodeOfConductType
 
 
 class CodesOfConductClient:
@@ -40,7 +41,7 @@ class CodesOfConductClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeOfConduct]]:
+    ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
         from ..models import CodeOfConduct
@@ -60,7 +61,7 @@ class CodesOfConductClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeOfConduct]]:
+    ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
         from ..models import CodeOfConduct
@@ -81,7 +82,7 @@ class CodesOfConductClient:
         key: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeOfConduct]:
+    ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 
         from ..models import BasicError, CodeOfConduct
@@ -105,7 +106,7 @@ class CodesOfConductClient:
         key: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeOfConduct]:
+    ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 
         from ..models import BasicError, CodeOfConduct

--- a/githubkit/versions/ghec_v2022_11_28/rest/codespaces.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/codespaces.py
@@ -26,23 +26,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        UserCodespacesPostBodyOneof0Type,
-        UserCodespacesPostBodyOneof1Type,
-        OrgsOrgCodespacesAccessPutBodyType,
-        ReposOwnerRepoCodespacesPostBodyType,
-        UserCodespacesCodespaceNamePatchBodyType,
-        UserCodespacesSecretsSecretNamePutBodyType,
-        OrgsOrgCodespacesSecretsSecretNamePutBodyType,
-        UserCodespacesCodespaceNamePublishPostBodyType,
-        UserCodespacesPostBodyOneof1PropPullRequestType,
-        OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
-        OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
-        ReposOwnerRepoPullsPullNumberCodespacesPostBodyType,
-        ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
-        UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
-        OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
-    )
     from ..models import (
         Codespace,
         EmptyObject,
@@ -69,6 +52,47 @@ if TYPE_CHECKING:
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
     )
+    from ..types import (
+        CodespaceType,
+        EmptyObjectType,
+        CodespacesSecretType,
+        CodespacesOrgSecretType,
+        CodespacesPublicKeyType,
+        RepoCodespacesSecretType,
+        CodespaceExportDetailsType,
+        CodespacesUserPublicKeyType,
+        CodespaceWithFullRepositoryType,
+        UserCodespacesGetResponse200Type,
+        UserCodespacesPostBodyOneof0Type,
+        UserCodespacesPostBodyOneof1Type,
+        OrgsOrgCodespacesAccessPutBodyType,
+        OrgsOrgCodespacesGetResponse200Type,
+        ReposOwnerRepoCodespacesPostBodyType,
+        UserCodespacesSecretsGetResponse200Type,
+        UserCodespacesCodespaceNamePatchBodyType,
+        OrgsOrgCodespacesSecretsGetResponse200Type,
+        ReposOwnerRepoCodespacesGetResponse200Type,
+        UserCodespacesSecretsSecretNamePutBodyType,
+        CodespacesPermissionsCheckForDevcontainerType,
+        OrgsOrgCodespacesSecretsSecretNamePutBodyType,
+        ReposOwnerRepoCodespacesNewGetResponse200Type,
+        UserCodespacesCodespaceNamePublishPostBodyType,
+        UserCodespacesPostBodyOneof1PropPullRequestType,
+        OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
+        ReposOwnerRepoCodespacesSecretsGetResponse200Type,
+        OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
+        OrgsOrgMembersUsernameCodespacesGetResponse200Type,
+        ReposOwnerRepoCodespacesMachinesGetResponse200Type,
+        ReposOwnerRepoPullsPullNumberCodespacesPostBodyType,
+        ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
+        UserCodespacesCodespaceNameMachinesGetResponse200Type,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+        UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    )
 
 
 class CodespacesClient:
@@ -93,7 +117,7 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesGetResponse200]:
+    ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
         from ..models import BasicError, OrgsOrgCodespacesGetResponse200
@@ -128,7 +152,7 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesGetResponse200]:
+    ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
         from ..models import BasicError, OrgsOrgCodespacesGetResponse200
@@ -535,7 +559,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsGetResponse200,
+        OrgsOrgCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgCodespacesSecretsGetResponse200
@@ -564,7 +591,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsGetResponse200,
+        OrgsOrgCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgCodespacesSecretsGetResponse200
@@ -591,7 +621,7 @@ class CodespacesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -612,7 +642,7 @@ class CodespacesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -634,7 +664,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesOrgSecret]:
+    ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-secret"""
 
         from ..models import CodespacesOrgSecret
@@ -656,7 +686,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesOrgSecret]:
+    ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-secret"""
 
         from ..models import CodespacesOrgSecret
@@ -680,7 +710,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_org_secret(
@@ -694,7 +724,7 @@ class CodespacesClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_org_secret(
         self,
@@ -704,7 +734,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#create-or-update-an-organization-secret"""
 
         from ..models import (
@@ -747,7 +777,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_org_secret(
@@ -761,7 +791,7 @@ class CodespacesClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_org_secret(
         self,
@@ -771,7 +801,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#create-or-update-an-organization-secret"""
 
         from ..models import (
@@ -862,7 +892,10 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -898,7 +931,10 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -1174,7 +1210,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgMembersUsernameCodespacesGetResponse200]:
+    ) -> Response[
+        OrgsOrgMembersUsernameCodespacesGetResponse200,
+        OrgsOrgMembersUsernameCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#list-codespaces-for-a-user-in-organization"""
 
         from ..models import BasicError, OrgsOrgMembersUsernameCodespacesGetResponse200
@@ -1210,7 +1249,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgMembersUsernameCodespacesGetResponse200]:
+    ) -> Response[
+        OrgsOrgMembersUsernameCodespacesGetResponse200,
+        OrgsOrgMembersUsernameCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#list-codespaces-for-a-user-in-organization"""
 
         from ..models import BasicError, OrgsOrgMembersUsernameCodespacesGetResponse200
@@ -1245,7 +1287,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#delete-a-codespace-from-the-organization"""
 
         from ..models import (
@@ -1277,7 +1322,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#delete-a-codespace-from-the-organization"""
 
         from ..models import (
@@ -1309,7 +1357,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
         from ..models import Codespace, BasicError
@@ -1338,7 +1386,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
         from ..models import Codespace, BasicError
@@ -1368,7 +1416,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesGetResponse200,
+        ReposOwnerRepoCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-codespaces-in-a-repository-for-the-authenticated-user"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesGetResponse200
@@ -1404,7 +1455,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesGetResponse200,
+        ReposOwnerRepoCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-codespaces-in-a-repository-for-the-authenticated-user"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesGetResponse200
@@ -1440,7 +1494,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_with_repo_for_authenticated_user(
@@ -1463,7 +1517,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def create_with_repo_for_authenticated_user(
         self,
@@ -1473,7 +1527,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-codespace-in-a-repository"""
 
         from typing import Union
@@ -1523,7 +1577,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_with_repo_for_authenticated_user(
@@ -1546,7 +1600,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_create_with_repo_for_authenticated_user(
         self,
@@ -1556,7 +1610,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-codespace-in-a-repository"""
 
         from typing import Union
@@ -1606,7 +1660,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesDevcontainersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200,
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-devcontainer-configurations-in-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -1646,7 +1703,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesDevcontainersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200,
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-devcontainer-configurations-in-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -1687,7 +1747,10 @@ class CodespacesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesMachinesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesMachinesGetResponse200,
+        ReposOwnerRepoCodespacesMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/machines#list-available-machine-types-for-a-repository"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesMachinesGetResponse200
@@ -1725,7 +1788,10 @@ class CodespacesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesMachinesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesMachinesGetResponse200,
+        ReposOwnerRepoCodespacesMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/machines#list-available-machine-types-for-a-repository"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesMachinesGetResponse200
@@ -1762,7 +1828,10 @@ class CodespacesClient:
         client_ip: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesNewGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesNewGetResponse200,
+        ReposOwnerRepoCodespacesNewGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-default-attributes-for-a-codespace"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesNewGetResponse200
@@ -1797,7 +1866,10 @@ class CodespacesClient:
         client_ip: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesNewGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesNewGetResponse200,
+        ReposOwnerRepoCodespacesNewGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-default-attributes-for-a-codespace"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesNewGetResponse200
@@ -1832,7 +1904,10 @@ class CodespacesClient:
         devcontainer_path: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPermissionsCheckForDevcontainer]:
+    ) -> Response[
+        CodespacesPermissionsCheckForDevcontainer,
+        CodespacesPermissionsCheckForDevcontainerType,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#check-if-permissions-defined-by-a-devcontainer-have-been-accepted-by-the-authenticated-user"""
 
         from ..models import (
@@ -1874,7 +1949,10 @@ class CodespacesClient:
         devcontainer_path: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPermissionsCheckForDevcontainer]:
+    ) -> Response[
+        CodespacesPermissionsCheckForDevcontainer,
+        CodespacesPermissionsCheckForDevcontainerType,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#check-if-permissions-defined-by-a-devcontainer-have-been-accepted-by-the-authenticated-user"""
 
         from ..models import (
@@ -1916,7 +1994,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesSecretsGetResponse200,
+        ReposOwnerRepoCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoCodespacesSecretsGetResponse200
@@ -1946,7 +2027,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesSecretsGetResponse200,
+        ReposOwnerRepoCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoCodespacesSecretsGetResponse200
@@ -1974,7 +2058,7 @@ class CodespacesClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -1996,7 +2080,7 @@ class CodespacesClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -2019,7 +2103,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepoCodespacesSecret]:
+    ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-secret"""
 
         from ..models import RepoCodespacesSecret
@@ -2042,7 +2126,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepoCodespacesSecret]:
+    ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-secret"""
 
         from ..models import RepoCodespacesSecret
@@ -2067,7 +2151,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_repo_secret(
@@ -2080,7 +2164,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_repo_secret(
         self,
@@ -2091,7 +2175,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#create-or-update-a-repository-secret"""
 
         from ..models import (
@@ -2131,7 +2215,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_repo_secret(
@@ -2144,7 +2228,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_repo_secret(
         self,
@@ -2155,7 +2239,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#create-or-update-a-repository-secret"""
 
         from ..models import (
@@ -2235,7 +2319,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_with_pr_for_authenticated_user(
@@ -2258,7 +2342,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def create_with_pr_for_authenticated_user(
         self,
@@ -2271,7 +2355,7 @@ class CodespacesClient:
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-codespace-from-a-pull-request"""
 
         from typing import Union
@@ -2321,7 +2405,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_with_pr_for_authenticated_user(
@@ -2344,7 +2428,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_create_with_pr_for_authenticated_user(
         self,
@@ -2357,7 +2441,7 @@ class CodespacesClient:
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-codespace-from-a-pull-request"""
 
         from typing import Union
@@ -2405,7 +2489,7 @@ class CodespacesClient:
         repository_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesGetResponse200]:
+    ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
         from ..models import BasicError, UserCodespacesGetResponse200
@@ -2441,7 +2525,7 @@ class CodespacesClient:
         repository_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesGetResponse200]:
+    ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
         from ..models import BasicError, UserCodespacesGetResponse200
@@ -2476,7 +2560,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -2498,7 +2582,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -2515,7 +2599,7 @@ class CodespacesClient:
         devcontainer_path: Missing[str] = UNSET,
         working_directory: Missing[str] = UNSET,
         idle_timeout_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def create_for_authenticated_user(
         self,
@@ -2525,7 +2609,7 @@ class CodespacesClient:
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-codespace-for-the-authenticated-user"""
 
         from typing import Union
@@ -2573,7 +2657,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -2595,7 +2679,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -2612,7 +2696,7 @@ class CodespacesClient:
         devcontainer_path: Missing[str] = UNSET,
         working_directory: Missing[str] = UNSET,
         idle_timeout_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_create_for_authenticated_user(
         self,
@@ -2622,7 +2706,7 @@ class CodespacesClient:
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-codespace-for-the-authenticated-user"""
 
         from typing import Union
@@ -2670,7 +2754,9 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#list-secrets-for-the-authenticated-user"""
 
         from ..models import UserCodespacesSecretsGetResponse200
@@ -2698,7 +2784,9 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#list-secrets-for-the-authenticated-user"""
 
         from ..models import UserCodespacesSecretsGetResponse200
@@ -2724,7 +2812,7 @@ class CodespacesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesUserPublicKey]:
+    ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
         from ..models import CodespacesUserPublicKey
@@ -2744,7 +2832,7 @@ class CodespacesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesUserPublicKey]:
+    ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
         from ..models import CodespacesUserPublicKey
@@ -2765,7 +2853,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesSecret]:
+    ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
         from ..models import CodespacesSecret
@@ -2786,7 +2874,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesSecret]:
+    ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
         from ..models import CodespacesSecret
@@ -2809,7 +2897,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_secret_for_authenticated_user(
@@ -2821,7 +2909,7 @@ class CodespacesClient:
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_secret_for_authenticated_user(
         self,
@@ -2830,7 +2918,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#create-or-update-a-secret-for-the-authenticated-user"""
 
         from ..models import (
@@ -2872,7 +2960,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_secret_for_authenticated_user(
@@ -2884,7 +2972,7 @@ class CodespacesClient:
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_secret_for_authenticated_user(
         self,
@@ -2893,7 +2981,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#create-or-update-a-secret-for-the-authenticated-user"""
 
         from ..models import (
@@ -2969,7 +3057,10 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#list-selected-repositories-for-a-user-secret"""
 
         from ..models import (
@@ -2999,7 +3090,10 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#list-selected-repositories-for-a-user-secret"""
 
         from ..models import (
@@ -3261,7 +3355,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3288,7 +3382,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3315,7 +3409,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#delete-a-codespace-for-the-authenticated-user"""
 
         from ..models import (
@@ -3345,7 +3442,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#delete-a-codespace-for-the-authenticated-user"""
 
         from ..models import (
@@ -3377,7 +3477,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def update_for_authenticated_user(
@@ -3389,7 +3489,7 @@ class CodespacesClient:
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def update_for_authenticated_user(
         self,
@@ -3398,7 +3498,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#update-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError, UserCodespacesCodespaceNamePatchBody
@@ -3436,7 +3536,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_update_for_authenticated_user(
@@ -3448,7 +3548,7 @@ class CodespacesClient:
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_update_for_authenticated_user(
         self,
@@ -3457,7 +3557,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#update-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError, UserCodespacesCodespaceNamePatchBody
@@ -3493,7 +3593,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
         from ..models import BasicError, ValidationError, CodespaceExportDetails
@@ -3521,7 +3621,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
         from ..models import BasicError, ValidationError, CodespaceExportDetails
@@ -3550,7 +3650,7 @@ class CodespacesClient:
         export_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
         from ..models import BasicError, CodespaceExportDetails
@@ -3575,7 +3675,7 @@ class CodespacesClient:
         export_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
         from ..models import BasicError, CodespaceExportDetails
@@ -3599,7 +3699,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesCodespaceNameMachinesGetResponse200]:
+    ) -> Response[
+        UserCodespacesCodespaceNameMachinesGetResponse200,
+        UserCodespacesCodespaceNameMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/machines#list-machine-types-for-a-codespace"""
 
         from ..models import (
@@ -3629,7 +3732,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesCodespaceNameMachinesGetResponse200]:
+    ) -> Response[
+        UserCodespacesCodespaceNameMachinesGetResponse200,
+        UserCodespacesCodespaceNameMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/machines#list-machine-types-for-a-codespace"""
 
         from ..models import (
@@ -3661,7 +3767,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     @overload
     def publish_for_authenticated_user(
@@ -3672,7 +3778,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     def publish_for_authenticated_user(
         self,
@@ -3681,7 +3787,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodespaceWithFullRepository]:
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-repository-from-an-unpublished-codespace"""
 
         from ..models import (
@@ -3727,7 +3833,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     @overload
     async def async_publish_for_authenticated_user(
@@ -3738,7 +3844,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     async def async_publish_for_authenticated_user(
         self,
@@ -3747,7 +3853,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodespaceWithFullRepository]:
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#create-a-repository-from-an-unpublished-codespace"""
 
         from ..models import (
@@ -3791,7 +3897,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3821,7 +3927,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3851,7 +3957,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3878,7 +3984,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError

--- a/githubkit/versions/ghec_v2022_11_28/rest/copilot.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/copilot.py
@@ -24,12 +24,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
-        OrgsOrgCopilotBillingSelectedUsersPostBodyType,
-        OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
-        OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
-    )
     from ..models import (
         CopilotSeatDetails,
         CopilotUsageMetrics,
@@ -41,6 +35,22 @@ if TYPE_CHECKING:
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
         EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
+    )
+    from ..types import (
+        CopilotSeatDetailsType,
+        CopilotUsageMetricsType,
+        CopilotUsageMetricsDayType,
+        CopilotOrganizationDetailsType,
+        OrgsOrgCopilotBillingSeatsGetResponse200Type,
+        OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
+        OrgsOrgCopilotBillingSelectedUsersPostBodyType,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
+        OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
     )
 
 
@@ -66,7 +76,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-enterprise"""
 
         from ..models import (
@@ -104,7 +117,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-enterprise"""
 
         from ..models import (
@@ -144,7 +160,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -183,7 +199,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -222,7 +238,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-enterprise-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -261,7 +277,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-enterprise-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -301,7 +317,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -341,7 +357,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -381,7 +397,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -421,7 +437,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -456,7 +472,7 @@ class CopilotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotOrganizationDetails]:
+    ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
         from ..models import BasicError, CopilotOrganizationDetails
@@ -483,7 +499,7 @@ class CopilotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotOrganizationDetails]:
+    ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
         from ..models import BasicError, CopilotOrganizationDetails
@@ -512,7 +528,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSeatsGetResponse200,
+        OrgsOrgCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-organization"""
 
         from ..models import BasicError, OrgsOrgCopilotBillingSeatsGetResponse200
@@ -547,7 +566,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSeatsGetResponse200,
+        OrgsOrgCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-organization"""
 
         from ..models import BasicError, OrgsOrgCopilotBillingSeatsGetResponse200
@@ -582,7 +604,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     @overload
     def add_copilot_seats_for_teams(
@@ -592,7 +617,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     def add_copilot_seats_for_teams(
         self,
@@ -601,7 +629,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#add-teams-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -646,7 +677,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_add_copilot_seats_for_teams(
@@ -656,7 +690,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     async def async_add_copilot_seats_for_teams(
         self,
@@ -665,7 +702,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#add-teams-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -710,7 +750,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     @overload
     def cancel_copilot_seat_assignment_for_teams(
@@ -720,7 +763,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     def cancel_copilot_seat_assignment_for_teams(
         self,
@@ -729,7 +775,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#remove-teams-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -774,7 +823,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     @overload
     async def async_cancel_copilot_seat_assignment_for_teams(
@@ -784,7 +836,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     async def async_cancel_copilot_seat_assignment_for_teams(
         self,
@@ -793,7 +848,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#remove-teams-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -838,7 +896,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     @overload
     def add_copilot_seats_for_users(
@@ -848,7 +909,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     def add_copilot_seats_for_users(
         self,
@@ -857,7 +921,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#add-users-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -902,7 +969,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_add_copilot_seats_for_users(
@@ -912,7 +982,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     async def async_add_copilot_seats_for_users(
         self,
@@ -921,7 +994,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#add-users-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -966,7 +1042,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     @overload
     def cancel_copilot_seat_assignment_for_users(
@@ -976,7 +1055,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     def cancel_copilot_seat_assignment_for_users(
         self,
@@ -985,7 +1067,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#remove-users-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -1030,7 +1115,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     @overload
     async def async_cancel_copilot_seat_assignment_for_users(
@@ -1040,7 +1128,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     async def async_cancel_copilot_seat_assignment_for_users(
         self,
@@ -1049,7 +1140,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#remove-users-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -1096,7 +1190,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1135,7 +1229,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1174,7 +1268,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -1213,7 +1307,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -1249,7 +1343,7 @@ class CopilotClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotSeatDetails]:
+    ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
         from ..models import BasicError, CopilotSeatDetails
@@ -1277,7 +1371,7 @@ class CopilotClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotSeatDetails]:
+    ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
         from ..models import BasicError, CopilotSeatDetails
@@ -1309,7 +1403,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1349,7 +1443,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1389,7 +1483,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -1429,7 +1523,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetrics

--- a/githubkit/versions/ghec_v2022_11_28/rest/dependabot.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/dependabot.py
@@ -26,12 +26,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        OrgsOrgDependabotSecretsSecretNamePutBodyType,
-        ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
-        ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
-        OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
-    )
     from ..models import (
         EmptyObject,
         DependabotAlert,
@@ -42,6 +36,21 @@ if TYPE_CHECKING:
         OrgsOrgDependabotSecretsGetResponse200,
         ReposOwnerRepoDependabotSecretsGetResponse200,
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
+    )
+    from ..types import (
+        EmptyObjectType,
+        DependabotAlertType,
+        DependabotSecretType,
+        DependabotPublicKeyType,
+        OrganizationDependabotSecretType,
+        DependabotAlertWithRepositoryType,
+        OrgsOrgDependabotSecretsGetResponse200Type,
+        OrgsOrgDependabotSecretsSecretNamePutBodyType,
+        ReposOwnerRepoDependabotSecretsGetResponse200Type,
+        ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
+        ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
     )
 
 
@@ -77,7 +86,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -135,7 +146,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -193,7 +206,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-an-organization"""
 
         from ..models import (
@@ -252,7 +267,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-an-organization"""
 
         from ..models import (
@@ -301,7 +318,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsGetResponse200,
+        OrgsOrgDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgDependabotSecretsGetResponse200
@@ -330,7 +350,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsGetResponse200,
+        OrgsOrgDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgDependabotSecretsGetResponse200
@@ -357,7 +380,7 @@ class DependabotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-public-key"""
 
         from ..models import DependabotPublicKey
@@ -378,7 +401,7 @@ class DependabotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-public-key"""
 
         from ..models import DependabotPublicKey
@@ -400,7 +423,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationDependabotSecret]:
+    ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationDependabotSecret
@@ -422,7 +445,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationDependabotSecret]:
+    ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationDependabotSecret
@@ -446,7 +469,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_org_secret(
@@ -460,7 +483,7 @@ class DependabotClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_org_secret(
         self,
@@ -470,7 +493,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgDependabotSecretsSecretNamePutBody
@@ -504,7 +527,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_org_secret(
@@ -518,7 +541,7 @@ class DependabotClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_org_secret(
         self,
@@ -528,7 +551,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgDependabotSecretsSecretNamePutBody
@@ -600,7 +623,10 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -632,7 +658,10 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -884,7 +913,7 @@ class DependabotClient:
         last: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlert]]:
+    ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
         from ..models import BasicError, DependabotAlert, ValidationErrorSimple
@@ -944,7 +973,7 @@ class DependabotClient:
         last: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlert]]:
+    ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
         from ..models import BasicError, DependabotAlert, ValidationErrorSimple
@@ -991,7 +1020,7 @@ class DependabotClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#get-a-dependabot-alert"""
 
         from ..models import BasicError, DependabotAlert
@@ -1018,7 +1047,7 @@ class DependabotClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#get-a-dependabot-alert"""
 
         from ..models import BasicError, DependabotAlert
@@ -1047,7 +1076,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     @overload
     def update_alert(
@@ -1069,7 +1098,7 @@ class DependabotClient:
             ]
         ] = UNSET,
         dismissed_comment: Missing[str] = UNSET,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     def update_alert(
         self,
@@ -1080,7 +1109,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#update-a-dependabot-alert"""
 
         from ..models import (
@@ -1129,7 +1158,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     @overload
     async def async_update_alert(
@@ -1151,7 +1180,7 @@ class DependabotClient:
             ]
         ] = UNSET,
         dismissed_comment: Missing[str] = UNSET,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     async def async_update_alert(
         self,
@@ -1162,7 +1191,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#update-a-dependabot-alert"""
 
         from ..models import (
@@ -1210,7 +1239,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoDependabotSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoDependabotSecretsGetResponse200,
+        ReposOwnerRepoDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoDependabotSecretsGetResponse200
@@ -1240,7 +1272,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoDependabotSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoDependabotSecretsGetResponse200,
+        ReposOwnerRepoDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoDependabotSecretsGetResponse200
@@ -1268,7 +1303,7 @@ class DependabotClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-public-key"""
 
         from ..models import DependabotPublicKey
@@ -1290,7 +1325,7 @@ class DependabotClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-public-key"""
 
         from ..models import DependabotPublicKey
@@ -1313,7 +1348,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotSecret]:
+    ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-secret"""
 
         from ..models import DependabotSecret
@@ -1336,7 +1371,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotSecret]:
+    ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-secret"""
 
         from ..models import DependabotSecret
@@ -1361,7 +1396,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_repo_secret(
@@ -1374,7 +1409,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_repo_secret(
         self,
@@ -1385,7 +1420,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#create-or-update-a-repository-secret"""
 
         from ..models import (
@@ -1425,7 +1460,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_repo_secret(
@@ -1438,7 +1473,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_repo_secret(
         self,
@@ -1449,7 +1484,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#create-or-update-a-repository-secret"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/dependency_graph.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/dependency_graph.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
         SnapshotPropJobType,
         SnapshotPropDetectorType,
         SnapshotPropManifestsType,
+        DependencyGraphSpdxSbomType,
+        DependencyGraphDiffItemsType,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
     )
 
 
@@ -63,7 +66,7 @@ class DependencyGraphClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependencyGraphDiffItems]]:
+    ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
         from ..models import BasicError, DependencyGraphDiffItems
@@ -96,7 +99,7 @@ class DependencyGraphClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependencyGraphDiffItems]]:
+    ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
         from ..models import BasicError, DependencyGraphDiffItems
@@ -127,7 +130,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependencyGraphSpdxSbom]:
+    ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
         from ..models import BasicError, DependencyGraphSpdxSbom
@@ -153,7 +156,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependencyGraphSpdxSbom]:
+    ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
         from ..models import BasicError, DependencyGraphSpdxSbom
@@ -181,7 +184,10 @@ class DependencyGraphClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: SnapshotType,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     @overload
     def create_repository_snapshot(
@@ -199,7 +205,10 @@ class DependencyGraphClient:
         metadata: Missing[MetadataType] = UNSET,
         manifests: Missing[SnapshotPropManifestsType] = UNSET,
         scanned: datetime,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     def create_repository_snapshot(
         self,
@@ -209,7 +218,10 @@ class DependencyGraphClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository"""
 
         from ..models import (
@@ -246,7 +258,10 @@ class DependencyGraphClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: SnapshotType,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_create_repository_snapshot(
@@ -264,7 +279,10 @@ class DependencyGraphClient:
         metadata: Missing[MetadataType] = UNSET,
         manifests: Missing[SnapshotPropManifestsType] = UNSET,
         scanned: datetime,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     async def async_create_repository_snapshot(
         self,
@@ -274,7 +292,10 @@ class DependencyGraphClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/emojis.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/emojis.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import EmojisGetResponse200
+    from ..types import EmojisGetResponse200Type
 
 
 class EmojisClient:
@@ -40,7 +41,7 @@ class EmojisClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmojisGetResponse200]:
+    ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/emojis/emojis#get-emojis"""
 
         from ..models import EmojisGetResponse200
@@ -60,7 +61,7 @@ class EmojisClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmojisGetResponse200]:
+    ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/emojis/emojis#get-emojis"""
 
         from ..models import EmojisGetResponse200

--- a/githubkit/versions/ghec_v2022_11_28/rest/enterprise_admin.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/enterprise_admin.py
@@ -27,27 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        UserType,
-        GroupType,
-        UserNameType,
-        PatchSchemaType,
-        AnnouncementType,
-        UserRoleItemsType,
-        SelectedActionsType,
-        UserEmailsItemsType,
-        GroupPropMembersItemsType,
-        PatchSchemaPropOperationsItemsType,
-        EnterprisesEnterpriseActionsPermissionsPutBodyType,
-        EnterprisesEnterpriseActionsRunnerGroupsPostBodyType,
-        EnterprisesEnterpriseCodeSecurityAndAnalysisPatchBodyType,
-        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType,
-        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType,
-        EnterprisesEnterpriseActionsPermissionsOrganizationsPutBodyType,
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsPutBodyType,
-    )
     from ..models import (
         Runner,
         AuditLogEvent,
@@ -72,6 +51,48 @@ if TYPE_CHECKING:
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200,
     )
+    from ..types import (
+        UserType,
+        GroupType,
+        RunnerType,
+        UserNameType,
+        PatchSchemaType,
+        AnnouncementType,
+        AuditLogEventType,
+        UserRoleItemsType,
+        SelectedActionsType,
+        UserEmailsItemsType,
+        RunnerApplicationType,
+        AnnouncementBannerType,
+        AuthenticationTokenType,
+        GetConsumedLicensesType,
+        GetLicenseSyncStatusType,
+        GroupPropMembersItemsType,
+        RunnerGroupsEnterpriseType,
+        ScimEnterpriseUserListType,
+        ScimEnterpriseGroupListType,
+        ScimEnterpriseUserResponseType,
+        ScimEnterpriseGroupResponseType,
+        ActionsEnterprisePermissionsType,
+        PatchSchemaPropOperationsItemsType,
+        EnterpriseSecurityAnalysisSettingsType,
+        EnterprisesEnterpriseActionsPermissionsPutBodyType,
+        EnterprisesEnterpriseActionsRunnerGroupsPostBodyType,
+        EnterprisesEnterpriseActionsRunnersGetResponse200Type,
+        EnterprisesEnterpriseCodeSecurityAndAnalysisPatchBodyType,
+        EnterprisesEnterpriseActionsRunnerGroupsGetResponse200Type,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType,
+        EnterprisesEnterpriseActionsPermissionsOrganizationsPutBodyType,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+        EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200Type,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsPutBodyType,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200Type,
+    )
 
 
 class EnterpriseAdminClient:
@@ -94,7 +115,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsEnterprisePermissions]:
+    ) -> Response[ActionsEnterprisePermissions, ActionsEnterprisePermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-enterprise"""
 
         from ..models import ActionsEnterprisePermissions
@@ -115,7 +136,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsEnterprisePermissions]:
+    ) -> Response[ActionsEnterprisePermissions, ActionsEnterprisePermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-enterprise"""
 
         from ..models import ActionsEnterprisePermissions
@@ -246,7 +267,10 @@ class EnterpriseAdminClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200,
+        EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#list-selected-organizations-enabled-for-github-actions-in-an-enterprise"""
 
         from ..models import (
@@ -277,7 +301,10 @@ class EnterpriseAdminClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200,
+        EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#list-selected-organizations-enabled-for-github-actions-in-an-enterprise"""
 
         from ..models import (
@@ -492,7 +519,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-enterprise"""
 
         from ..models import SelectedActions
@@ -513,7 +540,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-enterprise"""
 
         from ..models import SelectedActions
@@ -643,7 +670,10 @@ class EnterpriseAdminClient:
         visible_to_organization: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnerGroupsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnerGroupsGetResponse200,
+        EnterprisesEnterpriseActionsRunnerGroupsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-enterprise"""
 
         from ..models import EnterprisesEnterpriseActionsRunnerGroupsGetResponse200
@@ -674,7 +704,10 @@ class EnterpriseAdminClient:
         visible_to_organization: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnerGroupsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnerGroupsGetResponse200,
+        EnterprisesEnterpriseActionsRunnerGroupsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-enterprise"""
 
         from ..models import EnterprisesEnterpriseActionsRunnerGroupsGetResponse200
@@ -704,7 +737,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsPostBodyType,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     @overload
     def create_self_hosted_runner_group_for_enterprise(
@@ -720,7 +753,7 @@ class EnterpriseAdminClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     def create_self_hosted_runner_group_for_enterprise(
         self,
@@ -729,7 +762,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[EnterprisesEnterpriseActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsEnterprise]:
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-enterprise"""
 
         from ..models import (
@@ -767,7 +800,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsPostBodyType,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     @overload
     async def async_create_self_hosted_runner_group_for_enterprise(
@@ -783,7 +816,7 @@ class EnterpriseAdminClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     async def async_create_self_hosted_runner_group_for_enterprise(
         self,
@@ -792,7 +825,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[EnterprisesEnterpriseActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsEnterprise]:
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-enterprise"""
 
         from ..models import (
@@ -829,7 +862,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RunnerGroupsEnterprise]:
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-enterprise"""
 
         from ..models import RunnerGroupsEnterprise
@@ -851,7 +884,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RunnerGroupsEnterprise]:
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-enterprise"""
 
         from ..models import RunnerGroupsEnterprise
@@ -915,7 +948,7 @@ class EnterpriseAdminClient:
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     @overload
     def update_self_hosted_runner_group_for_enterprise(
@@ -930,7 +963,7 @@ class EnterpriseAdminClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     def update_self_hosted_runner_group_for_enterprise(
         self,
@@ -942,7 +975,7 @@ class EnterpriseAdminClient:
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsEnterprise]:
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-enterprise"""
 
         from ..models import (
@@ -983,7 +1016,7 @@ class EnterpriseAdminClient:
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     @overload
     async def async_update_self_hosted_runner_group_for_enterprise(
@@ -998,7 +1031,7 @@ class EnterpriseAdminClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsEnterprise]: ...
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
     async def async_update_self_hosted_runner_group_for_enterprise(
         self,
@@ -1010,7 +1043,7 @@ class EnterpriseAdminClient:
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsEnterprise]:
+    ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-enterprise"""
 
         from ..models import (
@@ -1050,7 +1083,8 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-organization-access-to-a-self-hosted-runner-group-in-an-enterprise"""
 
@@ -1084,7 +1118,8 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-organization-access-to-a-self-hosted-runner-group-in-an-enterprise"""
 
@@ -1320,7 +1355,8 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-enterprise"""
 
@@ -1356,7 +1392,8 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
+        EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-enterprise"""
 
@@ -1597,7 +1634,10 @@ class EnterpriseAdminClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGetResponse200,
+        EnterprisesEnterpriseActionsRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-enterprise"""
 
         from ..models import EnterprisesEnterpriseActionsRunnersGetResponse200
@@ -1628,7 +1668,10 @@ class EnterpriseAdminClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersGetResponse200,
+        EnterprisesEnterpriseActionsRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-enterprise"""
 
         from ..models import EnterprisesEnterpriseActionsRunnersGetResponse200
@@ -1656,7 +1699,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-enterprise"""
 
         from ..models import RunnerApplication
@@ -1677,7 +1720,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-enterprise"""
 
         from ..models import RunnerApplication
@@ -1698,7 +1741,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-enterprise"""
 
         from ..models import AuthenticationToken
@@ -1719,7 +1762,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-enterprise"""
 
         from ..models import AuthenticationToken
@@ -1740,7 +1783,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-enterprise"""
 
         from ..models import AuthenticationToken
@@ -1761,7 +1804,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-enterprise"""
 
         from ..models import AuthenticationToken
@@ -1783,7 +1826,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import Runner
@@ -1805,7 +1848,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import Runner
@@ -1865,7 +1908,10 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -1893,7 +1939,10 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -1923,7 +1972,10 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def set_custom_labels_for_self_hosted_runner_for_enterprise(
@@ -1934,7 +1986,10 @@ class EnterpriseAdminClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def set_custom_labels_for_self_hosted_runner_for_enterprise(
         self,
@@ -1946,7 +2001,10 @@ class EnterpriseAdminClient:
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -1991,7 +2049,10 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_set_custom_labels_for_self_hosted_runner_for_enterprise(
@@ -2002,7 +2063,10 @@ class EnterpriseAdminClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_set_custom_labels_for_self_hosted_runner_for_enterprise(
         self,
@@ -2014,7 +2078,10 @@ class EnterpriseAdminClient:
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2059,7 +2126,10 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def add_custom_labels_to_self_hosted_runner_for_enterprise(
@@ -2070,7 +2140,10 @@ class EnterpriseAdminClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def add_custom_labels_to_self_hosted_runner_for_enterprise(
         self,
@@ -2082,7 +2155,10 @@ class EnterpriseAdminClient:
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2127,7 +2203,10 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_add_custom_labels_to_self_hosted_runner_for_enterprise(
@@ -2138,7 +2217,10 @@ class EnterpriseAdminClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_add_custom_labels_to_self_hosted_runner_for_enterprise(
         self,
@@ -2150,7 +2232,10 @@ class EnterpriseAdminClient:
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2193,7 +2278,10 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2223,7 +2311,10 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2254,7 +2345,10 @@ class EnterpriseAdminClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2285,7 +2379,10 @@ class EnterpriseAdminClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
+        EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-enterprise"""
 
         from ..models import (
@@ -2314,7 +2411,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#get-announcement-banner-for-enterprise"""
 
         from ..models import AnnouncementBanner
@@ -2335,7 +2432,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#get-announcement-banner-for-enterprise"""
 
         from ..models import AnnouncementBanner
@@ -2394,7 +2491,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AnnouncementType,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     @overload
     def set_announcement_banner_for_enterprise(
@@ -2405,7 +2502,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     def set_announcement_banner_for_enterprise(
         self,
@@ -2414,7 +2511,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#set-announcement-banner-for-enterprise"""
 
         from ..models import Announcement, AnnouncementBanner
@@ -2447,7 +2544,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AnnouncementType,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     @overload
     async def async_set_announcement_banner_for_enterprise(
@@ -2458,7 +2555,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     async def async_set_announcement_banner_for_enterprise(
         self,
@@ -2467,7 +2564,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#set-announcement-banner-for-enterprise"""
 
         from ..models import Announcement, AnnouncementBanner
@@ -2505,7 +2602,7 @@ class EnterpriseAdminClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[AuditLogEvent]]:
+    ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-for-an-enterprise"""
 
         from ..models import AuditLogEvent
@@ -2544,7 +2641,7 @@ class EnterpriseAdminClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[AuditLogEvent]]:
+    ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-for-an-enterprise"""
 
         from ..models import AuditLogEvent
@@ -2576,7 +2673,9 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterpriseSecurityAnalysisSettings]:
+    ) -> Response[
+        EnterpriseSecurityAnalysisSettings, EnterpriseSecurityAnalysisSettingsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#get-code-security-and-analysis-features-for-an-enterprise"""
 
         from ..models import BasicError, EnterpriseSecurityAnalysisSettings
@@ -2600,7 +2699,9 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterpriseSecurityAnalysisSettings]:
+    ) -> Response[
+        EnterpriseSecurityAnalysisSettings, EnterpriseSecurityAnalysisSettingsType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#get-code-security-and-analysis-features-for-an-enterprise"""
 
         from ..models import BasicError, EnterpriseSecurityAnalysisSettings
@@ -2772,7 +2873,7 @@ class EnterpriseAdminClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GetConsumedLicenses]:
+    ) -> Response[GetConsumedLicenses, GetConsumedLicensesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#list-enterprise-consumed-licenses"""
 
         from ..models import GetConsumedLicenses
@@ -2801,7 +2902,7 @@ class EnterpriseAdminClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GetConsumedLicenses]:
+    ) -> Response[GetConsumedLicenses, GetConsumedLicensesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#list-enterprise-consumed-licenses"""
 
         from ..models import GetConsumedLicenses
@@ -2828,7 +2929,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GetLicenseSyncStatus]:
+    ) -> Response[GetLicenseSyncStatus, GetLicenseSyncStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#get-a-license-sync-status"""
 
         from ..models import GetLicenseSyncStatus
@@ -2849,7 +2950,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GetLicenseSyncStatus]:
+    ) -> Response[GetLicenseSyncStatus, GetLicenseSyncStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#get-a-license-sync-status"""
 
         from ..models import GetLicenseSyncStatus
@@ -2938,7 +3039,7 @@ class EnterpriseAdminClient:
         count: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseGroupList]:
+    ) -> Response[ScimEnterpriseGroupList, ScimEnterpriseGroupListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise"""
 
         from ..models import ScimError, ScimEnterpriseGroupList
@@ -2976,7 +3077,7 @@ class EnterpriseAdminClient:
         count: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseGroupList]:
+    ) -> Response[ScimEnterpriseGroupList, ScimEnterpriseGroupListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise"""
 
         from ..models import ScimError, ScimEnterpriseGroupList
@@ -3012,7 +3113,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GroupType,
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     @overload
     def provision_enterprise_group(
@@ -3025,7 +3126,7 @@ class EnterpriseAdminClient:
         external_id: str,
         display_name: str,
         members: list[GroupPropMembersItemsType],
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     def provision_enterprise_group(
         self,
@@ -3034,7 +3135,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseGroupResponse]:
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#provision-a-scim-enterprise-group"""
 
         from ..models import Group, ScimError, ScimEnterpriseGroupResponse
@@ -3072,7 +3173,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GroupType,
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     @overload
     async def async_provision_enterprise_group(
@@ -3085,7 +3186,7 @@ class EnterpriseAdminClient:
         external_id: str,
         display_name: str,
         members: list[GroupPropMembersItemsType],
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     async def async_provision_enterprise_group(
         self,
@@ -3094,7 +3195,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseGroupResponse]:
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#provision-a-scim-enterprise-group"""
 
         from ..models import Group, ScimError, ScimEnterpriseGroupResponse
@@ -3132,7 +3233,7 @@ class EnterpriseAdminClient:
         excluded_attributes: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseGroupResponse]:
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group"""
 
         from ..models import ScimError, BasicError, ScimEnterpriseGroupResponse
@@ -3166,7 +3267,7 @@ class EnterpriseAdminClient:
         excluded_attributes: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseGroupResponse]:
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group"""
 
         from ..models import ScimError, BasicError, ScimEnterpriseGroupResponse
@@ -3201,7 +3302,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GroupType,
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     @overload
     def set_information_for_provisioned_enterprise_group(
@@ -3215,7 +3316,7 @@ class EnterpriseAdminClient:
         external_id: str,
         display_name: str,
         members: list[GroupPropMembersItemsType],
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     def set_information_for_provisioned_enterprise_group(
         self,
@@ -3225,7 +3326,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseGroupResponse]:
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-group"""
 
         from ..models import Group, ScimError, BasicError, ScimEnterpriseGroupResponse
@@ -3265,7 +3366,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GroupType,
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     @overload
     async def async_set_information_for_provisioned_enterprise_group(
@@ -3279,7 +3380,7 @@ class EnterpriseAdminClient:
         external_id: str,
         display_name: str,
         members: list[GroupPropMembersItemsType],
-    ) -> Response[ScimEnterpriseGroupResponse]: ...
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
     async def async_set_information_for_provisioned_enterprise_group(
         self,
@@ -3289,7 +3390,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseGroupResponse]:
+    ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-group"""
 
         from ..models import Group, ScimError, BasicError, ScimEnterpriseGroupResponse
@@ -3505,7 +3606,7 @@ class EnterpriseAdminClient:
         count: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseUserList]:
+    ) -> Response[ScimEnterpriseUserList, ScimEnterpriseUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise"""
 
         from ..models import ScimError, ScimEnterpriseUserList
@@ -3541,7 +3642,7 @@ class EnterpriseAdminClient:
         count: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseUserList]:
+    ) -> Response[ScimEnterpriseUserList, ScimEnterpriseUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise"""
 
         from ..models import ScimError, ScimEnterpriseUserList
@@ -3576,7 +3677,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserType,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     @overload
     def provision_enterprise_user(
@@ -3593,7 +3694,7 @@ class EnterpriseAdminClient:
         display_name: str,
         emails: list[UserEmailsItemsType],
         roles: Missing[list[UserRoleItemsType]] = UNSET,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     def provision_enterprise_user(
         self,
@@ -3602,7 +3703,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#provision-a-scim-enterprise-user"""
 
         from ..models import User, ScimError, ScimEnterpriseUserResponse
@@ -3640,7 +3741,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserType,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     @overload
     async def async_provision_enterprise_user(
@@ -3657,7 +3758,7 @@ class EnterpriseAdminClient:
         display_name: str,
         emails: list[UserEmailsItemsType],
         roles: Missing[list[UserRoleItemsType]] = UNSET,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     async def async_provision_enterprise_user(
         self,
@@ -3666,7 +3767,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#provision-a-scim-enterprise-user"""
 
         from ..models import User, ScimError, ScimEnterpriseUserResponse
@@ -3703,7 +3804,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user"""
 
         from ..models import ScimError, BasicError, ScimEnterpriseUserResponse
@@ -3731,7 +3832,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user"""
 
         from ..models import ScimError, BasicError, ScimEnterpriseUserResponse
@@ -3761,7 +3862,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserType,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     @overload
     def set_information_for_provisioned_enterprise_user(
@@ -3779,7 +3880,7 @@ class EnterpriseAdminClient:
         display_name: str,
         emails: list[UserEmailsItemsType],
         roles: Missing[list[UserRoleItemsType]] = UNSET,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     def set_information_for_provisioned_enterprise_user(
         self,
@@ -3789,7 +3890,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-user"""
 
         from ..models import User, ScimError, BasicError, ScimEnterpriseUserResponse
@@ -3829,7 +3930,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserType,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     @overload
     async def async_set_information_for_provisioned_enterprise_user(
@@ -3847,7 +3948,7 @@ class EnterpriseAdminClient:
         display_name: str,
         emails: list[UserEmailsItemsType],
         roles: Missing[list[UserRoleItemsType]] = UNSET,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     async def async_set_information_for_provisioned_enterprise_user(
         self,
@@ -3857,7 +3958,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#set-scim-information-for-a-provisioned-enterprise-user"""
 
         from ..models import User, ScimError, BasicError, ScimEnterpriseUserResponse
@@ -3951,7 +4052,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: PatchSchemaType,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     @overload
     def update_attribute_for_enterprise_user(
@@ -3963,7 +4064,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         operations: list[PatchSchemaPropOperationsItemsType],
         schemas: list[Literal["urn:ietf:params:scim:api:messages:2.0:PatchOp"]],
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     def update_attribute_for_enterprise_user(
         self,
@@ -3973,7 +4074,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[PatchSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-user"""
 
         from ..models import (
@@ -4018,7 +4119,7 @@ class EnterpriseAdminClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: PatchSchemaType,
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     @overload
     async def async_update_attribute_for_enterprise_user(
@@ -4030,7 +4131,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         operations: list[PatchSchemaPropOperationsItemsType],
         schemas: list[Literal["urn:ietf:params:scim:api:messages:2.0:PatchOp"]],
-    ) -> Response[ScimEnterpriseUserResponse]: ...
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
     async def async_update_attribute_for_enterprise_user(
         self,
@@ -4040,7 +4141,7 @@ class EnterpriseAdminClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[PatchSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[ScimEnterpriseUserResponse]:
+    ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#update-an-attribute-for-a-scim-enterprise-user"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/gists.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/gists.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
 
     from ..models import BaseGist, GistCommit, GistSimple, GistComment
     from ..types import (
+        BaseGistType,
+        GistCommitType,
+        GistSimpleType,
+        GistCommentType,
         GistsPostBodyType,
         GistsGistIdPatchBodyType,
         GistsPostBodyPropFilesType,
@@ -60,7 +64,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-the-authenticated-user"""
 
         from ..models import BaseGist, BasicError
@@ -93,7 +97,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-the-authenticated-user"""
 
         from ..models import BaseGist, BasicError
@@ -122,7 +126,7 @@ class GistsClient:
     @overload
     def create(
         self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     def create(
@@ -133,7 +137,7 @@ class GistsClient:
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     def create(
         self,
@@ -141,7 +145,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#create-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsPostBody, ValidationError
@@ -175,7 +179,7 @@ class GistsClient:
     @overload
     async def async_create(
         self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     async def async_create(
@@ -186,7 +190,7 @@ class GistsClient:
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     async def async_create(
         self,
@@ -194,7 +198,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#create-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsPostBody, ValidationError
@@ -232,7 +236,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-public-gists"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -266,7 +270,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-public-gists"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -300,7 +304,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-starred-gists"""
 
         from ..models import BaseGist, BasicError
@@ -334,7 +338,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-starred-gists"""
 
         from ..models import BaseGist, BasicError
@@ -366,7 +370,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsGistIdGetResponse403
@@ -391,7 +395,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsGistIdGetResponse403
@@ -466,7 +470,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     def update(
@@ -477,7 +481,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     def update(
         self,
@@ -486,7 +490,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#update-a-gist"""
 
         from typing import Union
@@ -530,7 +534,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     async def async_update(
@@ -541,7 +545,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     async def async_update(
         self,
@@ -550,7 +554,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#update-a-gist"""
 
         from typing import Union
@@ -594,7 +598,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistComment]]:
+    ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#list-gist-comments"""
 
         from ..models import BasicError, GistComment
@@ -627,7 +631,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistComment]]:
+    ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#list-gist-comments"""
 
         from ..models import BasicError, GistComment
@@ -660,7 +664,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     def create_comment(
@@ -670,7 +674,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     def create_comment(
         self,
@@ -679,7 +683,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#create-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdCommentsPostBody
@@ -716,7 +720,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     async def async_create_comment(
@@ -726,7 +730,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     async def async_create_comment(
         self,
@@ -735,7 +739,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#create-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdCommentsPostBody
@@ -771,7 +775,7 @@ class GistsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#get-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdGetResponse403
@@ -797,7 +801,7 @@ class GistsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#get-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdGetResponse403
@@ -875,7 +879,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     def update_comment(
@@ -886,7 +890,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     def update_comment(
         self,
@@ -896,7 +900,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#update-a-gist-comment"""
 
         from ..models import (
@@ -937,7 +941,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     async def async_update_comment(
@@ -948,7 +952,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     async def async_update_comment(
         self,
@@ -958,7 +962,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#update-a-gist-comment"""
 
         from ..models import (
@@ -998,7 +1002,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistCommit]]:
+    ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-commits"""
 
         from ..models import BasicError, GistCommit
@@ -1031,7 +1035,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistCommit]]:
+    ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-commits"""
 
         from ..models import BasicError, GistCommit
@@ -1064,7 +1068,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistSimple]]:
+    ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-forks"""
 
         from ..models import BasicError, GistSimple
@@ -1097,7 +1101,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistSimple]]:
+    ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-forks"""
 
         from ..models import BasicError, GistSimple
@@ -1128,7 +1132,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BaseGist]:
+    ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#fork-a-gist"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -1154,7 +1158,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BaseGist]:
+    ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#fork-a-gist"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -1325,7 +1329,7 @@ class GistsClient:
         sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist-revision"""
 
         from ..models import BasicError, GistSimple, ValidationError
@@ -1352,7 +1356,7 @@ class GistsClient:
         sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist-revision"""
 
         from ..models import BasicError, GistSimple, ValidationError
@@ -1381,7 +1385,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-a-user"""
 
         from ..models import BaseGist, ValidationError
@@ -1415,7 +1419,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-a-user"""
 
         from ..models import BaseGist, ValidationError

--- a/githubkit/versions/ghec_v2022_11_28/rest/git.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/git.py
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
 
     from ..models import Blob, GitRef, GitTag, GitTree, GitCommit, ShortBlob
     from ..types import (
+        BlobType,
+        GitRefType,
+        GitTagType,
+        GitTreeType,
+        GitCommitType,
+        ShortBlobType,
         ReposOwnerRepoGitRefsPostBodyType,
         ReposOwnerRepoGitTagsPostBodyType,
         ReposOwnerRepoGitBlobsPostBodyType,
@@ -64,7 +70,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     @overload
     def create_blob(
@@ -76,7 +82,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     def create_blob(
         self,
@@ -86,7 +92,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ShortBlob]:
+    ) -> Response[ShortBlob, ShortBlobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/blobs#create-a-blob"""
 
         from typing import Union
@@ -134,7 +140,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     @overload
     async def async_create_blob(
@@ -146,7 +152,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     async def async_create_blob(
         self,
@@ -156,7 +162,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ShortBlob]:
+    ) -> Response[ShortBlob, ShortBlobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/blobs#create-a-blob"""
 
         from typing import Union
@@ -203,7 +209,7 @@ class GitClient:
         file_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Blob]:
+    ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/blobs#get-a-blob"""
 
         from ..models import Blob, BasicError, ValidationError
@@ -232,7 +238,7 @@ class GitClient:
         file_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Blob]:
+    ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/blobs#get-a-blob"""
 
         from ..models import Blob, BasicError, ValidationError
@@ -262,7 +268,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     @overload
     def create_commit(
@@ -278,7 +284,7 @@ class GitClient:
         author: Missing[ReposOwnerRepoGitCommitsPostBodyPropAuthorType] = UNSET,
         committer: Missing[ReposOwnerRepoGitCommitsPostBodyPropCommitterType] = UNSET,
         signature: Missing[str] = UNSET,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     def create_commit(
         self,
@@ -288,7 +294,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/commits#create-a-commit"""
 
         from ..models import (
@@ -332,7 +338,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     @overload
     async def async_create_commit(
@@ -348,7 +354,7 @@ class GitClient:
         author: Missing[ReposOwnerRepoGitCommitsPostBodyPropAuthorType] = UNSET,
         committer: Missing[ReposOwnerRepoGitCommitsPostBodyPropCommitterType] = UNSET,
         signature: Missing[str] = UNSET,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     async def async_create_commit(
         self,
@@ -358,7 +364,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/commits#create-a-commit"""
 
         from ..models import (
@@ -401,7 +407,7 @@ class GitClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/commits#get-a-commit-object"""
 
         from ..models import GitCommit, BasicError
@@ -428,7 +434,7 @@ class GitClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/commits#get-a-commit-object"""
 
         from ..models import GitCommit, BasicError
@@ -455,7 +461,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GitRef]]:
+    ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#list-matching-references"""
 
         from ..models import GitRef, BasicError
@@ -481,7 +487,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GitRef]]:
+    ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#list-matching-references"""
 
         from ..models import GitRef, BasicError
@@ -507,7 +513,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#get-a-reference"""
 
         from ..models import GitRef, BasicError
@@ -534,7 +540,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#get-a-reference"""
 
         from ..models import GitRef, BasicError
@@ -562,7 +568,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     def create_ref(
@@ -574,7 +580,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         ref: str,
         sha: str,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     def create_ref(
         self,
@@ -584,7 +590,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#create-a-reference"""
 
         from ..models import (
@@ -627,7 +633,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     async def async_create_ref(
@@ -639,7 +645,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         ref: str,
         sha: str,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     async def async_create_ref(
         self,
@@ -649,7 +655,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#create-a-reference"""
 
         from ..models import (
@@ -745,7 +751,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     def update_ref(
@@ -758,7 +764,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     def update_ref(
         self,
@@ -769,7 +775,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#update-a-reference"""
 
         from ..models import (
@@ -813,7 +819,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     async def async_update_ref(
@@ -826,7 +832,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     async def async_update_ref(
         self,
@@ -837,7 +843,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#update-a-reference"""
 
         from ..models import (
@@ -880,7 +886,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     @overload
     def create_tag(
@@ -895,7 +901,7 @@ class GitClient:
         object_: str,
         type: Literal["commit", "tree", "blob"],
         tagger: Missing[ReposOwnerRepoGitTagsPostBodyPropTaggerType] = UNSET,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     def create_tag(
         self,
@@ -905,7 +911,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/tags#create-a-tag-object"""
 
         from ..models import (
@@ -948,7 +954,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     @overload
     async def async_create_tag(
@@ -963,7 +969,7 @@ class GitClient:
         object_: str,
         type: Literal["commit", "tree", "blob"],
         tagger: Missing[ReposOwnerRepoGitTagsPostBodyPropTaggerType] = UNSET,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     async def async_create_tag(
         self,
@@ -973,7 +979,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/tags#create-a-tag-object"""
 
         from ..models import (
@@ -1015,7 +1021,7 @@ class GitClient:
         tag_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/tags#get-a-tag"""
 
         from ..models import GitTag, BasicError
@@ -1042,7 +1048,7 @@ class GitClient:
         tag_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/tags#get-a-tag"""
 
         from ..models import GitTag, BasicError
@@ -1070,7 +1076,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     @overload
     def create_tree(
@@ -1082,7 +1088,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     def create_tree(
         self,
@@ -1092,7 +1098,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/trees#create-a-tree"""
 
         from ..models import (
@@ -1137,7 +1143,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     @overload
     async def async_create_tree(
@@ -1149,7 +1155,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     async def async_create_tree(
         self,
@@ -1159,7 +1165,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/trees#create-a-tree"""
 
         from ..models import (
@@ -1204,7 +1210,7 @@ class GitClient:
         recursive: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/trees#get-a-tree"""
 
         from ..models import GitTree, BasicError, ValidationError
@@ -1238,7 +1244,7 @@ class GitClient:
         recursive: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/trees#get-a-tree"""
 
         from ..models import GitTree, BasicError, ValidationError

--- a/githubkit/versions/ghec_v2022_11_28/rest/gitignore.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/gitignore.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import GitignoreTemplate
+    from ..types import GitignoreTemplateType
 
 
 class GitignoreClient:
@@ -40,7 +41,7 @@ class GitignoreClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-all-gitignore-templates"""
 
         url = "/gitignore/templates"
@@ -58,7 +59,7 @@ class GitignoreClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-all-gitignore-templates"""
 
         url = "/gitignore/templates"
@@ -77,7 +78,7 @@ class GitignoreClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitignoreTemplate]:
+    ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-a-gitignore-template"""
 
         from ..models import GitignoreTemplate
@@ -98,7 +99,7 @@ class GitignoreClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitignoreTemplate]:
+    ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-a-gitignore-template"""
 
         from ..models import GitignoreTemplate

--- a/githubkit/versions/ghec_v2022_11_28/rest/interactions.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/interactions.py
@@ -26,12 +26,18 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import InteractionLimitType
     from ..models import (
         InteractionLimitResponse,
         UserInteractionLimitsGetResponse200Anyof1,
         OrgsOrgInteractionLimitsGetResponse200Anyof1,
         ReposOwnerRepoInteractionLimitsGetResponse200Anyof1,
+    )
+    from ..types import (
+        InteractionLimitType,
+        InteractionLimitResponseType,
+        UserInteractionLimitsGetResponse200Anyof1Type,
+        OrgsOrgInteractionLimitsGetResponse200Anyof1Type,
+        ReposOwnerRepoInteractionLimitsGetResponse200Anyof1Type,
     )
 
 
@@ -56,7 +62,11 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType,
+            OrgsOrgInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/orgs#get-interaction-restrictions-for-an-organization"""
 
@@ -86,7 +96,11 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType,
+            OrgsOrgInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/orgs#get-interaction-restrictions-for-an-organization"""
 
@@ -117,7 +131,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     def set_restrictions_for_org(
@@ -130,7 +144,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     def set_restrictions_for_org(
         self,
@@ -139,7 +153,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/orgs#set-interaction-restrictions-for-an-organization"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse
@@ -175,7 +189,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     async def async_set_restrictions_for_org(
@@ -188,7 +202,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     async def async_set_restrictions_for_org(
         self,
@@ -197,7 +211,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/orgs#set-interaction-restrictions-for-an-organization"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse
@@ -272,7 +286,11 @@ class InteractionsClient:
         Union[
             InteractionLimitResponse,
             ReposOwnerRepoInteractionLimitsGetResponse200Anyof1,
-        ]
+        ],
+        Union[
+            InteractionLimitResponseType,
+            ReposOwnerRepoInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/repos#get-interaction-restrictions-for-a-repository"""
 
@@ -307,7 +325,11 @@ class InteractionsClient:
         Union[
             InteractionLimitResponse,
             ReposOwnerRepoInteractionLimitsGetResponse200Anyof1,
-        ]
+        ],
+        Union[
+            InteractionLimitResponseType,
+            ReposOwnerRepoInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/repos#get-interaction-restrictions-for-a-repository"""
 
@@ -340,7 +362,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     def set_restrictions_for_repo(
@@ -354,7 +376,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     def set_restrictions_for_repo(
         self,
@@ -364,7 +386,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/repos#set-interaction-restrictions-for-a-repository"""
 
         from ..models import InteractionLimit, InteractionLimitResponse
@@ -399,7 +421,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     async def async_set_restrictions_for_repo(
@@ -413,7 +435,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     async def async_set_restrictions_for_repo(
         self,
@@ -423,7 +445,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/repos#set-interaction-restrictions-for-a-repository"""
 
         from ..models import InteractionLimit, InteractionLimitResponse
@@ -495,7 +517,10 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType, UserInteractionLimitsGetResponse200Anyof1Type
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/user#get-interaction-restrictions-for-your-public-repositories"""
 
@@ -524,7 +549,10 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType, UserInteractionLimitsGetResponse200Anyof1Type
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/user#get-interaction-restrictions-for-your-public-repositories"""
 
@@ -551,7 +579,7 @@ class InteractionsClient:
     @overload
     def set_restrictions_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     def set_restrictions_for_authenticated_user(
@@ -563,7 +591,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     def set_restrictions_for_authenticated_user(
         self,
@@ -571,7 +599,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/user#set-interaction-restrictions-for-your-public-repositories"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse
@@ -603,7 +631,7 @@ class InteractionsClient:
     @overload
     async def async_set_restrictions_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     async def async_set_restrictions_for_authenticated_user(
@@ -615,7 +643,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     async def async_set_restrictions_for_authenticated_user(
         self,
@@ -623,7 +651,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/user#set-interaction-restrictions-for-your-public-repositories"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse

--- a/githubkit/versions/ghec_v2022_11_28/rest/issues.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/issues.py
@@ -60,8 +60,38 @@ if TYPE_CHECKING:
         ReviewRequestRemovedIssueEvent,
     )
     from ..types import (
+        IssueType,
+        LabelType,
+        MilestoneType,
+        IssueEventType,
+        SimpleUserType,
+        IssueCommentType,
+        LockedIssueEventType,
+        LabeledIssueEventType,
+        RenamedIssueEventType,
+        AssignedIssueEventType,
+        UnlabeledIssueEventType,
+        MilestonedIssueEventType,
+        TimelineCommentEventType,
+        UnassignedIssueEventType,
+        StateChangeIssueEventType,
+        TimelineReviewedEventType,
+        DemilestonedIssueEventType,
+        TimelineCommittedEventType,
+        AddedToProjectIssueEventType,
+        ReviewDismissedIssueEventType,
+        ReviewRequestedIssueEventType,
+        TimelineAssignedIssueEventType,
+        TimelineLineCommentedEventType,
+        RemovedFromProjectIssueEventType,
         ReposOwnerRepoIssuesPostBodyType,
         ReposOwnerRepoLabelsPostBodyType,
+        TimelineCommitCommentedEventType,
+        TimelineCrossReferencedEventType,
+        TimelineUnassignedIssueEventType,
+        ConvertedNoteToIssueIssueEventType,
+        MovedColumnInProjectIssueEventType,
+        ReviewRequestRemovedIssueEventType,
         ReposOwnerRepoMilestonesPostBodyType,
         ReposOwnerRepoLabelsNamePatchBodyType,
         ReposOwnerRepoIssuesIssueNumberPatchBodyType,
@@ -117,7 +147,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -171,7 +201,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -222,7 +252,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError
@@ -268,7 +298,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError
@@ -307,7 +337,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#list-assignees"""
 
         from ..models import BasicError, SimpleUser
@@ -340,7 +370,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#list-assignees"""
 
         from ..models import BasicError, SimpleUser
@@ -432,7 +462,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-repository-issues"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -484,7 +514,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-repository-issues"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -527,7 +557,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def create(
@@ -545,7 +575,7 @@ class IssuesClient:
             list[Union[str, ReposOwnerRepoIssuesPostBodyPropLabelsItemsOneof1Type]]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def create(
         self,
@@ -555,7 +585,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#create-an-issue"""
 
         from ..models import (
@@ -603,7 +633,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_create(
@@ -621,7 +651,7 @@ class IssuesClient:
             list[Union[str, ReposOwnerRepoIssuesPostBodyPropLabelsItemsOneof1Type]]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_create(
         self,
@@ -631,7 +661,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#create-an-issue"""
 
         from ..models import (
@@ -682,7 +712,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments-for-a-repository"""
 
         from ..models import BasicError, IssueComment, ValidationError
@@ -722,7 +752,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments-for-a-repository"""
 
         from ..models import BasicError, IssueComment, ValidationError
@@ -758,7 +788,7 @@ class IssuesClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#get-an-issue-comment"""
 
         from ..models import BasicError, IssueComment
@@ -784,7 +814,7 @@ class IssuesClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#get-an-issue-comment"""
 
         from ..models import BasicError, IssueComment
@@ -852,7 +882,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     def update_comment(
@@ -864,7 +894,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     def update_comment(
         self,
@@ -875,7 +905,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#update-an-issue-comment"""
 
         from ..models import (
@@ -919,7 +949,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     async def async_update_comment(
@@ -931,7 +961,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     async def async_update_comment(
         self,
@@ -942,7 +972,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#update-an-issue-comment"""
 
         from ..models import (
@@ -985,7 +1015,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueEvent]]:
+    ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#list-issue-events-for-a-repository"""
 
         from ..models import IssueEvent, ValidationError
@@ -1018,7 +1048,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueEvent]]:
+    ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#list-issue-events-for-a-repository"""
 
         from ..models import IssueEvent, ValidationError
@@ -1050,7 +1080,7 @@ class IssuesClient:
         event_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueEvent]:
+    ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#get-an-issue-event"""
 
         from ..models import BasicError, IssueEvent
@@ -1078,7 +1108,7 @@ class IssuesClient:
         event_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueEvent]:
+    ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#get-an-issue-event"""
 
         from ..models import BasicError, IssueEvent
@@ -1106,7 +1136,7 @@ class IssuesClient:
         issue_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#get-an-issue"""
 
         from ..models import Issue, BasicError
@@ -1133,7 +1163,7 @@ class IssuesClient:
         issue_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#get-an-issue"""
 
         from ..models import Issue, BasicError
@@ -1162,7 +1192,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def update(
@@ -1190,7 +1220,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def update(
         self,
@@ -1201,7 +1231,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#update-an-issue"""
 
         from ..models import (
@@ -1249,7 +1279,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_update(
@@ -1277,7 +1307,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_update(
         self,
@@ -1288,7 +1318,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#update-an-issue"""
 
         from ..models import (
@@ -1336,7 +1366,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def add_assignees(
@@ -1348,7 +1378,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def add_assignees(
         self,
@@ -1359,7 +1389,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#add-assignees-to-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesPostBody
@@ -1396,7 +1426,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_add_assignees(
@@ -1408,7 +1438,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_add_assignees(
         self,
@@ -1419,7 +1449,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#add-assignees-to-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesPostBody
@@ -1456,7 +1486,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def remove_assignees(
@@ -1468,7 +1498,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def remove_assignees(
         self,
@@ -1479,7 +1509,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#remove-assignees-from-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBody
@@ -1516,7 +1546,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_remove_assignees(
@@ -1528,7 +1558,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_remove_assignees(
         self,
@@ -1539,7 +1569,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#remove-assignees-from-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBody
@@ -1629,7 +1659,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments"""
 
         from ..models import BasicError, IssueComment
@@ -1666,7 +1696,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments"""
 
         from ..models import BasicError, IssueComment
@@ -1702,7 +1732,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     def create_comment(
@@ -1714,7 +1744,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     def create_comment(
         self,
@@ -1725,7 +1755,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#create-an-issue-comment"""
 
         from ..models import (
@@ -1773,7 +1803,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     async def async_create_comment(
@@ -1785,7 +1815,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     async def async_create_comment(
         self,
@@ -1796,7 +1826,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#create-an-issue-comment"""
 
         from ..models import (
@@ -1863,7 +1893,26 @@ class IssuesClient:
                 RemovedFromProjectIssueEvent,
                 ConvertedNoteToIssueIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                AssignedIssueEventType,
+                UnassignedIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#list-issue-events"""
 
@@ -1954,7 +2003,26 @@ class IssuesClient:
                 RemovedFromProjectIssueEvent,
                 ConvertedNoteToIssueIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                AssignedIssueEventType,
+                UnassignedIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#list-issue-events"""
 
@@ -2026,7 +2094,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-an-issue"""
 
         from ..models import Label, BasicError
@@ -2061,7 +2129,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-an-issue"""
 
         from ..models import Label, BasicError
@@ -2104,7 +2172,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def set_labels(
@@ -2116,7 +2184,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def set_labels(
@@ -2130,7 +2198,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     def set_labels(
         self,
@@ -2149,7 +2217,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#set-labels-for-an-issue"""
 
         from typing import Union
@@ -2220,7 +2288,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_set_labels(
@@ -2232,7 +2300,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_set_labels(
@@ -2246,7 +2314,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     async def async_set_labels(
         self,
@@ -2265,7 +2333,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#set-labels-for-an-issue"""
 
         from typing import Union
@@ -2336,7 +2404,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def add_labels(
@@ -2348,7 +2416,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def add_labels(
@@ -2362,7 +2430,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     def add_labels(
         self,
@@ -2381,7 +2449,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#add-labels-to-an-issue"""
 
         from typing import Union
@@ -2452,7 +2520,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_add_labels(
@@ -2464,7 +2532,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_add_labels(
@@ -2478,7 +2546,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     async def async_add_labels(
         self,
@@ -2497,7 +2565,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#add-labels-to-an-issue"""
 
         from typing import Union
@@ -2611,7 +2679,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#remove-a-label-from-an-issue"""
 
         from ..models import Label, BasicError
@@ -2639,7 +2707,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#remove-a-label-from-an-issue"""
 
         from ..models import Label, BasicError
@@ -2900,7 +2968,33 @@ class IssuesClient:
                 TimelineUnassignedIssueEvent,
                 StateChangeIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+                TimelineCommentEventType,
+                TimelineCrossReferencedEventType,
+                TimelineCommittedEventType,
+                TimelineReviewedEventType,
+                TimelineLineCommentedEventType,
+                TimelineCommitCommentedEventType,
+                TimelineAssignedIssueEventType,
+                TimelineUnassignedIssueEventType,
+                StateChangeIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/timeline#list-timeline-events-for-an-issue"""
 
@@ -3013,7 +3107,33 @@ class IssuesClient:
                 TimelineUnassignedIssueEvent,
                 StateChangeIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+                TimelineCommentEventType,
+                TimelineCrossReferencedEventType,
+                TimelineCommittedEventType,
+                TimelineReviewedEventType,
+                TimelineLineCommentedEventType,
+                TimelineCommitCommentedEventType,
+                TimelineAssignedIssueEventType,
+                TimelineUnassignedIssueEventType,
+                StateChangeIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/timeline#list-timeline-events-for-an-issue"""
 
@@ -3099,7 +3219,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-a-repository"""
 
         from ..models import Label, BasicError
@@ -3132,7 +3252,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-a-repository"""
 
         from ..models import Label, BasicError
@@ -3165,7 +3285,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     def create_label(
@@ -3178,7 +3298,7 @@ class IssuesClient:
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     def create_label(
         self,
@@ -3188,7 +3308,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#create-a-label"""
 
         from ..models import (
@@ -3231,7 +3351,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     async def async_create_label(
@@ -3244,7 +3364,7 @@ class IssuesClient:
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     async def async_create_label(
         self,
@@ -3254,7 +3374,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#create-a-label"""
 
         from ..models import (
@@ -3296,7 +3416,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#get-a-label"""
 
         from ..models import Label, BasicError
@@ -3322,7 +3442,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#get-a-label"""
 
         from ..models import Label, BasicError
@@ -3390,7 +3510,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     def update_label(
@@ -3404,7 +3524,7 @@ class IssuesClient:
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     def update_label(
         self,
@@ -3415,7 +3535,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#update-a-label"""
 
         from ..models import Label, ReposOwnerRepoLabelsNamePatchBody
@@ -3450,7 +3570,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     async def async_update_label(
@@ -3464,7 +3584,7 @@ class IssuesClient:
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     async def async_update_label(
         self,
@@ -3475,7 +3595,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#update-a-label"""
 
         from ..models import Label, ReposOwnerRepoLabelsNamePatchBody
@@ -3512,7 +3632,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Milestone]]:
+    ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#list-milestones"""
 
         from ..models import Milestone, BasicError
@@ -3551,7 +3671,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Milestone]]:
+    ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#list-milestones"""
 
         from ..models import Milestone, BasicError
@@ -3587,7 +3707,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     def create_milestone(
@@ -3601,7 +3721,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     def create_milestone(
         self,
@@ -3611,7 +3731,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#create-a-milestone"""
 
         from ..models import (
@@ -3654,7 +3774,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     async def async_create_milestone(
@@ -3668,7 +3788,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     async def async_create_milestone(
         self,
@@ -3678,7 +3798,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#create-a-milestone"""
 
         from ..models import (
@@ -3720,7 +3840,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#get-a-milestone"""
 
         from ..models import Milestone, BasicError
@@ -3746,7 +3866,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#get-a-milestone"""
 
         from ..models import Milestone, BasicError
@@ -3824,7 +3944,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     def update_milestone(
@@ -3839,7 +3959,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     def update_milestone(
         self,
@@ -3850,7 +3970,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#update-a-milestone"""
 
         from ..models import Milestone, ReposOwnerRepoMilestonesMilestoneNumberPatchBody
@@ -3887,7 +4007,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     async def async_update_milestone(
@@ -3902,7 +4022,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     async def async_update_milestone(
         self,
@@ -3913,7 +4033,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#update-a-milestone"""
 
         from ..models import Milestone, ReposOwnerRepoMilestonesMilestoneNumberPatchBody
@@ -3950,7 +4070,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
         from ..models import Label
@@ -3981,7 +4101,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
         from ..models import Label
@@ -4017,7 +4137,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError
@@ -4062,7 +4182,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError

--- a/githubkit/versions/ghec_v2022_11_28/rest/licenses.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/licenses.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import License, LicenseSimple, LicenseContent
+    from ..types import LicenseType, LicenseSimpleType, LicenseContentType
 
 
 class LicensesClient:
@@ -46,7 +47,7 @@ class LicensesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[LicenseSimple]]:
+    ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-all-commonly-used-licenses"""
 
         from ..models import LicenseSimple
@@ -76,7 +77,7 @@ class LicensesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[LicenseSimple]]:
+    ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-all-commonly-used-licenses"""
 
         from ..models import LicenseSimple
@@ -104,7 +105,7 @@ class LicensesClient:
         license_: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[License]:
+    ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-a-license"""
 
         from ..models import License, BasicError
@@ -129,7 +130,7 @@ class LicensesClient:
         license_: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[License]:
+    ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-a-license"""
 
         from ..models import License, BasicError
@@ -156,7 +157,7 @@ class LicensesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[LicenseContent]:
+    ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-the-license-for-a-repository"""
 
         from ..models import BasicError, LicenseContent
@@ -187,7 +188,7 @@ class LicensesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[LicenseContent]:
+    ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-the-license-for-a-repository"""
 
         from ..models import BasicError, LicenseContent

--- a/githubkit/versions/ghec_v2022_11_28/rest/markdown.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/markdown.py
@@ -47,7 +47,7 @@ class MarkdownClient:
     @overload
     def render(
         self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     @overload
     def render(
@@ -58,7 +58,7 @@ class MarkdownClient:
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     def render(
         self,
@@ -66,7 +66,7 @@ class MarkdownClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/markdown/markdown#render-a-markdown-document"""
 
         from ..models import MarkdownPostBody
@@ -95,7 +95,7 @@ class MarkdownClient:
     @overload
     async def async_render(
         self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     @overload
     async def async_render(
@@ -106,7 +106,7 @@ class MarkdownClient:
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     async def async_render(
         self,
@@ -114,7 +114,7 @@ class MarkdownClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/markdown/markdown#render-a-markdown-document"""
 
         from ..models import MarkdownPostBody
@@ -145,7 +145,7 @@ class MarkdownClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: str,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""
 
         url = "/markdown/raw"
@@ -171,7 +171,7 @@ class MarkdownClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: str,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""
 
         url = "/markdown/raw"

--- a/githubkit/versions/ghec_v2022_11_28/rest/meta.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/meta.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import Root, ApiOverview
+    from ..types import RootType, ApiOverviewType
 
 
 class MetaClient:
@@ -45,7 +46,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Root]:
+    ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#github-api-root"""
 
         from ..models import Root
@@ -65,7 +66,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Root]:
+    ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#github-api-root"""
 
         from ..models import Root
@@ -85,7 +86,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiOverview]:
+    ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-apiname-meta-information"""
 
         from ..models import ApiOverview
@@ -105,7 +106,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiOverview]:
+    ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-apiname-meta-information"""
 
         from ..models import ApiOverview
@@ -126,7 +127,7 @@ class MetaClient:
         s: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-octocat"""
 
         url = "/octocat"
@@ -150,7 +151,7 @@ class MetaClient:
         s: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-octocat"""
 
         url = "/octocat"
@@ -173,7 +174,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[date]]:
+    ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-all-api-versions"""
 
         from datetime import date
@@ -198,7 +199,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[date]]:
+    ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-all-api-versions"""
 
         from datetime import date
@@ -223,7 +224,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-the-zen-of-github"""
 
         url = "/zen"
@@ -241,7 +242,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-the-zen-of-github"""
 
         url = "/zen"

--- a/githubkit/versions/ghec_v2022_11_28/rest/migrations.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/migrations.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
         MinimalRepository,
     )
     from ..types import (
+        ImportType,
+        MigrationType,
+        PorterAuthorType,
+        PorterLargeFileType,
+        MinimalRepositoryType,
         UserMigrationsPostBodyType,
         OrgsOrgMigrationsPostBodyType,
         ReposOwnerRepoImportPutBodyType,
@@ -66,7 +71,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-organization-migrations"""
 
         from ..models import Migration
@@ -97,7 +102,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-organization-migrations"""
 
         from ..models import Migration
@@ -127,7 +132,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     def start_for_org(
@@ -145,7 +150,7 @@ class MigrationsClient:
         exclude_owner_projects: Missing[bool] = UNSET,
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     def start_for_org(
         self,
@@ -154,7 +159,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#start-an-organization-migration"""
 
         from ..models import (
@@ -196,7 +201,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     async def async_start_for_org(
@@ -214,7 +219,7 @@ class MigrationsClient:
         exclude_owner_projects: Missing[bool] = UNSET,
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     async def async_start_for_org(
         self,
@@ -223,7 +228,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#start-an-organization-migration"""
 
         from ..models import (
@@ -265,7 +270,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#get-an-organization-migration-status"""
 
         from ..models import Migration, BasicError
@@ -296,7 +301,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#get-an-organization-migration-status"""
 
         from ..models import Migration, BasicError
@@ -474,7 +479,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
         from ..models import BasicError, MinimalRepository
@@ -507,7 +512,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
         from ..models import BasicError, MinimalRepository
@@ -538,7 +543,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-an-import-status"""
 
         from ..models import Import, BasicError
@@ -564,7 +569,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-an-import-status"""
 
         from ..models import Import, BasicError
@@ -592,7 +597,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     def start_import(
@@ -607,7 +612,7 @@ class MigrationsClient:
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     def start_import(
         self,
@@ -617,7 +622,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#start-an-import"""
 
         from ..models import (
@@ -661,7 +666,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     async def async_start_import(
@@ -676,7 +681,7 @@ class MigrationsClient:
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     async def async_start_import(
         self,
@@ -686,7 +691,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#start-an-import"""
 
         from ..models import (
@@ -778,7 +783,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     def update_import(
@@ -792,7 +797,7 @@ class MigrationsClient:
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     def update_import(
         self,
@@ -802,7 +807,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#update-an-import"""
 
         from typing import Union
@@ -843,7 +848,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     async def async_update_import(
@@ -857,7 +862,7 @@ class MigrationsClient:
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     async def async_update_import(
         self,
@@ -867,7 +872,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#update-an-import"""
 
         from typing import Union
@@ -907,7 +912,7 @@ class MigrationsClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterAuthor]]:
+    ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-commit-authors"""
 
         from ..models import BasicError, PorterAuthor
@@ -939,7 +944,7 @@ class MigrationsClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterAuthor]]:
+    ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-commit-authors"""
 
         from ..models import BasicError, PorterAuthor
@@ -973,7 +978,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     @overload
     def map_commit_author(
@@ -986,7 +991,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     def map_commit_author(
         self,
@@ -997,7 +1002,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PorterAuthor]:
+    ) -> Response[PorterAuthor, PorterAuthorType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#map-a-commit-author"""
 
         from ..models import (
@@ -1044,7 +1049,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     @overload
     async def async_map_commit_author(
@@ -1057,7 +1062,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     async def async_map_commit_author(
         self,
@@ -1068,7 +1073,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PorterAuthor]:
+    ) -> Response[PorterAuthor, PorterAuthorType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#map-a-commit-author"""
 
         from ..models import (
@@ -1112,7 +1117,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterLargeFile]]:
+    ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-large-files"""
 
         from ..models import BasicError, PorterLargeFile
@@ -1137,7 +1142,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterLargeFile]]:
+    ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-large-files"""
 
         from ..models import BasicError, PorterLargeFile
@@ -1164,7 +1169,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     def set_lfs_preference(
@@ -1175,7 +1180,7 @@ class MigrationsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     def set_lfs_preference(
         self,
@@ -1185,7 +1190,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#update-git-lfs-preference"""
 
         from ..models import (
@@ -1228,7 +1233,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     async def async_set_lfs_preference(
@@ -1239,7 +1244,7 @@ class MigrationsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     async def async_set_lfs_preference(
         self,
@@ -1249,7 +1254,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#update-git-lfs-preference"""
 
         from ..models import (
@@ -1290,7 +1295,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-user-migrations"""
 
         from ..models import Migration, BasicError
@@ -1322,7 +1327,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-user-migrations"""
 
         from ..models import Migration, BasicError
@@ -1354,7 +1359,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     def start_for_authenticated_user(
@@ -1371,7 +1376,7 @@ class MigrationsClient:
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         repositories: list[str],
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     def start_for_authenticated_user(
         self,
@@ -1379,7 +1384,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#start-a-user-migration"""
 
         from ..models import (
@@ -1421,7 +1426,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     async def async_start_for_authenticated_user(
@@ -1438,7 +1443,7 @@ class MigrationsClient:
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         repositories: list[str],
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     async def async_start_for_authenticated_user(
         self,
@@ -1446,7 +1451,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#start-a-user-migration"""
 
         from ..models import (
@@ -1488,7 +1493,7 @@ class MigrationsClient:
         exclude: Missing[list[str]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#get-a-user-migration-status"""
 
         from ..models import Migration, BasicError
@@ -1520,7 +1525,7 @@ class MigrationsClient:
         exclude: Missing[list[str]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#get-a-user-migration-status"""
 
         from ..models import Migration, BasicError
@@ -1703,7 +1708,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-repositories-for-a-user-migration"""
 
         from ..models import BasicError, MinimalRepository
@@ -1735,7 +1740,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-repositories-for-a-user-migration"""
 
         from ..models import BasicError, MinimalRepository

--- a/githubkit/versions/ghec_v2022_11_28/rest/oidc.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/oidc.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from githubkit import GitHubCore
     from githubkit.response import Response
 
-    from ..types import OidcCustomSubType
     from ..models import EmptyObject, OidcCustomSub
+    from ..types import EmptyObjectType, OidcCustomSubType
 
 
 class OidcClient:
@@ -46,7 +46,7 @@ class OidcClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSub]:
+    ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import OidcCustomSub
@@ -67,7 +67,7 @@ class OidcClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSub]:
+    ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import OidcCustomSub
@@ -90,7 +90,7 @@ class OidcClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OidcCustomSubType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def update_oidc_custom_sub_template_for_org(
@@ -100,7 +100,7 @@ class OidcClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         include_claim_keys: list[str],
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def update_oidc_custom_sub_template_for_org(
         self,
@@ -109,7 +109,7 @@ class OidcClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import BasicError, EmptyObject, OidcCustomSub
@@ -146,7 +146,7 @@ class OidcClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OidcCustomSubType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_update_oidc_custom_sub_template_for_org(
@@ -156,7 +156,7 @@ class OidcClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         include_claim_keys: list[str],
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_update_oidc_custom_sub_template_for_org(
         self,
@@ -165,7 +165,7 @@ class OidcClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import BasicError, EmptyObject, OidcCustomSub

--- a/githubkit/versions/ghec_v2022_11_28/rest/orgs.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/orgs.py
@@ -27,33 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        AnnouncementType,
-        CustomPropertyType,
-        OrgsOrgPatchBodyType,
-        CustomPropertyValueType,
-        OrgsOrgHooksPostBodyType,
-        OrgsOrgInvitationsPostBodyType,
-        OrgsOrgHooksHookIdPatchBodyType,
-        OrgsOrgHooksPostBodyPropConfigType,
-        UserMembershipsOrgsOrgPatchBodyType,
-        OrgsOrgPropertiesSchemaPatchBodyType,
-        OrgsOrgPropertiesValuesPatchBodyType,
-        OrgsOrgHooksHookIdConfigPatchBodyType,
-        OrgsOrgMembershipsUsernamePutBodyType,
-        OrgsOrgPersonalAccessTokensPostBodyType,
-        OrgsOrgHooksHookIdPatchBodyPropConfigType,
-        OrgsOrgPersonalAccessTokensPatIdPostBodyType,
-        OrgsOrgSecurityProductEnablementPostBodyType,
-        OrgsOrgOutsideCollaboratorsUsernamePutBodyType,
-        OrgsOrgPersonalAccessTokenRequestsPostBodyType,
-        OrganizationCustomRepositoryRoleCreateSchemaType,
-        OrganizationCustomRepositoryRoleUpdateSchemaType,
-        OrganizationCustomOrganizationRoleCreateSchemaType,
-        OrganizationCustomOrganizationRoleUpdateSchemaType,
-        OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
-        OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
-    )
     from ..models import (
         Team,
         OrgHook,
@@ -93,6 +66,69 @@ if TYPE_CHECKING:
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         OrganizationsOrganizationIdCustomRolesGetResponse200,
     )
+    from ..types import (
+        TeamType,
+        OrgHookType,
+        SimpleUserType,
+        TeamSimpleType,
+        AnnouncementType,
+        HookDeliveryType,
+        AuditLogEventType,
+        OrgMembershipType,
+        WebhookConfigType,
+        CustomPropertyType,
+        HookDeliveryItemType,
+        OrganizationFullType,
+        OrganizationRoleType,
+        OrgsOrgPatchBodyType,
+        MinimalRepositoryType,
+        AnnouncementBannerType,
+        OrganizationSimpleType,
+        TeamRoleAssignmentType,
+        UserRoleAssignmentType,
+        CustomPropertyValueType,
+        OrgsOrgHooksPostBodyType,
+        OrganizationInvitationType,
+        ApiInsightsSummaryStatsType,
+        CredentialAuthorizationType,
+        ApiInsightsTimeStatsItemsType,
+        ApiInsightsUserStatsItemsType,
+        ApiInsightsRouteStatsItemsType,
+        OrgsOrgInvitationsPostBodyType,
+        OrgRepoCustomPropertyValuesType,
+        OrgsOrgHooksHookIdPatchBodyType,
+        ApiInsightsSubjectStatsItemsType,
+        OrgsOrgHooksPostBodyPropConfigType,
+        RepositoryFineGrainedPermissionType,
+        UserMembershipsOrgsOrgPatchBodyType,
+        OrganizationCustomRepositoryRoleType,
+        OrgsOrgPropertiesSchemaPatchBodyType,
+        OrgsOrgPropertiesValuesPatchBodyType,
+        OrganizationFineGrainedPermissionType,
+        OrgsOrgHooksHookIdConfigPatchBodyType,
+        OrgsOrgMembershipsUsernamePutBodyType,
+        OrgsOrgInstallationsGetResponse200Type,
+        OrganizationProgrammaticAccessGrantType,
+        OrgsOrgPersonalAccessTokensPostBodyType,
+        OrgsOrgHooksHookIdPatchBodyPropConfigType,
+        OrgsOrgOrganizationRolesGetResponse200Type,
+        OrgsOrgPersonalAccessTokensPatIdPostBodyType,
+        OrgsOrgSecurityProductEnablementPostBodyType,
+        OrganizationProgrammaticAccessGrantRequestType,
+        OrgsOrgCustomRepositoryRolesGetResponse200Type,
+        OrgsOrgOutsideCollaboratorsUsernamePutBodyType,
+        OrgsOrgPersonalAccessTokenRequestsPostBodyType,
+        OrganizationCustomRepositoryRoleCreateSchemaType,
+        OrganizationCustomRepositoryRoleUpdateSchemaType,
+        OrganizationCustomOrganizationRoleCreateSchemaType,
+        OrganizationCustomOrganizationRoleUpdateSchemaType,
+        OrgsOrgAttestationsSubjectDigestGetResponse200Type,
+        OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+        OrganizationsOrganizationIdCustomRolesGetResponse200Type,
+        OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
+    )
 
 
 class OrgsClient:
@@ -116,7 +152,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations"""
 
         from ..models import OrganizationSimple
@@ -144,7 +180,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations"""
 
         from ..models import OrganizationSimple
@@ -171,7 +207,10 @@ class OrgsClient:
         organization_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationsOrganizationIdCustomRolesGetResponse200]:
+    ) -> Response[
+        OrganizationsOrganizationIdCustomRolesGetResponse200,
+        OrganizationsOrganizationIdCustomRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---list-custom-repository-roles-in-an-organization"""
 
         from ..models import OrganizationsOrganizationIdCustomRolesGetResponse200
@@ -192,7 +231,10 @@ class OrgsClient:
         organization_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationsOrganizationIdCustomRolesGetResponse200]:
+    ) -> Response[
+        OrganizationsOrganizationIdCustomRolesGetResponse200,
+        OrganizationsOrganizationIdCustomRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---list-custom-repository-roles-in-an-organization"""
 
         from ..models import OrganizationsOrganizationIdCustomRolesGetResponse200
@@ -213,7 +255,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-an-organization"""
 
         from ..models import BasicError, OrganizationFull
@@ -237,7 +279,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-an-organization"""
 
         from ..models import BasicError, OrganizationFull
@@ -261,7 +303,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#delete-an-organization"""
 
         from ..models import (
@@ -289,7 +334,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#delete-an-organization"""
 
         from ..models import (
@@ -319,7 +367,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     @overload
     def update(
@@ -364,7 +412,7 @@ class OrgsClient:
         secret_scanning_push_protection_custom_link_enabled: Missing[bool] = UNSET,
         secret_scanning_push_protection_custom_link: Missing[str] = UNSET,
         secret_scanning_validity_checks_enabled: Missing[bool] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     def update(
         self,
@@ -373,7 +421,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#update-an-organization"""
 
         from typing import Union
@@ -418,7 +466,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     @overload
     async def async_update(
@@ -463,7 +511,7 @@ class OrgsClient:
         secret_scanning_push_protection_custom_link_enabled: Missing[bool] = UNSET,
         secret_scanning_push_protection_custom_link: Missing[str] = UNSET,
         secret_scanning_validity_checks_enabled: Missing[bool] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     async def async_update(
         self,
@@ -472,7 +520,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#update-an-organization"""
 
         from typing import Union
@@ -515,7 +563,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#get-announcement-banner-for-organization"""
 
         from ..models import AnnouncementBanner
@@ -536,7 +584,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#get-announcement-banner-for-organization"""
 
         from ..models import AnnouncementBanner
@@ -595,7 +643,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AnnouncementType,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     @overload
     def set_announcement_banner_for_org(
@@ -606,7 +654,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     def set_announcement_banner_for_org(
         self,
@@ -615,7 +663,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#set-announcement-banner-for-organization"""
 
         from ..models import Announcement, AnnouncementBanner
@@ -648,7 +696,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AnnouncementType,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     @overload
     async def async_set_announcement_banner_for_org(
@@ -659,7 +707,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
-    ) -> Response[AnnouncementBanner]: ...
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
     async def async_set_announcement_banner_for_org(
         self,
@@ -668,7 +716,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
-    ) -> Response[AnnouncementBanner]:
+    ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#set-announcement-banner-for-organization"""
 
         from ..models import Announcement, AnnouncementBanner
@@ -703,7 +751,10 @@ class OrgsClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        OrgsOrgAttestationsSubjectDigestGetResponse200,
+        OrgsOrgAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-attestations"""
 
         from ..models import OrgsOrgAttestationsSubjectDigestGetResponse200
@@ -735,7 +786,10 @@ class OrgsClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        OrgsOrgAttestationsSubjectDigestGetResponse200,
+        OrgsOrgAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-attestations"""
 
         from ..models import OrgsOrgAttestationsSubjectDigestGetResponse200
@@ -769,7 +823,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[AuditLogEvent]]:
+    ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-the-audit-log-for-an-organization"""
 
         from ..models import AuditLogEvent
@@ -806,7 +860,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[AuditLogEvent]]:
+    ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-the-audit-log-for-an-organization"""
 
         from ..models import AuditLogEvent
@@ -839,7 +893,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
         from ..models import SimpleUser
@@ -868,7 +922,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
         from ..models import SimpleUser
@@ -1032,7 +1086,7 @@ class OrgsClient:
         login: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CredentialAuthorization]]:
+    ) -> Response[list[CredentialAuthorization], list[CredentialAuthorizationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization"""
 
         from ..models import CredentialAuthorization
@@ -1063,7 +1117,7 @@ class OrgsClient:
         login: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CredentialAuthorization]]:
+    ) -> Response[list[CredentialAuthorization], list[CredentialAuthorizationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization"""
 
         from ..models import CredentialAuthorization
@@ -1139,7 +1193,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCustomRepositoryRolesGetResponse200]:
+    ) -> Response[
+        OrgsOrgCustomRepositoryRolesGetResponse200,
+        OrgsOrgCustomRepositoryRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#list-custom-repository-roles-in-an-organization"""
 
         from ..models import OrgsOrgCustomRepositoryRolesGetResponse200
@@ -1160,7 +1217,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCustomRepositoryRolesGetResponse200]:
+    ) -> Response[
+        OrgsOrgCustomRepositoryRolesGetResponse200,
+        OrgsOrgCustomRepositoryRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#list-custom-repository-roles-in-an-organization"""
 
         from ..models import OrgsOrgCustomRepositoryRolesGetResponse200
@@ -1183,7 +1243,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     def create_custom_repo_role(
@@ -1196,7 +1258,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
         permissions: list[str],
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     def create_custom_repo_role(
         self,
@@ -1205,7 +1269,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#create-a-custom-repository-role"""
 
         from ..models import (
@@ -1249,7 +1315,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     async def async_create_custom_repo_role(
@@ -1262,7 +1330,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
         permissions: list[str],
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     async def async_create_custom_repo_role(
         self,
@@ -1271,7 +1341,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#create-a-custom-repository-role"""
 
         from ..models import (
@@ -1314,7 +1386,9 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#get-a-custom-repository-role"""
 
         from ..models import BasicError, OrganizationCustomRepositoryRole
@@ -1339,7 +1413,9 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#get-a-custom-repository-role"""
 
         from ..models import BasicError, OrganizationCustomRepositoryRole
@@ -1404,7 +1480,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     def update_custom_repo_role(
@@ -1418,7 +1496,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
         permissions: Missing[list[str]] = UNSET,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     def update_custom_repo_role(
         self,
@@ -1428,7 +1508,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#update-a-custom-repository-role"""
 
         from ..models import (
@@ -1473,7 +1555,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     async def async_update_custom_repo_role(
@@ -1487,7 +1571,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
         permissions: Missing[list[str]] = UNSET,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     async def async_update_custom_repo_role(
         self,
@@ -1497,7 +1583,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#update-a-custom-repository-role"""
 
         from ..models import (
@@ -1541,7 +1629,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     def create_custom_role(
@@ -1554,7 +1644,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
         permissions: list[str],
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     def create_custom_role(
         self,
@@ -1563,7 +1655,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---create-a-custom-role"""
 
         from ..models import (
@@ -1607,7 +1701,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     async def async_create_custom_role(
@@ -1620,7 +1716,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
         permissions: list[str],
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     async def async_create_custom_role(
         self,
@@ -1629,7 +1727,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---create-a-custom-role"""
 
         from ..models import (
@@ -1672,7 +1772,9 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---get-a-custom-role"""
 
         from ..models import BasicError, OrganizationCustomRepositoryRole
@@ -1697,7 +1799,9 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---get-a-custom-role"""
 
         from ..models import BasicError, OrganizationCustomRepositoryRole
@@ -1762,7 +1866,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     def update_custom_role(
@@ -1776,7 +1882,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
         permissions: Missing[list[str]] = UNSET,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     def update_custom_role(
         self,
@@ -1786,7 +1894,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---update-a-custom-role"""
 
         from ..models import (
@@ -1831,7 +1941,9 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     @overload
     async def async_update_custom_role(
@@ -1845,7 +1957,9 @@ class OrgsClient:
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
         permissions: Missing[list[str]] = UNSET,
-    ) -> Response[OrganizationCustomRepositoryRole]: ...
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]: ...
 
     async def async_update_custom_role(
         self,
@@ -1855,7 +1969,9 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationCustomRepositoryRole]:
+    ) -> Response[
+        OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---update-a-custom-role"""
 
         from ..models import (
@@ -1899,7 +2015,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-failed-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -1931,7 +2047,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-failed-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -1961,7 +2077,9 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryFineGrainedPermission]]:
+    ) -> Response[
+        list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---list-fine-grained-permissions-for-an-organization"""
 
         from ..models import RepositoryFineGrainedPermission
@@ -1982,7 +2100,9 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryFineGrainedPermission]]:
+    ) -> Response[
+        list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---list-fine-grained-permissions-for-an-organization"""
 
         from ..models import RepositoryFineGrainedPermission
@@ -2005,7 +2125,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgHook]]:
+    ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-organization-webhooks"""
 
         from ..models import OrgHook, BasicError
@@ -2037,7 +2157,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgHook]]:
+    ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-organization-webhooks"""
 
         from ..models import OrgHook, BasicError
@@ -2069,7 +2189,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     def create_webhook(
@@ -2082,7 +2202,7 @@ class OrgsClient:
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     def create_webhook(
         self,
@@ -2091,7 +2211,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#create-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError, ValidationError, OrgsOrgHooksPostBody
@@ -2128,7 +2248,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     async def async_create_webhook(
@@ -2141,7 +2261,7 @@ class OrgsClient:
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     async def async_create_webhook(
         self,
@@ -2150,7 +2270,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#create-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError, ValidationError, OrgsOrgHooksPostBody
@@ -2186,7 +2306,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError
@@ -2211,7 +2331,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError
@@ -2286,7 +2406,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     def update_webhook(
@@ -2300,7 +2420,7 @@ class OrgsClient:
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     def update_webhook(
         self,
@@ -2310,7 +2430,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#update-an-organization-webhook"""
 
         from ..models import (
@@ -2353,7 +2473,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     async def async_update_webhook(
@@ -2367,7 +2487,7 @@ class OrgsClient:
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     async def async_update_webhook(
         self,
@@ -2377,7 +2497,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#update-an-organization-webhook"""
 
         from ..models import (
@@ -2418,7 +2538,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig
@@ -2440,7 +2560,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig
@@ -2464,7 +2584,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     def update_webhook_config_for_org(
@@ -2478,7 +2598,7 @@ class OrgsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     def update_webhook_config_for_org(
         self,
@@ -2488,7 +2608,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#update-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig, OrgsOrgHooksHookIdConfigPatchBody
@@ -2522,7 +2642,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     async def async_update_webhook_config_for_org(
@@ -2536,7 +2656,7 @@ class OrgsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     async def async_update_webhook_config_for_org(
         self,
@@ -2546,7 +2666,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#update-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig, OrgsOrgHooksHookIdConfigPatchBody
@@ -2580,7 +2700,7 @@ class OrgsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -2614,7 +2734,7 @@ class OrgsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -2647,7 +2767,7 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -2674,7 +2794,7 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -2701,7 +2821,10 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#redeliver-a-delivery-for-an-organization-webhook"""
 
         from ..models import (
@@ -2732,7 +2855,10 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#redeliver-a-delivery-for-an-organization-webhook"""
 
         from ..models import (
@@ -2834,7 +2960,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsRouteStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-route-stats-by-actor"""
 
         from ..models import ApiInsightsRouteStatsItems
@@ -2890,7 +3018,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsRouteStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-route-stats-by-actor"""
 
         from ..models import ApiInsightsRouteStatsItems
@@ -2937,7 +3067,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsSubjectStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-subject-stats"""
 
         from ..models import ApiInsightsSubjectStatsItems
@@ -2984,7 +3116,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsSubjectStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-subject-stats"""
 
         from ..models import ApiInsightsSubjectStatsItems
@@ -3017,7 +3151,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats"""
 
         from ..models import ApiInsightsSummaryStats
@@ -3046,7 +3180,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats"""
 
         from ..models import ApiInsightsSummaryStats
@@ -3076,7 +3210,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-user"""
 
         from ..models import ApiInsightsSummaryStats
@@ -3106,7 +3240,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-user"""
 
         from ..models import ApiInsightsSummaryStats
@@ -3143,7 +3277,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-actor"""
 
         from ..models import ApiInsightsSummaryStats
@@ -3180,7 +3314,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-actor"""
 
         from ..models import ApiInsightsSummaryStats
@@ -3210,7 +3344,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -3241,7 +3375,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -3273,7 +3407,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-user"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -3305,7 +3439,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-user"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -3344,7 +3478,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-actor"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -3383,7 +3517,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-actor"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -3428,7 +3562,7 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsUserStatsItems]]:
+    ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-user-stats"""
 
         from ..models import ApiInsightsUserStatsItems
@@ -3476,7 +3610,7 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsUserStatsItems]]:
+    ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-user-stats"""
 
         from ..models import ApiInsightsUserStatsItems
@@ -3509,7 +3643,9 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgInstallationsGetResponse200]:
+    ) -> Response[
+        OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-app-installations-for-an-organization"""
 
         from ..models import OrgsOrgInstallationsGetResponse200
@@ -3538,7 +3674,9 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgInstallationsGetResponse200]:
+    ) -> Response[
+        OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-app-installations-for-an-organization"""
 
         from ..models import OrgsOrgInstallationsGetResponse200
@@ -3573,7 +3711,7 @@ class OrgsClient:
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-pending-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -3613,7 +3751,7 @@ class OrgsClient:
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-pending-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -3647,7 +3785,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     @overload
     def create_invitation(
@@ -3662,7 +3800,7 @@ class OrgsClient:
             Literal["admin", "direct_member", "billing_manager", "reinstate"]
         ] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     def create_invitation(
         self,
@@ -3671,7 +3809,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationInvitation]:
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#create-an-organization-invitation"""
 
         from ..models import (
@@ -3713,7 +3851,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     @overload
     async def async_create_invitation(
@@ -3728,7 +3866,7 @@ class OrgsClient:
             Literal["admin", "direct_member", "billing_manager", "reinstate"]
         ] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     async def async_create_invitation(
         self,
@@ -3737,7 +3875,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationInvitation]:
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#create-an-organization-invitation"""
 
         from ..models import (
@@ -3830,7 +3968,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-invitation-teams"""
 
         from ..models import Team, BasicError
@@ -3863,7 +4001,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-invitation-teams"""
 
         from ..models import Team, BasicError
@@ -3897,7 +4035,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-members"""
 
         from ..models import SimpleUser, ValidationError
@@ -3933,7 +4071,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-members"""
 
         from ..models import SimpleUser, ValidationError
@@ -4054,7 +4192,7 @@ class OrgsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-organization-membership-for-a-user"""
 
         from ..models import BasicError, OrgMembership
@@ -4080,7 +4218,7 @@ class OrgsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-organization-membership-for-a-user"""
 
         from ..models import BasicError, OrgMembership
@@ -4108,7 +4246,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     def set_membership_for_user(
@@ -4119,7 +4257,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     def set_membership_for_user(
         self,
@@ -4129,7 +4267,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#set-organization-membership-for-a-user"""
 
         from ..models import (
@@ -4172,7 +4310,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     async def async_set_membership_for_user(
@@ -4183,7 +4321,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     async def async_set_membership_for_user(
         self,
@@ -4193,7 +4331,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#set-organization-membership-for-a-user"""
 
         from ..models import (
@@ -4283,7 +4421,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationFineGrainedPermission]]:
+    ) -> Response[
+        list[OrganizationFineGrainedPermission],
+        list[OrganizationFineGrainedPermissionType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-organization-fine-grained-permissions-for-an-organization"""
 
         from ..models import (
@@ -4312,7 +4453,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationFineGrainedPermission]]:
+    ) -> Response[
+        list[OrganizationFineGrainedPermission],
+        list[OrganizationFineGrainedPermissionType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-organization-fine-grained-permissions-for-an-organization"""
 
         from ..models import (
@@ -4341,7 +4485,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgOrganizationRolesGetResponse200]:
+    ) -> Response[
+        OrgsOrgOrganizationRolesGetResponse200,
+        OrgsOrgOrganizationRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#get-all-organization-roles-for-an-organization"""
 
         from ..models import (
@@ -4370,7 +4517,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgOrganizationRolesGetResponse200]:
+    ) -> Response[
+        OrgsOrgOrganizationRolesGetResponse200,
+        OrgsOrgOrganizationRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#get-all-organization-roles-for-an-organization"""
 
         from ..models import (
@@ -4401,7 +4551,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomOrganizationRoleCreateSchemaType,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     @overload
     def create_custom_organization_role(
@@ -4416,7 +4566,7 @@ class OrgsClient:
         base_role: Missing[
             Literal["read", "triage", "write", "maintain", "admin"]
         ] = UNSET,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     def create_custom_organization_role(
         self,
@@ -4425,7 +4575,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleCreateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#create-a-custom-organization-role"""
 
         from ..models import (
@@ -4470,7 +4620,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomOrganizationRoleCreateSchemaType,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     @overload
     async def async_create_custom_organization_role(
@@ -4485,7 +4635,7 @@ class OrgsClient:
         base_role: Missing[
             Literal["read", "triage", "write", "maintain", "admin"]
         ] = UNSET,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     async def async_create_custom_organization_role(
         self,
@@ -4494,7 +4644,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleCreateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#create-a-custom-organization-role"""
 
         from ..models import (
@@ -4778,7 +4928,7 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#get-an-organization-role"""
 
         from ..models import BasicError, ValidationError, OrganizationRole
@@ -4804,7 +4954,7 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#get-an-organization-role"""
 
         from ..models import BasicError, ValidationError, OrganizationRole
@@ -4870,7 +5020,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomOrganizationRoleUpdateSchemaType,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     @overload
     def patch_custom_organization_role(
@@ -4886,7 +5036,7 @@ class OrgsClient:
         base_role: Missing[
             Literal["none", "read", "triage", "write", "maintain", "admin"]
         ] = UNSET,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     def patch_custom_organization_role(
         self,
@@ -4896,7 +5046,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleUpdateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#update-a-custom-organization-role"""
 
         from ..models import (
@@ -4942,7 +5092,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrganizationCustomOrganizationRoleUpdateSchemaType,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     @overload
     async def async_patch_custom_organization_role(
@@ -4958,7 +5108,7 @@ class OrgsClient:
         base_role: Missing[
             Literal["none", "read", "triage", "write", "maintain", "admin"]
         ] = UNSET,
-    ) -> Response[OrganizationRole]: ...
+    ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
     async def async_patch_custom_organization_role(
         self,
@@ -4968,7 +5118,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleUpdateSchemaType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#update-a-custom-organization-role"""
 
         from ..models import (
@@ -5014,7 +5164,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamRoleAssignment]]:
+    ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
         from ..models import TeamRoleAssignment
@@ -5045,7 +5195,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamRoleAssignment]]:
+    ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
         from ..models import TeamRoleAssignment
@@ -5076,7 +5226,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserRoleAssignment]]:
+    ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
         from ..models import UserRoleAssignment
@@ -5107,7 +5257,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserRoleAssignment]]:
+    ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
         from ..models import UserRoleAssignment
@@ -5138,7 +5288,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
         from ..models import SimpleUser
@@ -5169,7 +5319,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
         from ..models import SimpleUser
@@ -5200,7 +5350,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     @overload
     def convert_member_to_outside_collaborator(
@@ -5211,7 +5364,10 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         async_: Missing[bool] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     def convert_member_to_outside_collaborator(
         self,
@@ -5221,7 +5377,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]:
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator"""
 
         from ..models import (
@@ -5264,7 +5423,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     @overload
     async def async_convert_member_to_outside_collaborator(
@@ -5275,7 +5437,10 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         async_: Missing[bool] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     async def async_convert_member_to_outside_collaborator(
         self,
@@ -5285,7 +5450,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]:
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator"""
 
         from ..models import (
@@ -5382,7 +5550,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrantRequest]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrantRequest],
+        list[OrganizationProgrammaticAccessGrantRequestType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -5435,7 +5606,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrantRequest]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrantRequest],
+        list[OrganizationProgrammaticAccessGrantRequestType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -5481,7 +5655,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     def review_pat_grant_requests_in_bulk(
@@ -5493,7 +5670,10 @@ class OrgsClient:
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     def review_pat_grant_requests_in_bulk(
         self,
@@ -5502,7 +5682,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#review-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -5548,7 +5731,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     async def async_review_pat_grant_requests_in_bulk(
@@ -5560,7 +5746,10 @@ class OrgsClient:
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     async def async_review_pat_grant_requests_in_bulk(
         self,
@@ -5569,7 +5758,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#review-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -5754,7 +5946,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
         from ..models import BasicError, MinimalRepository
@@ -5791,7 +5983,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
         from ..models import BasicError, MinimalRepository
@@ -5834,7 +6026,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrant]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrant],
+        list[OrganizationProgrammaticAccessGrantType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-fine-grained-personal-access-tokens-with-access-to-organization-resources"""
 
         from ..models import (
@@ -5887,7 +6082,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrant]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrant],
+        list[OrganizationProgrammaticAccessGrantType],
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-fine-grained-personal-access-tokens-with-access-to-organization-resources"""
 
         from ..models import (
@@ -5933,7 +6131,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     def update_pat_accesses(
@@ -5944,7 +6145,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     def update_pat_accesses(
         self,
@@ -5953,7 +6157,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#update-the-access-to-organization-resources-via-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -5997,7 +6204,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     async def async_update_pat_accesses(
@@ -6008,7 +6218,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     async def async_update_pat_accesses(
         self,
@@ -6017,7 +6230,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#update-the-access-to-organization-resources-via-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -6190,7 +6406,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
         from ..models import BasicError, MinimalRepository
@@ -6225,7 +6441,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
         from ..models import BasicError, MinimalRepository
@@ -6257,7 +6473,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -6282,7 +6498,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -6309,7 +6525,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     @overload
     def create_or_update_custom_properties(
@@ -6319,7 +6535,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         properties: list[CustomPropertyType],
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     def create_or_update_custom_properties(
         self,
@@ -6328,7 +6544,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#create-or-update-custom-properties-for-an-organization"""
 
         from ..models import (
@@ -6369,7 +6585,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     @overload
     async def async_create_or_update_custom_properties(
@@ -6379,7 +6595,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         properties: list[CustomPropertyType],
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     async def async_create_or_update_custom_properties(
         self,
@@ -6388,7 +6604,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#create-or-update-custom-properties-for-an-organization"""
 
         from ..models import (
@@ -6428,7 +6644,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -6454,7 +6670,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -6482,7 +6698,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     @overload
     def create_or_update_custom_property(
@@ -6497,7 +6713,7 @@ class OrgsClient:
         default_value: Missing[Union[str, list[str], None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         allowed_values: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     def create_or_update_custom_property(
         self,
@@ -6507,7 +6723,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#create-or-update-a-custom-property-for-an-organization"""
 
         from ..models import (
@@ -6551,7 +6767,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     @overload
     async def async_create_or_update_custom_property(
@@ -6566,7 +6782,7 @@ class OrgsClient:
         default_value: Missing[Union[str, list[str], None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         allowed_values: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     async def async_create_or_update_custom_property(
         self,
@@ -6576,7 +6792,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#create-or-update-a-custom-property-for-an-organization"""
 
         from ..models import (
@@ -6670,7 +6886,9 @@ class OrgsClient:
         repository_query: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgRepoCustomPropertyValues]]:
+    ) -> Response[
+        list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#list-custom-property-values-for-organization-repositories"""
 
         from ..models import BasicError, OrgRepoCustomPropertyValues
@@ -6705,7 +6923,9 @@ class OrgsClient:
         repository_query: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgRepoCustomPropertyValues]]:
+    ) -> Response[
+        list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#list-custom-property-values-for-organization-repositories"""
 
         from ..models import BasicError, OrgRepoCustomPropertyValues
@@ -6861,7 +7081,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-public-organization-members"""
 
         from ..models import SimpleUser
@@ -6890,7 +7110,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-public-organization-members"""
 
         from ..models import SimpleUser
@@ -7043,7 +7263,9 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryFineGrainedPermission]]:
+    ) -> Response[
+        list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#list-repository-fine-grained-permissions-for-an-organization"""
 
         from ..models import RepositoryFineGrainedPermission
@@ -7064,7 +7286,9 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryFineGrainedPermission]]:
+    ) -> Response[
+        list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#list-repository-fine-grained-permissions-for-an-organization"""
 
         from ..models import RepositoryFineGrainedPermission
@@ -7085,7 +7309,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamSimple]]:
+    ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#list-security-manager-teams"""
 
         from ..models import TeamSimple
@@ -7106,7 +7330,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamSimple]]:
+    ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#list-security-manager-teams"""
 
         from ..models import TeamSimple
@@ -7369,7 +7593,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgMembership]]:
+    ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership, ValidationError
@@ -7404,7 +7628,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgMembership]]:
+    ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership, ValidationError
@@ -7437,7 +7661,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership
@@ -7462,7 +7686,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership
@@ -7489,7 +7713,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     def update_membership_for_authenticated_user(
@@ -7499,7 +7723,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         state: Literal["active"],
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     def update_membership_for_authenticated_user(
         self,
@@ -7508,7 +7732,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#update-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import (
@@ -7551,7 +7775,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     async def async_update_membership_for_authenticated_user(
@@ -7561,7 +7785,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         state: Literal["active"],
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     async def async_update_membership_for_authenticated_user(
         self,
@@ -7570,7 +7794,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#update-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import (
@@ -7612,7 +7836,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
         from ..models import BasicError, OrganizationSimple
@@ -7644,7 +7868,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
         from ..models import BasicError, OrganizationSimple
@@ -7677,7 +7901,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-a-user"""
 
         from ..models import OrganizationSimple
@@ -7706,7 +7930,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-a-user"""
 
         from ..models import OrganizationSimple

--- a/githubkit/versions/ghec_v2022_11_28/rest/packages.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/packages.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import Package, PackageVersion
+    from ..types import PackageType, PackageVersionType
 
 
 class PackagesClient:
@@ -46,7 +47,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
         from ..models import Package, BasicError
@@ -71,7 +72,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
         from ..models import Package, BasicError
@@ -102,7 +103,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-an-organization"""
 
         from ..models import Package, BasicError
@@ -141,7 +142,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-an-organization"""
 
         from ..models import Package, BasicError
@@ -178,7 +179,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-an-organization"""
 
         from ..models import Package
@@ -203,7 +204,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-an-organization"""
 
         from ..models import Package
@@ -359,7 +360,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
         from ..models import BasicError, PackageVersion
@@ -399,7 +400,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
         from ..models import BasicError, PackageVersion
@@ -437,7 +438,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-an-organization"""
 
         from ..models import PackageVersion
@@ -463,7 +464,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-an-organization"""
 
         from ..models import PackageVersion
@@ -603,7 +604,7 @@ class PackagesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
         from ..models import Package
@@ -623,7 +624,7 @@ class PackagesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
         from ..models import Package
@@ -649,7 +650,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
         from ..models import Package
@@ -684,7 +685,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
         from ..models import Package
@@ -717,7 +718,7 @@ class PackagesClient:
         package_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
         from ..models import Package
@@ -741,7 +742,7 @@ class PackagesClient:
         package_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
         from ..models import Package
@@ -892,7 +893,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
         from ..models import BasicError, PackageVersion
@@ -931,7 +932,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
         from ..models import BasicError, PackageVersion
@@ -968,7 +969,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
         from ..models import PackageVersion
@@ -993,7 +994,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
         from ..models import PackageVersion
@@ -1130,7 +1131,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
         from ..models import Package, BasicError
@@ -1155,7 +1156,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
         from ..models import Package, BasicError
@@ -1186,7 +1187,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-a-user"""
 
         from ..models import Package, BasicError
@@ -1225,7 +1226,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-a-user"""
 
         from ..models import Package, BasicError
@@ -1262,7 +1263,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-a-user"""
 
         from ..models import Package
@@ -1287,7 +1288,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-a-user"""
 
         from ..models import Package
@@ -1440,7 +1441,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
         from ..models import BasicError, PackageVersion
@@ -1470,7 +1471,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
         from ..models import BasicError, PackageVersion
@@ -1501,7 +1502,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-a-user"""
 
         from ..models import PackageVersion
@@ -1527,7 +1528,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-a-user"""
 
         from ..models import PackageVersion

--- a/githubkit/versions/ghec_v2022_11_28/rest/projects.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/projects.py
@@ -36,9 +36,14 @@ if TYPE_CHECKING:
         ProjectsColumnsCardsCardIdMovesPostResponse201,
     )
     from ..types import (
+        ProjectType,
+        SimpleUserType,
+        ProjectCardType,
+        ProjectColumnType,
         UserProjectsPostBodyType,
         OrgsOrgProjectsPostBodyType,
         ProjectsProjectIdPatchBodyType,
+        ProjectCollaboratorPermissionType,
         ReposOwnerRepoProjectsPostBodyType,
         ProjectsColumnsColumnIdPatchBodyType,
         ProjectsProjectIdColumnsPostBodyType,
@@ -47,7 +52,9 @@ if TYPE_CHECKING:
         ProjectsColumnsCardsCardIdMovesPostBodyType,
         ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
         ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
         ProjectsProjectIdCollaboratorsUsernamePutBodyType,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
     )
 
 
@@ -74,7 +81,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-organization-projects"""
 
         from ..models import Project, ValidationErrorSimple
@@ -108,7 +115,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-organization-projects"""
 
         from ..models import Project, ValidationErrorSimple
@@ -141,7 +148,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def create_for_org(
@@ -152,7 +159,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def create_for_org(
         self,
@@ -161,7 +168,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#create-an-organization-project"""
 
         from ..models import (
@@ -206,7 +213,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_create_for_org(
@@ -217,7 +224,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_create_for_org(
         self,
@@ -226,7 +233,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#create-an-organization-project"""
 
         from ..models import (
@@ -269,7 +276,7 @@ class ProjectsClient:
         card_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#get-a-project-card"""
 
         from ..models import BasicError, ProjectCard
@@ -295,7 +302,7 @@ class ProjectsClient:
         card_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#get-a-project-card"""
 
         from ..models import BasicError, ProjectCard
@@ -373,7 +380,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     def update_card(
@@ -384,7 +391,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     def update_card(
         self,
@@ -393,7 +400,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#update-an-existing-project-card"""
 
         from ..models import (
@@ -437,7 +444,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     async def async_update_card(
@@ -448,7 +455,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     async def async_update_card(
         self,
@@ -457,7 +464,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#update-an-existing-project-card"""
 
         from ..models import (
@@ -501,7 +508,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     def move_card(
@@ -512,7 +522,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     def move_card(
         self,
@@ -521,7 +534,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#move-a-project-card"""
 
         from ..models import (
@@ -567,7 +583,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_move_card(
@@ -578,7 +597,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     async def async_move_card(
         self,
@@ -587,7 +609,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#move-a-project-card"""
 
         from ..models import (
@@ -631,7 +656,7 @@ class ProjectsClient:
         column_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#get-a-project-column"""
 
         from ..models import BasicError, ProjectColumn
@@ -657,7 +682,7 @@ class ProjectsClient:
         column_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#get-a-project-column"""
 
         from ..models import BasicError, ProjectColumn
@@ -733,7 +758,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     def update_column(
@@ -743,7 +768,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     def update_column(
         self,
@@ -752,7 +777,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#update-an-existing-project-column"""
 
         from ..models import BasicError, ProjectColumn, ProjectsColumnsColumnIdPatchBody
@@ -789,7 +814,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     async def async_update_column(
@@ -799,7 +824,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     async def async_update_column(
         self,
@@ -808,7 +833,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#update-an-existing-project-column"""
 
         from ..models import BasicError, ProjectColumn, ProjectsColumnsColumnIdPatchBody
@@ -846,7 +871,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectCard]]:
+    ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#list-project-cards"""
 
         from ..models import BasicError, ProjectCard
@@ -881,7 +906,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectCard]]:
+    ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#list-project-cards"""
 
         from ..models import BasicError, ProjectCard
@@ -918,7 +943,7 @@ class ProjectsClient:
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
         ],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     def create_card(
@@ -928,7 +953,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         note: Union[str, None],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     def create_card(
@@ -939,7 +964,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         content_id: int,
         content_type: str,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     def create_card(
         self,
@@ -953,7 +978,7 @@ class ProjectsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#create-a-project-card"""
 
         from typing import Union
@@ -1011,7 +1036,7 @@ class ProjectsClient:
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
         ],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     async def async_create_card(
@@ -1021,7 +1046,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         note: Union[str, None],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     async def async_create_card(
@@ -1032,7 +1057,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         content_id: int,
         content_type: str,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     async def async_create_card(
         self,
@@ -1046,7 +1071,7 @@ class ProjectsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#create-a-project-card"""
 
         from typing import Union
@@ -1101,7 +1126,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     def move_column(
@@ -1111,7 +1139,10 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         position: str,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     def move_column(
         self,
@@ -1120,7 +1151,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#move-a-project-column"""
 
         from ..models import (
@@ -1163,7 +1197,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_move_column(
@@ -1173,7 +1210,10 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         position: str,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     async def async_move_column(
         self,
@@ -1182,7 +1222,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#move-a-project-column"""
 
         from ..models import (
@@ -1223,7 +1266,7 @@ class ProjectsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#get-a-project"""
 
         from ..models import Project, BasicError
@@ -1248,7 +1291,7 @@ class ProjectsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#get-a-project"""
 
         from ..models import Project, BasicError
@@ -1327,7 +1370,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def update(
@@ -1343,7 +1386,7 @@ class ProjectsClient:
             Literal["read", "write", "admin", "none"]
         ] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def update(
         self,
@@ -1352,7 +1395,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#update-a-project"""
 
         from ..models import (
@@ -1397,7 +1440,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_update(
@@ -1413,7 +1456,7 @@ class ProjectsClient:
             Literal["read", "write", "admin", "none"]
         ] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_update(
         self,
@@ -1422,7 +1465,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#update-a-project"""
 
         from ..models import (
@@ -1468,7 +1511,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#list-project-collaborators"""
 
         from ..models import BasicError, SimpleUser, ValidationError
@@ -1505,7 +1548,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#list-project-collaborators"""
 
         from ..models import BasicError, SimpleUser, ValidationError
@@ -1738,7 +1781,7 @@ class ProjectsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCollaboratorPermission]:
+    ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#get-project-permission-for-a-user"""
 
         from ..models import BasicError, ValidationError, ProjectCollaboratorPermission
@@ -1766,7 +1809,7 @@ class ProjectsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCollaboratorPermission]:
+    ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#get-project-permission-for-a-user"""
 
         from ..models import BasicError, ValidationError, ProjectCollaboratorPermission
@@ -1795,7 +1838,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectColumn]]:
+    ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#list-project-columns"""
 
         from ..models import BasicError, ProjectColumn
@@ -1828,7 +1871,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectColumn]]:
+    ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#list-project-columns"""
 
         from ..models import BasicError, ProjectColumn
@@ -1861,7 +1904,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     def create_column(
@@ -1871,7 +1914,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     def create_column(
         self,
@@ -1880,7 +1923,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#create-a-project-column"""
 
         from ..models import (
@@ -1923,7 +1966,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     async def async_create_column(
@@ -1933,7 +1976,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     async def async_create_column(
         self,
@@ -1942,7 +1985,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#create-a-project-column"""
 
         from ..models import (
@@ -1987,7 +2030,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-repository-projects"""
 
         from ..models import Project, BasicError, ValidationErrorSimple
@@ -2026,7 +2069,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-repository-projects"""
 
         from ..models import Project, BasicError, ValidationErrorSimple
@@ -2064,7 +2107,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def create_for_repo(
@@ -2076,7 +2119,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def create_for_repo(
         self,
@@ -2086,7 +2129,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#create-a-repository-project"""
 
         from ..models import (
@@ -2132,7 +2175,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_create_for_repo(
@@ -2144,7 +2187,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_create_for_repo(
         self,
@@ -2154,7 +2197,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#create-a-repository-project"""
 
         from ..models import (
@@ -2198,7 +2241,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -2208,7 +2251,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def create_for_authenticated_user(
         self,
@@ -2216,7 +2259,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#create-a-user-project"""
 
         from ..models import (
@@ -2258,7 +2301,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -2268,7 +2311,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_create_for_authenticated_user(
         self,
@@ -2276,7 +2319,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#create-a-user-project"""
 
         from ..models import (
@@ -2320,7 +2363,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-user-projects"""
 
         from ..models import Project, ValidationError
@@ -2354,7 +2397,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-user-projects"""
 
         from ..models import Project, ValidationError

--- a/githubkit/versions/ghec_v2022_11_28/rest/pulls.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/pulls.py
@@ -40,6 +40,15 @@ if TYPE_CHECKING:
         ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
     )
     from ..types import (
+        CommitType,
+        DiffEntryType,
+        PullRequestType,
+        ReviewCommentType,
+        PullRequestReviewType,
+        PullRequestSimpleType,
+        PullRequestMergeResultType,
+        PullRequestReviewCommentType,
+        PullRequestReviewRequestType,
         ReposOwnerRepoPullsPostBodyType,
         ReposOwnerRepoPullsPullNumberPatchBodyType,
         ReposOwnerRepoPullsPullNumberMergePutBodyType,
@@ -48,6 +57,7 @@ if TYPE_CHECKING:
         ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
         ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType,
         ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
         ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
         ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
         ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
@@ -88,7 +98,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests"""
 
         from ..models import ValidationError, PullRequestSimple
@@ -133,7 +143,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests"""
 
         from ..models import ValidationError, PullRequestSimple
@@ -171,7 +181,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     def create(
@@ -189,7 +199,7 @@ class PullsClient:
         maintainer_can_modify: Missing[bool] = UNSET,
         draft: Missing[bool] = UNSET,
         issue: Missing[int] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     def create(
         self,
@@ -199,7 +209,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#create-a-pull-request"""
 
         from ..models import (
@@ -242,7 +252,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     async def async_create(
@@ -260,7 +270,7 @@ class PullsClient:
         maintainer_can_modify: Missing[bool] = UNSET,
         draft: Missing[bool] = UNSET,
         issue: Missing[int] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     async def async_create(
         self,
@@ -270,7 +280,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#create-a-pull-request"""
 
         from ..models import (
@@ -316,7 +326,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-in-a-repository"""
 
         from ..models import PullRequestReviewComment
@@ -352,7 +362,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-in-a-repository"""
 
         from ..models import PullRequestReviewComment
@@ -384,7 +394,7 @@ class PullsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReviewComment
@@ -410,7 +420,7 @@ class PullsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReviewComment
@@ -488,7 +498,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     def update_review_comment(
@@ -500,7 +510,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     def update_review_comment(
         self,
@@ -511,7 +521,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#update-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -551,7 +561,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     async def async_update_review_comment(
@@ -563,7 +573,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     async def async_update_review_comment(
         self,
@@ -574,7 +584,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#update-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -612,7 +622,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#get-a-pull-request"""
 
         from ..models import (
@@ -645,7 +655,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#get-a-pull-request"""
 
         from ..models import (
@@ -680,7 +690,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     def update(
@@ -696,7 +706,7 @@ class PullsClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         base: Missing[str] = UNSET,
         maintainer_can_modify: Missing[bool] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     def update(
         self,
@@ -707,7 +717,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#update-a-pull-request"""
 
         from ..models import (
@@ -751,7 +761,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     async def async_update(
@@ -767,7 +777,7 @@ class PullsClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         base: Missing[str] = UNSET,
         maintainer_can_modify: Missing[bool] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     async def async_update(
         self,
@@ -778,7 +788,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#update-a-pull-request"""
 
         from ..models import (
@@ -825,7 +835,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
         from ..models import PullRequestReviewComment
@@ -862,7 +872,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
         from ..models import PullRequestReviewComment
@@ -896,7 +906,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     def create_review_comment(
@@ -917,7 +927,7 @@ class PullsClient:
         start_side: Missing[Literal["LEFT", "RIGHT", "side"]] = UNSET,
         in_reply_to: Missing[int] = UNSET,
         subject_type: Missing[Literal["line", "file"]] = UNSET,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     def create_review_comment(
         self,
@@ -928,7 +938,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#create-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -974,7 +984,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     async def async_create_review_comment(
@@ -995,7 +1005,7 @@ class PullsClient:
         start_side: Missing[Literal["LEFT", "RIGHT", "side"]] = UNSET,
         in_reply_to: Missing[int] = UNSET,
         subject_type: Missing[Literal["line", "file"]] = UNSET,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     async def async_create_review_comment(
         self,
@@ -1006,7 +1016,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#create-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -1053,7 +1063,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     def create_reply_for_review_comment(
@@ -1066,7 +1076,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     def create_reply_for_review_comment(
         self,
@@ -1080,7 +1090,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#create-a-reply-for-a-review-comment"""
 
         from ..models import (
@@ -1125,7 +1135,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     async def async_create_reply_for_review_comment(
@@ -1138,7 +1148,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     async def async_create_reply_for_review_comment(
         self,
@@ -1152,7 +1162,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#create-a-reply-for-a-review-comment"""
 
         from ..models import (
@@ -1196,7 +1206,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-commits-on-a-pull-request"""
 
         from ..models import Commit
@@ -1227,7 +1237,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-commits-on-a-pull-request"""
 
         from ..models import Commit
@@ -1258,7 +1268,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DiffEntry]]:
+    ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests-files"""
 
         from ..models import (
@@ -1299,7 +1309,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DiffEntry]]:
+    ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests-files"""
 
         from ..models import (
@@ -1384,7 +1394,7 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     @overload
     def merge(
@@ -1399,7 +1409,7 @@ class PullsClient:
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
         merge_method: Missing[Literal["merge", "squash", "rebase"]] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     def merge(
         self,
@@ -1412,7 +1422,7 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestMergeResult]:
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#merge-a-pull-request"""
 
         from typing import Union
@@ -1467,7 +1477,7 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     @overload
     async def async_merge(
@@ -1482,7 +1492,7 @@ class PullsClient:
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
         merge_method: Missing[Literal["merge", "squash", "rebase"]] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     async def async_merge(
         self,
@@ -1495,7 +1505,7 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestMergeResult]:
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#merge-a-pull-request"""
 
         from typing import Union
@@ -1546,7 +1556,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewRequest]:
+    ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
         from ..models import PullRequestReviewRequest
@@ -1569,7 +1579,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewRequest]:
+    ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
         from ..models import PullRequestReviewRequest
@@ -1599,7 +1609,7 @@ class PullsClient:
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof1Type,
             ]
         ] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     def request_reviewers(
@@ -1612,7 +1622,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     def request_reviewers(
@@ -1625,7 +1635,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     def request_reviewers(
         self,
@@ -1641,7 +1651,7 @@ class PullsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#request-reviewers-for-a-pull-request"""
 
         from typing import Union
@@ -1697,7 +1707,7 @@ class PullsClient:
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof1Type,
             ]
         ] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     async def async_request_reviewers(
@@ -1710,7 +1720,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     async def async_request_reviewers(
@@ -1723,7 +1733,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     async def async_request_reviewers(
         self,
@@ -1739,7 +1749,7 @@ class PullsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#request-reviewers-for-a-pull-request"""
 
         from typing import Union
@@ -1790,7 +1800,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     def remove_requested_reviewers(
@@ -1803,7 +1813,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     def remove_requested_reviewers(
         self,
@@ -1816,7 +1826,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request"""
 
         from ..models import (
@@ -1860,7 +1870,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     async def async_remove_requested_reviewers(
@@ -1873,7 +1883,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     async def async_remove_requested_reviewers(
         self,
@@ -1886,7 +1896,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request"""
 
         from ..models import (
@@ -1930,7 +1940,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReview]]:
+    ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
         from ..models import PullRequestReview
@@ -1961,7 +1971,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReview]]:
+    ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
         from ..models import PullRequestReview
@@ -1992,7 +2002,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def create_review(
@@ -2009,7 +2019,7 @@ class PullsClient:
         comments: Missing[
             list[ReposOwnerRepoPullsPullNumberReviewsPostBodyPropCommentsItemsType]
         ] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def create_review(
         self,
@@ -2020,7 +2030,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#create-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2066,7 +2076,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_create_review(
@@ -2083,7 +2093,7 @@ class PullsClient:
         comments: Missing[
             list[ReposOwnerRepoPullsPullNumberReviewsPostBodyPropCommentsItemsType]
         ] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_create_review(
         self,
@@ -2094,7 +2104,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#create-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2139,7 +2149,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview
@@ -2166,7 +2176,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview
@@ -2195,7 +2205,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def update_review(
@@ -2208,7 +2218,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def update_review(
         self,
@@ -2220,7 +2230,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#update-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2265,7 +2275,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_update_review(
@@ -2278,7 +2288,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_update_review(
         self,
@@ -2290,7 +2300,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#update-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2333,7 +2343,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview, ValidationErrorSimple
@@ -2361,7 +2371,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview, ValidationErrorSimple
@@ -2391,7 +2401,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReviewComment]]:
+    ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
         from ..models import BasicError, ReviewComment
@@ -2426,7 +2436,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReviewComment]]:
+    ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
         from ..models import BasicError, ReviewComment
@@ -2461,7 +2471,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def dismiss_review(
@@ -2475,7 +2485,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def dismiss_review(
         self,
@@ -2489,7 +2499,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#dismiss-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2538,7 +2548,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_dismiss_review(
@@ -2552,7 +2562,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_dismiss_review(
         self,
@@ -2566,7 +2576,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#dismiss-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2615,7 +2625,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def submit_review(
@@ -2629,7 +2639,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def submit_review(
         self,
@@ -2643,7 +2653,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#submit-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2691,7 +2701,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_submit_review(
@@ -2705,7 +2715,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_submit_review(
         self,
@@ -2719,7 +2729,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#submit-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2768,7 +2778,10 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     @overload
     def update_branch(
@@ -2780,7 +2793,10 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     def update_branch(
         self,
@@ -2793,7 +2809,10 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#update-a-pull-request-branch"""
 
         from typing import Union
@@ -2843,7 +2862,10 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     @overload
     async def async_update_branch(
@@ -2855,7 +2877,10 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     async def async_update_branch(
         self,
@@ -2868,7 +2893,10 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#update-a-pull-request-branch"""
 
         from typing import Union

--- a/githubkit/versions/ghec_v2022_11_28/rest/rate_limit.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/rate_limit.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import RateLimitOverview
+    from ..types import RateLimitOverviewType
 
 
 class RateLimitClient:
@@ -40,7 +41,7 @@ class RateLimitClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RateLimitOverview]:
+    ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 
         from ..models import BasicError, RateLimitOverview
@@ -63,7 +64,7 @@ class RateLimitClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RateLimitOverview]:
+    ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 
         from ..models import BasicError, RateLimitOverview

--- a/githubkit/versions/ghec_v2022_11_28/rest/reactions.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/reactions.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
     from ..models import Reaction
     from ..types import (
+        ReactionType,
         ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
         ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
         ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
@@ -70,7 +71,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
         from ..models import Reaction
@@ -108,7 +109,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
         from ..models import Reaction
@@ -141,7 +142,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_comment_in_org(
@@ -156,7 +157,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_comment_in_org(
         self,
@@ -170,7 +171,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion-comment"""
 
         from ..models import (
@@ -212,7 +213,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_comment_in_org(
@@ -227,7 +228,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_comment_in_org(
         self,
@@ -241,7 +242,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion-comment"""
 
         from ..models import (
@@ -331,7 +332,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
         from ..models import Reaction
@@ -368,7 +369,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
         from ..models import Reaction
@@ -400,7 +401,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_in_org(
@@ -414,7 +415,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_in_org(
         self,
@@ -427,7 +428,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion"""
 
         from ..models import (
@@ -467,7 +468,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_in_org(
@@ -481,7 +482,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_in_org(
         self,
@@ -494,7 +495,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion"""
 
         from ..models import (
@@ -581,7 +582,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
         from ..models import Reaction, BasicError
@@ -621,7 +622,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
         from ..models import Reaction, BasicError
@@ -656,7 +657,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_commit_comment(
@@ -670,7 +671,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_commit_comment(
         self,
@@ -681,7 +682,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-commit-comment"""
 
         from ..models import (
@@ -725,7 +726,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_commit_comment(
@@ -739,7 +740,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_commit_comment(
         self,
@@ -750,7 +751,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-commit-comment"""
 
         from ..models import (
@@ -841,7 +842,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
         from ..models import Reaction, BasicError
@@ -881,7 +882,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
         from ..models import Reaction, BasicError
@@ -916,7 +917,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_issue_comment(
@@ -930,7 +931,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_issue_comment(
         self,
@@ -943,7 +944,7 @@ class ReactionsClient:
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-an-issue-comment"""
 
         from ..models import (
@@ -987,7 +988,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_issue_comment(
@@ -1001,7 +1002,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_issue_comment(
         self,
@@ -1014,7 +1015,7 @@ class ReactionsClient:
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-an-issue-comment"""
 
         from ..models import (
@@ -1105,7 +1106,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue"""
 
         from ..models import Reaction, BasicError
@@ -1146,7 +1147,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue"""
 
         from ..models import Reaction, BasicError
@@ -1182,7 +1183,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_issue(
@@ -1196,7 +1197,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_issue(
         self,
@@ -1207,7 +1208,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-an-issue"""
 
         from ..models import (
@@ -1251,7 +1252,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_issue(
@@ -1265,7 +1266,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_issue(
         self,
@@ -1276,7 +1277,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-an-issue"""
 
         from ..models import (
@@ -1367,7 +1368,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
         from ..models import Reaction, BasicError
@@ -1407,7 +1408,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
         from ..models import Reaction, BasicError
@@ -1442,7 +1443,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_pull_request_review_comment(
@@ -1456,7 +1457,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_pull_request_review_comment(
         self,
@@ -1469,7 +1470,7 @@ class ReactionsClient:
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment"""
 
         from ..models import (
@@ -1513,7 +1514,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_pull_request_review_comment(
@@ -1527,7 +1528,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_pull_request_review_comment(
         self,
@@ -1540,7 +1541,7 @@ class ReactionsClient:
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment"""
 
         from ..models import (
@@ -1633,7 +1634,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-release"""
 
         from ..models import Reaction, BasicError
@@ -1671,7 +1672,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-release"""
 
         from ..models import Reaction, BasicError
@@ -1706,7 +1707,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_release(
@@ -1718,7 +1719,7 @@ class ReactionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_release(
         self,
@@ -1729,7 +1730,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-release"""
 
         from ..models import (
@@ -1773,7 +1774,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_release(
@@ -1785,7 +1786,7 @@ class ReactionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_release(
         self,
@@ -1796,7 +1797,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-release"""
 
         from ..models import (
@@ -1887,7 +1888,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
         from ..models import Reaction
@@ -1924,7 +1925,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
         from ..models import Reaction
@@ -1956,7 +1957,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_comment_legacy(
@@ -1970,7 +1971,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_comment_legacy(
         self,
@@ -1983,7 +1984,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion-comment-legacy"""
 
         from ..models import (
@@ -2024,7 +2025,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_comment_legacy(
@@ -2038,7 +2039,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_comment_legacy(
         self,
@@ -2051,7 +2052,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion-comment-legacy"""
 
         from ..models import (
@@ -2096,7 +2097,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
         from ..models import Reaction
@@ -2132,7 +2133,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
         from ..models import Reaction
@@ -2163,7 +2164,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_legacy(
@@ -2176,7 +2177,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_legacy(
         self,
@@ -2188,7 +2189,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion-legacy"""
 
         from ..models import (
@@ -2227,7 +2228,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_legacy(
@@ -2240,7 +2241,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_legacy(
         self,
@@ -2252,7 +2253,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#create-reaction-for-a-team-discussion-legacy"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/repos.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/repos.py
@@ -125,20 +125,84 @@ if TYPE_CHECKING:
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
     )
     from ..types import (
+        TagType,
+        HookType,
+        PageType,
+        TeamType,
+        TopicType,
+        CommitType,
+        StatusType,
+        ReleaseType,
+        ActivityType,
+        AutolinkType,
+        LanguageType,
+        DeployKeyType,
+        PageBuildType,
+        RuleSuiteType,
+        DeploymentType,
+        FileCommitType,
+        RepositoryType,
+        SimpleUserType,
+        BranchShortType,
+        ContentFileType,
+        ContributorType,
+        EnvironmentType,
+        IntegrationType,
+        ShortBranchType,
+        ViewTrafficType,
+        CloneTrafficType,
+        CollaboratorType,
+        HookDeliveryType,
+        ReleaseAssetType,
+        CommitCommentType,
+        TagProtectionType,
         WebhookConfigType,
+        CommitActivityType,
+        ContentSymlinkType,
+        ContentTrafficType,
+        FullRepositoryType,
+        MergedUpstreamType,
+        PageDeploymentType,
+        PageBuildStatusType,
+        ProtectedBranchType,
+        ReferrerTrafficType,
+        RuleSuitesItemsType,
+        BranchProtectionType,
+        CodeownersErrorsType,
+        CommitComparisonType,
+        CommunityProfileType,
+        ContentSubmoduleType,
+        DeploymentStatusType,
+        HookDeliveryItemType,
+        PagesHealthCheckType,
+        MinimalRepositoryType,
+        PullRequestSimpleType,
+        RepositoryRulesetType,
+        StatusCheckPolicyType,
         UserReposPostBodyType,
+        ParticipationStatsType,
+        ContributorActivityType,
         CustomPropertyValueType,
+        ReleaseNotesContentType,
+        BranchWithProtectionType,
+        CombinedCommitStatusType,
         OrgsOrgReposPostBodyType,
+        RepositoryInvitationType,
         RepositoryRuleUpdateType,
+        ContentDirectoryItemsType,
+        PagesDeploymentStatusType,
         RepositoryRuleOneof15Type,
         RepositoryRuleOneof16Type,
         RepositoryRuleOneof17Type,
         RepositoryRuleOneof18Type,
+        DeploymentBranchPolicyType,
         RepositoryRuleCreationType,
         RepositoryRuleDeletionType,
+        BranchRestrictionPolicyType,
         OrgsOrgRulesetsPostBodyType,
         RepositoryRuleWorkflowsType,
         ReposOwnerRepoPatchBodyType,
+        DeploymentProtectionRuleType,
         RepositoryRuleMergeQueueType,
         RepositoryRulePullRequestType,
         OrgRulesetConditionsOneof0Type,
@@ -146,14 +210,33 @@ if TYPE_CHECKING:
         OrgRulesetConditionsOneof2Type,
         RepositoryRuleCodeScanningType,
         ReposOwnerRepoKeysPostBodyType,
+        CheckAutomatedSecurityFixesType,
         RepositoryRulesetConditionsType,
         ReposOwnerRepoForksPostBodyType,
         ReposOwnerRepoHooksPostBodyType,
         ReposOwnerRepoTopicsPutBodyType,
+        ProtectedBranchAdminEnforcedType,
+        RepositoryRuleDetailedOneof0Type,
+        RepositoryRuleDetailedOneof1Type,
+        RepositoryRuleDetailedOneof2Type,
+        RepositoryRuleDetailedOneof3Type,
+        RepositoryRuleDetailedOneof4Type,
+        RepositoryRuleDetailedOneof5Type,
+        RepositoryRuleDetailedOneof6Type,
+        RepositoryRuleDetailedOneof7Type,
+        RepositoryRuleDetailedOneof8Type,
+        RepositoryRuleDetailedOneof9Type,
         RepositoryRuleNonFastForwardType,
         RepositoryRulesetBypassActorType,
         RepositoryRuleTagNamePatternType,
         ReposOwnerRepoMergesPostBodyType,
+        RepositoryRuleDetailedOneof10Type,
+        RepositoryRuleDetailedOneof11Type,
+        RepositoryRuleDetailedOneof12Type,
+        RepositoryRuleDetailedOneof13Type,
+        RepositoryRuleDetailedOneof14Type,
+        RepositoryRuleDetailedOneof15Type,
+        RepositoryRuleDetailedOneof16Type,
         DeploymentBranchPolicySettingsType,
         ReposOwnerRepoReleasesPostBodyType,
         ReposOwnerRepoRulesetsPostBodyType,
@@ -161,6 +244,8 @@ if TYPE_CHECKING:
         OrgsOrgRulesetsRulesetIdPutBodyType,
         RepositoryRuleBranchNamePatternType,
         ReposOwnerRepoAutolinksPostBodyType,
+        ProtectedBranchPullRequestReviewType,
+        RepositoryCollaboratorPermissionType,
         RepositoryRuleRequiredSignaturesType,
         ReposOwnerRepoDispatchesPostBodyType,
         ReposOwnerRepoPagesPutBodyAnyof0Type,
@@ -192,9 +277,11 @@ if TYPE_CHECKING:
         ReposOwnerRepoPropertiesValuesPatchBodyType,
         OrgsOrgReposPostBodyPropCustomPropertiesType,
         ReposOwnerRepoCommentsCommentIdPatchBodyType,
+        ReposOwnerRepoEnvironmentsGetResponse200Type,
         ReposOwnerRepoHooksHookIdConfigPatchBodyType,
         ReposOwnerRepoReleasesReleaseIdPatchBodyType,
         DeploymentBranchPolicyNamePatternWithTypeType,
+        ReposOwnerRepoAttestationsPostResponse201Type,
         ReposOwnerRepoBranchesBranchRenamePostBodyType,
         ReposOwnerRepoCollaboratorsUsernamePutBodyType,
         ReposOwnerRepoPagesPutBodyPropSourceAnyof1Type,
@@ -212,8 +299,11 @@ if TYPE_CHECKING:
         ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType,
         ReposOwnerRepoContentsPathDeleteBodyPropCommitterType,
         ReposOwnerRepoDispatchesPostBodyPropClientPayloadType,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         ReposOwnerRepoDeploymentsPostBodyPropPayloadOneof0Type,
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
         ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionPutBodyPropRestrictionsType,
         ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
         ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
@@ -231,9 +321,12 @@ if TYPE_CHECKING:
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
         ReposOwnerRepoBranchesBranchProtectionPutBodyPropRequiredPullRequestReviewsType,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyPropChecksItemsType,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropDismissalRestrictionsType,
         ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropBypassPullRequestAllowancesType,
     )
@@ -266,7 +359,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-organization-repositories"""
 
         from ..models import MinimalRepository
@@ -303,7 +396,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-organization-repositories"""
 
         from ..models import MinimalRepository
@@ -335,7 +428,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_in_org(
@@ -375,7 +468,7 @@ class ReposClient:
         custom_properties: Missing[
             OrgsOrgReposPostBodyPropCustomPropertiesType
         ] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_in_org(
         self,
@@ -384,7 +477,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-an-organization-repository"""
 
         from ..models import (
@@ -426,7 +519,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_in_org(
@@ -466,7 +559,7 @@ class ReposClient:
         custom_properties: Missing[
             OrgsOrgReposPostBodyPropCustomPropertiesType
         ] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_in_org(
         self,
@@ -475,7 +568,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-an-organization-repository"""
 
         from ..models import (
@@ -518,7 +611,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-all-organization-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -553,7 +646,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-all-organization-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -587,7 +680,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def create_org_ruleset(
@@ -634,7 +727,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def create_org_ruleset(
         self,
@@ -643,7 +736,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#create-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset, OrgsOrgRulesetsPostBody
@@ -680,7 +773,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_create_org_ruleset(
@@ -727,7 +820,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_create_org_ruleset(
         self,
@@ -736,7 +829,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#create-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset, OrgsOrgRulesetsPostBody
@@ -778,7 +871,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#list-organization-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -821,7 +914,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#list-organization-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -858,7 +951,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -884,7 +977,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -910,7 +1003,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -936,7 +1029,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -964,7 +1057,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def update_org_ruleset(
@@ -1012,7 +1105,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def update_org_ruleset(
         self,
@@ -1022,7 +1115,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#update-an-organization-repository-ruleset"""
 
         from ..models import (
@@ -1064,7 +1157,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_update_org_ruleset(
@@ -1112,7 +1205,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_update_org_ruleset(
         self,
@@ -1122,7 +1215,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#update-an-organization-repository-ruleset"""
 
         from ..models import (
@@ -1212,7 +1305,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-a-repository"""
 
         from ..models import BasicError, FullRepository
@@ -1238,7 +1331,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-a-repository"""
 
         from ..models import BasicError, FullRepository
@@ -1316,7 +1409,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def update(
@@ -1357,7 +1450,7 @@ class ReposClient:
         archived: Missing[bool] = UNSET,
         allow_forking: Missing[bool] = UNSET,
         web_commit_signoff_required: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def update(
         self,
@@ -1367,7 +1460,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#update-a-repository"""
 
         from ..models import (
@@ -1411,7 +1504,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_update(
@@ -1452,7 +1545,7 @@ class ReposClient:
         archived: Missing[bool] = UNSET,
         allow_forking: Missing[bool] = UNSET,
         web_commit_signoff_required: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_update(
         self,
@@ -1462,7 +1555,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#update-a-repository"""
 
         from ..models import (
@@ -1523,7 +1616,7 @@ class ReposClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Activity]]:
+    ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-activities"""
 
         from ..models import Activity, ValidationErrorSimple
@@ -1579,7 +1672,7 @@ class ReposClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Activity]]:
+    ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-activities"""
 
         from ..models import Activity, ValidationErrorSimple
@@ -1618,7 +1711,10 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     @overload
     def create_attestation(
@@ -1629,7 +1725,10 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     def create_attestation(
         self,
@@ -1639,7 +1738,10 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-an-attestation"""
 
         from ..models import (
@@ -1682,7 +1784,10 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_create_attestation(
@@ -1693,7 +1798,10 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     async def async_create_attestation(
         self,
@@ -1703,7 +1811,10 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-an-attestation"""
 
         from ..models import (
@@ -1748,7 +1859,10 @@ class ReposClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-attestations"""
 
         from ..models import ReposOwnerRepoAttestationsSubjectDigestGetResponse200
@@ -1781,7 +1895,10 @@ class ReposClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-attestations"""
 
         from ..models import ReposOwnerRepoAttestationsSubjectDigestGetResponse200
@@ -1810,7 +1927,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Autolink]]:
+    ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
         from ..models import Autolink
@@ -1832,7 +1949,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Autolink]]:
+    ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
         from ..models import Autolink
@@ -1856,7 +1973,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     @overload
     def create_autolink(
@@ -1869,7 +1986,7 @@ class ReposClient:
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     def create_autolink(
         self,
@@ -1879,7 +1996,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#create-an-autolink-reference-for-a-repository"""
 
         from ..models import Autolink, ValidationError, ReposOwnerRepoAutolinksPostBody
@@ -1916,7 +2033,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     @overload
     async def async_create_autolink(
@@ -1929,7 +2046,7 @@ class ReposClient:
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     async def async_create_autolink(
         self,
@@ -1939,7 +2056,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#create-an-autolink-reference-for-a-repository"""
 
         from ..models import Autolink, ValidationError, ReposOwnerRepoAutolinksPostBody
@@ -1975,7 +2092,7 @@ class ReposClient:
         autolink_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
         from ..models import Autolink, BasicError
@@ -2001,7 +2118,7 @@ class ReposClient:
         autolink_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
         from ..models import Autolink, BasicError
@@ -2076,7 +2193,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckAutomatedSecurityFixes]:
+    ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
         from ..models import CheckAutomatedSecurityFixes
@@ -2099,7 +2216,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckAutomatedSecurityFixes]:
+    ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
         from ..models import CheckAutomatedSecurityFixes
@@ -2201,7 +2318,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ShortBranch]]:
+    ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#list-branches"""
 
         from ..models import BasicError, ShortBranch
@@ -2236,7 +2353,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ShortBranch]]:
+    ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#list-branches"""
 
         from ..models import BasicError, ShortBranch
@@ -2269,7 +2386,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#get-a-branch"""
 
         from ..models import BasicError, BranchWithProtection
@@ -2295,7 +2412,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#get-a-branch"""
 
         from ..models import BasicError, BranchWithProtection
@@ -2321,7 +2438,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchProtection]:
+    ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-branch-protection"""
 
         from ..models import BasicError, BranchProtection
@@ -2347,7 +2464,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchProtection]:
+    ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-branch-protection"""
 
         from ..models import BasicError, BranchProtection
@@ -2375,7 +2492,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     @overload
     def update_branch_protection(
@@ -2405,7 +2522,7 @@ class ReposClient:
         required_conversation_resolution: Missing[bool] = UNSET,
         lock_branch: Missing[bool] = UNSET,
         allow_fork_syncing: Missing[bool] = UNSET,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     def update_branch_protection(
         self,
@@ -2416,7 +2533,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranch]:
+    ) -> Response[ProtectedBranch, ProtectedBranchType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#update-branch-protection"""
 
         from ..models import (
@@ -2463,7 +2580,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     @overload
     async def async_update_branch_protection(
@@ -2493,7 +2610,7 @@ class ReposClient:
         required_conversation_resolution: Missing[bool] = UNSET,
         lock_branch: Missing[bool] = UNSET,
         allow_fork_syncing: Missing[bool] = UNSET,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     async def async_update_branch_protection(
         self,
@@ -2504,7 +2621,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranch]:
+    ) -> Response[ProtectedBranch, ProtectedBranchType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#update-branch-protection"""
 
         from ..models import (
@@ -2599,7 +2716,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2622,7 +2739,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2645,7 +2762,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2668,7 +2785,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2741,7 +2858,9 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-pull-request-review-protection"""
 
         from ..models import ProtectedBranchPullRequestReview
@@ -2764,7 +2883,9 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-pull-request-review-protection"""
 
         from ..models import ProtectedBranchPullRequestReview
@@ -2841,7 +2962,9 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     @overload
     def update_pull_request_review_protection(
@@ -2862,7 +2985,9 @@ class ReposClient:
         bypass_pull_request_allowances: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropBypassPullRequestAllowancesType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     def update_pull_request_review_protection(
         self,
@@ -2875,7 +3000,9 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#update-pull-request-review-protection"""
 
         from ..models import (
@@ -2922,7 +3049,9 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     @overload
     async def async_update_pull_request_review_protection(
@@ -2943,7 +3072,9 @@ class ReposClient:
         bypass_pull_request_allowances: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropBypassPullRequestAllowancesType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     async def async_update_pull_request_review_protection(
         self,
@@ -2956,7 +3087,9 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#update-pull-request-review-protection"""
 
         from ..models import (
@@ -2999,7 +3132,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3025,7 +3158,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3051,7 +3184,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#create-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3077,7 +3210,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#create-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3153,7 +3286,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-status-checks-protection"""
 
         from ..models import BasicError, StatusCheckPolicy
@@ -3181,7 +3314,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-status-checks-protection"""
 
         from ..models import BasicError, StatusCheckPolicy
@@ -3257,7 +3390,7 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     @overload
     def update_status_check_protection(
@@ -3275,7 +3408,7 @@ class ReposClient:
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyPropChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     def update_status_check_protection(
         self,
@@ -3288,7 +3421,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#update-status-check-protection"""
 
         from ..models import (
@@ -3339,7 +3472,7 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     @overload
     async def async_update_status_check_protection(
@@ -3357,7 +3490,7 @@ class ReposClient:
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyPropChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     async def async_update_status_check_protection(
         self,
@@ -3370,7 +3503,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#update-status-check-protection"""
 
         from ..models import (
@@ -3417,7 +3550,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-all-status-check-contexts"""
 
         from ..models import BasicError
@@ -3443,7 +3576,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-all-status-check-contexts"""
 
         from ..models import BasicError
@@ -3476,7 +3609,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     def set_status_check_contexts(
@@ -3488,7 +3621,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     def set_status_check_contexts(
         self,
@@ -3504,7 +3637,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-status-check-contexts"""
 
         from typing import Union
@@ -3560,7 +3693,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     async def async_set_status_check_contexts(
@@ -3572,7 +3705,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     async def async_set_status_check_contexts(
         self,
@@ -3588,7 +3721,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-status-check-contexts"""
 
         from typing import Union
@@ -3644,7 +3777,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     def add_status_check_contexts(
@@ -3656,7 +3789,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     def add_status_check_contexts(
         self,
@@ -3672,7 +3805,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-status-check-contexts"""
 
         from typing import Union
@@ -3729,7 +3862,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     async def async_add_status_check_contexts(
@@ -3741,7 +3874,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     async def async_add_status_check_contexts(
         self,
@@ -3757,7 +3890,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-status-check-contexts"""
 
         from typing import Union
@@ -3814,7 +3947,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     def remove_status_check_contexts(
@@ -3826,7 +3959,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     def remove_status_check_contexts(
         self,
@@ -3842,7 +3975,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-status-check-contexts"""
 
         from typing import Union
@@ -3898,7 +4031,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     async def async_remove_status_check_contexts(
@@ -3910,7 +4043,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     async def async_remove_status_check_contexts(
         self,
@@ -3926,7 +4059,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-status-check-contexts"""
 
         from typing import Union
@@ -3975,7 +4108,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchRestrictionPolicy]:
+    ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-access-restrictions"""
 
         from ..models import BasicError, BranchRestrictionPolicy
@@ -4001,7 +4134,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchRestrictionPolicy]:
+    ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-access-restrictions"""
 
         from ..models import BasicError, BranchRestrictionPolicy
@@ -4067,7 +4200,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
         from typing import Union
@@ -4095,7 +4228,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
         from typing import Union
@@ -4125,7 +4258,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     def set_app_access_restrictions(
@@ -4137,7 +4272,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     def set_app_access_restrictions(
         self,
@@ -4150,7 +4287,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-app-access-restrictions"""
 
         from typing import Union
@@ -4196,7 +4333,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     async def async_set_app_access_restrictions(
@@ -4208,7 +4347,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     async def async_set_app_access_restrictions(
         self,
@@ -4221,7 +4362,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-app-access-restrictions"""
 
         from typing import Union
@@ -4267,7 +4408,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     def add_app_access_restrictions(
@@ -4279,7 +4422,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     def add_app_access_restrictions(
         self,
@@ -4292,7 +4437,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-app-access-restrictions"""
 
         from typing import Union
@@ -4338,7 +4483,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     async def async_add_app_access_restrictions(
@@ -4350,7 +4497,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     async def async_add_app_access_restrictions(
         self,
@@ -4363,7 +4512,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-app-access-restrictions"""
 
         from typing import Union
@@ -4409,7 +4558,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     def remove_app_access_restrictions(
@@ -4421,7 +4572,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     def remove_app_access_restrictions(
         self,
@@ -4434,7 +4587,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-app-access-restrictions"""
 
         from typing import Union
@@ -4480,7 +4633,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     async def async_remove_app_access_restrictions(
@@ -4492,7 +4647,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     async def async_remove_app_access_restrictions(
         self,
@@ -4505,7 +4662,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-app-access-restrictions"""
 
         from typing import Union
@@ -4549,7 +4706,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
         from ..models import Team, BasicError
@@ -4575,7 +4732,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
         from ..models import Team, BasicError
@@ -4608,7 +4765,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     def set_team_access_restrictions(
@@ -4620,7 +4777,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     def set_team_access_restrictions(
         self,
@@ -4636,7 +4793,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-team-access-restrictions"""
 
         from typing import Union
@@ -4691,7 +4848,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     async def async_set_team_access_restrictions(
@@ -4703,7 +4860,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     async def async_set_team_access_restrictions(
         self,
@@ -4719,7 +4876,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-team-access-restrictions"""
 
         from typing import Union
@@ -4774,7 +4931,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     def add_team_access_restrictions(
@@ -4786,7 +4943,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     def add_team_access_restrictions(
         self,
@@ -4802,7 +4959,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-team-access-restrictions"""
 
         from typing import Union
@@ -4857,7 +5014,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     async def async_add_team_access_restrictions(
@@ -4869,7 +5026,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     async def async_add_team_access_restrictions(
         self,
@@ -4885,7 +5042,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-team-access-restrictions"""
 
         from typing import Union
@@ -4940,7 +5097,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     def remove_team_access_restrictions(
@@ -4952,7 +5109,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     def remove_team_access_restrictions(
         self,
@@ -4968,7 +5125,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-team-access-restrictions"""
 
         from typing import Union
@@ -5023,7 +5180,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     async def async_remove_team_access_restrictions(
@@ -5035,7 +5192,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     async def async_remove_team_access_restrictions(
         self,
@@ -5051,7 +5208,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-team-access-restrictions"""
 
         from typing import Union
@@ -5099,7 +5256,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
         from ..models import BasicError, SimpleUser
@@ -5125,7 +5282,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
         from ..models import BasicError, SimpleUser
@@ -5153,7 +5310,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     def set_user_access_restrictions(
@@ -5165,7 +5322,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     def set_user_access_restrictions(
         self,
@@ -5178,7 +5335,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-user-access-restrictions"""
 
         from ..models import (
@@ -5222,7 +5379,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     async def async_set_user_access_restrictions(
@@ -5234,7 +5391,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     async def async_set_user_access_restrictions(
         self,
@@ -5247,7 +5404,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-user-access-restrictions"""
 
         from ..models import (
@@ -5291,7 +5448,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     def add_user_access_restrictions(
@@ -5303,7 +5460,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     def add_user_access_restrictions(
         self,
@@ -5316,7 +5473,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-user-access-restrictions"""
 
         from ..models import (
@@ -5360,7 +5517,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     async def async_add_user_access_restrictions(
@@ -5372,7 +5529,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     async def async_add_user_access_restrictions(
         self,
@@ -5385,7 +5542,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#add-user-access-restrictions"""
 
         from ..models import (
@@ -5429,7 +5586,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     def remove_user_access_restrictions(
@@ -5441,7 +5598,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     def remove_user_access_restrictions(
         self,
@@ -5454,7 +5611,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-user-access-restrictions"""
 
         from ..models import (
@@ -5498,7 +5655,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     async def async_remove_user_access_restrictions(
@@ -5510,7 +5667,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     async def async_remove_user_access_restrictions(
         self,
@@ -5523,7 +5680,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-user-access-restrictions"""
 
         from ..models import (
@@ -5567,7 +5724,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     @overload
     def rename_branch(
@@ -5579,7 +5736,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         new_name: str,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     def rename_branch(
         self,
@@ -5590,7 +5747,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#rename-a-branch"""
 
         from ..models import (
@@ -5637,7 +5794,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     @overload
     async def async_rename_branch(
@@ -5649,7 +5806,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         new_name: str,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     async def async_rename_branch(
         self,
@@ -5660,7 +5817,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#rename-a-branch"""
 
         from ..models import (
@@ -5705,7 +5862,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeownersErrors]:
+    ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-codeowners-errors"""
 
         from ..models import CodeownersErrors
@@ -5734,7 +5891,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeownersErrors]:
+    ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-codeowners-errors"""
 
         from ..models import CodeownersErrors
@@ -5768,7 +5925,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Collaborator]]:
+    ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#list-repository-collaborators"""
 
         from ..models import BasicError, Collaborator
@@ -5807,7 +5964,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Collaborator]]:
+    ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#list-repository-collaborators"""
 
         from ..models import BasicError, Collaborator
@@ -5885,7 +6042,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     def add_collaborator(
@@ -5897,7 +6054,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         permission: Missing[str] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     def add_collaborator(
         self,
@@ -5908,7 +6065,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#add-a-repository-collaborator"""
 
         from ..models import (
@@ -5954,7 +6111,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     async def async_add_collaborator(
@@ -5966,7 +6123,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         permission: Missing[str] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     async def async_add_collaborator(
         self,
@@ -5977,7 +6134,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#add-a-repository-collaborator"""
 
         from ..models import (
@@ -6073,7 +6230,9 @@ class ReposClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryCollaboratorPermission]:
+    ) -> Response[
+        RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#get-repository-permissions-for-a-user"""
 
         from ..models import BasicError, RepositoryCollaboratorPermission
@@ -6099,7 +6258,9 @@ class ReposClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryCollaboratorPermission]:
+    ) -> Response[
+        RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#get-repository-permissions-for-a-user"""
 
         from ..models import BasicError, RepositoryCollaboratorPermission
@@ -6126,7 +6287,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments-for-a-repository"""
 
         from ..models import CommitComment
@@ -6156,7 +6317,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments-for-a-repository"""
 
         from ..models import CommitComment
@@ -6185,7 +6346,7 @@ class ReposClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#get-a-commit-comment"""
 
         from ..models import BasicError, CommitComment
@@ -6211,7 +6372,7 @@ class ReposClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#get-a-commit-comment"""
 
         from ..models import BasicError, CommitComment
@@ -6289,7 +6450,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     def update_commit_comment(
@@ -6301,7 +6462,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     def update_commit_comment(
         self,
@@ -6312,7 +6473,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#update-a-commit-comment"""
 
         from ..models import (
@@ -6354,7 +6515,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     async def async_update_commit_comment(
@@ -6366,7 +6527,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     async def async_update_commit_comment(
         self,
@@ -6377,7 +6538,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#update-a-commit-comment"""
 
         from ..models import (
@@ -6424,7 +6585,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-commits"""
 
         from ..models import Commit, BasicError
@@ -6472,7 +6633,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-commits"""
 
         from ..models import Commit, BasicError
@@ -6513,7 +6674,7 @@ class ReposClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BranchShort]]:
+    ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-branches-for-head-commit"""
 
         from ..models import BasicError, BranchShort, ValidationError
@@ -6540,7 +6701,7 @@ class ReposClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BranchShort]]:
+    ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-branches-for-head-commit"""
 
         from ..models import BasicError, BranchShort, ValidationError
@@ -6569,7 +6730,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments"""
 
         from ..models import CommitComment
@@ -6600,7 +6761,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments"""
 
         from ..models import CommitComment
@@ -6631,7 +6792,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     def create_commit_comment(
@@ -6646,7 +6807,7 @@ class ReposClient:
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
         line: Missing[int] = UNSET,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     def create_commit_comment(
         self,
@@ -6657,7 +6818,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#create-a-commit-comment"""
 
         from ..models import (
@@ -6703,7 +6864,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     async def async_create_commit_comment(
@@ -6718,7 +6879,7 @@ class ReposClient:
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
         line: Missing[int] = UNSET,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     async def async_create_commit_comment(
         self,
@@ -6729,7 +6890,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#create-a-commit-comment"""
 
         from ..models import (
@@ -6775,7 +6936,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
         from ..models import BasicError, PullRequestSimple
@@ -6809,7 +6970,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
         from ..models import BasicError, PullRequestSimple
@@ -6843,7 +7004,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#get-a-commit"""
 
         from ..models import (
@@ -6886,7 +7047,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#get-a-commit"""
 
         from ..models import (
@@ -6929,7 +7090,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedCommitStatus]:
+    ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
         from ..models import BasicError, CombinedCommitStatus
@@ -6963,7 +7124,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedCommitStatus]:
+    ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
         from ..models import BasicError, CombinedCommitStatus
@@ -6997,7 +7158,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Status]]:
+    ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
         from ..models import Status
@@ -7028,7 +7189,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Status]]:
+    ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
         from ..models import Status
@@ -7056,7 +7217,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommunityProfile]:
+    ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/community#get-community-profile-metrics"""
 
         from ..models import CommunityProfile
@@ -7078,7 +7239,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommunityProfile]:
+    ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/community#get-community-profile-metrics"""
 
         from ..models import CommunityProfile
@@ -7103,7 +7264,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComparison]:
+    ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#compare-two-commits"""
 
         from ..models import (
@@ -7143,7 +7304,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComparison]:
+    ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#compare-two-commits"""
 
         from ..models import (
@@ -7185,7 +7346,13 @@ class ReposClient:
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
-        ]
+        ],
+        Union[
+            list[ContentDirectoryItemsType],
+            ContentFileType,
+            ContentSymlinkType,
+            ContentSubmoduleType,
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-repository-content"""
 
@@ -7235,7 +7402,13 @@ class ReposClient:
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
-        ]
+        ],
+        Union[
+            list[ContentDirectoryItemsType],
+            ContentFileType,
+            ContentSymlinkType,
+            ContentSubmoduleType,
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-repository-content"""
 
@@ -7283,7 +7456,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     def create_or_update_file_contents(
@@ -7300,7 +7473,7 @@ class ReposClient:
         branch: Missing[str] = UNSET,
         committer: Missing[ReposOwnerRepoContentsPathPutBodyPropCommitterType] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathPutBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     def create_or_update_file_contents(
         self,
@@ -7311,7 +7484,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#create-or-update-file-contents"""
 
         from typing import Union
@@ -7359,7 +7532,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     async def async_create_or_update_file_contents(
@@ -7376,7 +7549,7 @@ class ReposClient:
         branch: Missing[str] = UNSET,
         committer: Missing[ReposOwnerRepoContentsPathPutBodyPropCommitterType] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathPutBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     async def async_create_or_update_file_contents(
         self,
@@ -7387,7 +7560,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#create-or-update-file-contents"""
 
         from typing import Union
@@ -7435,7 +7608,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     def delete_file(
@@ -7453,7 +7626,7 @@ class ReposClient:
             ReposOwnerRepoContentsPathDeleteBodyPropCommitterType
         ] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathDeleteBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     def delete_file(
         self,
@@ -7464,7 +7637,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#delete-a-file"""
 
         from ..models import (
@@ -7511,7 +7684,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     async def async_delete_file(
@@ -7529,7 +7702,7 @@ class ReposClient:
             ReposOwnerRepoContentsPathDeleteBodyPropCommitterType
         ] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathDeleteBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     async def async_delete_file(
         self,
@@ -7540,7 +7713,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#delete-a-file"""
 
         from ..models import (
@@ -7587,7 +7760,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Contributor]]:
+    ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-contributors"""
 
         from ..models import BasicError, Contributor
@@ -7623,7 +7796,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Contributor]]:
+    ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-contributors"""
 
         from ..models import BasicError, Contributor
@@ -7662,7 +7835,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#list-deployments"""
 
         from ..models import Deployment
@@ -7700,7 +7873,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#list-deployments"""
 
         from ..models import Deployment
@@ -7734,7 +7907,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     @overload
     def create_deployment(
@@ -7755,7 +7928,7 @@ class ReposClient:
         description: Missing[Union[str, None]] = UNSET,
         transient_environment: Missing[bool] = UNSET,
         production_environment: Missing[bool] = UNSET,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     def create_deployment(
         self,
@@ -7765,7 +7938,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#create-a-deployment"""
 
         from ..models import (
@@ -7806,7 +7979,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     @overload
     async def async_create_deployment(
@@ -7827,7 +8000,7 @@ class ReposClient:
         description: Missing[Union[str, None]] = UNSET,
         transient_environment: Missing[bool] = UNSET,
         production_environment: Missing[bool] = UNSET,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     async def async_create_deployment(
         self,
@@ -7837,7 +8010,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#create-a-deployment"""
 
         from ..models import (
@@ -7877,7 +8050,7 @@ class ReposClient:
         deployment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#get-a-deployment"""
 
         from ..models import BasicError, Deployment
@@ -7903,7 +8076,7 @@ class ReposClient:
         deployment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#get-a-deployment"""
 
         from ..models import BasicError, Deployment
@@ -7983,7 +8156,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeploymentStatus]]:
+    ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#list-deployment-statuses"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8017,7 +8190,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeploymentStatus]]:
+    ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#list-deployment-statuses"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8051,7 +8224,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     @overload
     def create_deployment_status(
@@ -8077,7 +8250,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         environment_url: Missing[str] = UNSET,
         auto_inactive: Missing[bool] = UNSET,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     def create_deployment_status(
         self,
@@ -8090,7 +8263,7 @@ class ReposClient:
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#create-a-deployment-status"""
 
         from ..models import (
@@ -8134,7 +8307,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     @overload
     async def async_create_deployment_status(
@@ -8160,7 +8333,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         environment_url: Missing[str] = UNSET,
         auto_inactive: Missing[bool] = UNSET,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     async def async_create_deployment_status(
         self,
@@ -8173,7 +8346,7 @@ class ReposClient:
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#create-a-deployment-status"""
 
         from ..models import (
@@ -8216,7 +8389,7 @@ class ReposClient:
         status_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#get-a-deployment-status"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8243,7 +8416,7 @@ class ReposClient:
         status_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#get-a-deployment-status"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8400,7 +8573,10 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsGetResponse200,
+        ReposOwnerRepoEnvironmentsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#list-environments"""
 
         from ..models import ReposOwnerRepoEnvironmentsGetResponse200
@@ -8430,7 +8606,10 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsGetResponse200,
+        ReposOwnerRepoEnvironmentsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#list-environments"""
 
         from ..models import ReposOwnerRepoEnvironmentsGetResponse200
@@ -8459,7 +8638,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#get-an-environment"""
 
         from ..models import Environment
@@ -8482,7 +8661,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#get-an-environment"""
 
         from ..models import Environment
@@ -8509,7 +8688,7 @@ class ReposClient:
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     @overload
     def create_or_update_environment(
@@ -8533,7 +8712,7 @@ class ReposClient:
         deployment_branch_policy: Missing[
             Union[DeploymentBranchPolicySettingsType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     def create_or_update_environment(
         self,
@@ -8546,7 +8725,7 @@ class ReposClient:
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#create-or-update-an-environment"""
 
         from typing import Union
@@ -8594,7 +8773,7 @@ class ReposClient:
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     @overload
     async def async_create_or_update_environment(
@@ -8618,7 +8797,7 @@ class ReposClient:
         deployment_branch_policy: Missing[
             Union[DeploymentBranchPolicySettingsType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     async def async_create_or_update_environment(
         self,
@@ -8631,7 +8810,7 @@ class ReposClient:
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#create-or-update-an-environment"""
 
         from typing import Union
@@ -8718,7 +8897,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#list-deployment-branch-policies"""
 
@@ -8753,7 +8933,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#list-deployment-branch-policies"""
 
@@ -8787,7 +8968,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     def create_deployment_branch_policy(
@@ -8800,7 +8981,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     def create_deployment_branch_policy(
         self,
@@ -8811,7 +8992,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#create-a-deployment-branch-policy"""
 
         from ..models import (
@@ -8850,7 +9031,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     async def async_create_deployment_branch_policy(
@@ -8863,7 +9044,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     async def async_create_deployment_branch_policy(
         self,
@@ -8874,7 +9055,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#create-a-deployment-branch-policy"""
 
         from ..models import (
@@ -8912,7 +9093,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy
@@ -8936,7 +9117,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy
@@ -8962,7 +9143,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     def update_deployment_branch_policy(
@@ -8975,7 +9156,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     def update_deployment_branch_policy(
         self,
@@ -8987,7 +9168,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#update-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy, DeploymentBranchPolicyNamePattern
@@ -9023,7 +9204,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     async def async_update_deployment_branch_policy(
@@ -9036,7 +9217,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     async def async_update_deployment_branch_policy(
         self,
@@ -9048,7 +9229,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#update-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy, DeploymentBranchPolicyNamePattern
@@ -9124,7 +9305,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#get-all-deployment-protection-rules-for-an-environment"""
 
@@ -9151,7 +9333,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#get-all-deployment-protection-rules-for-an-environment"""
 
@@ -9179,7 +9362,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     @overload
     def create_deployment_protection_rule(
@@ -9191,7 +9374,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         integration_id: Missing[int] = UNSET,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     def create_deployment_protection_rule(
         self,
@@ -9204,7 +9387,7 @@ class ReposClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#create-a-custom-deployment-protection-rule-on-an-environment"""
 
         from ..models import (
@@ -9245,7 +9428,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     @overload
     async def async_create_deployment_protection_rule(
@@ -9257,7 +9440,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         integration_id: Missing[int] = UNSET,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     async def async_create_deployment_protection_rule(
         self,
@@ -9270,7 +9453,7 @@ class ReposClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#create-a-custom-deployment-protection-rule-on-an-environment"""
 
         from ..models import (
@@ -9312,7 +9495,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#list-custom-deployment-rule-integrations-available-for-an-environment"""
 
@@ -9347,7 +9531,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#list-custom-deployment-rule-integrations-available-for-an-environment"""
 
@@ -9380,7 +9565,7 @@ class ReposClient:
         protection_rule_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
         from ..models import DeploymentProtectionRule
@@ -9404,7 +9589,7 @@ class ReposClient:
         protection_rule_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
         from ..models import DeploymentProtectionRule
@@ -9471,7 +9656,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/forks#list-forks"""
 
         from ..models import BasicError, MinimalRepository
@@ -9506,7 +9691,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/forks#list-forks"""
 
         from ..models import BasicError, MinimalRepository
@@ -9540,7 +9725,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_fork(
@@ -9553,7 +9738,7 @@ class ReposClient:
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_fork(
         self,
@@ -9563,7 +9748,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/forks#create-a-fork"""
 
         from typing import Union
@@ -9610,7 +9795,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_fork(
@@ -9623,7 +9808,7 @@ class ReposClient:
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_fork(
         self,
@@ -9633,7 +9818,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/forks#create-a-fork"""
 
         from typing import Union
@@ -9680,7 +9865,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Hook]]:
+    ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-repository-webhooks"""
 
         from ..models import Hook, BasicError
@@ -9713,7 +9898,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Hook]]:
+    ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-repository-webhooks"""
 
         from ..models import Hook, BasicError
@@ -9746,7 +9931,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     def create_webhook(
@@ -9760,7 +9945,7 @@ class ReposClient:
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     def create_webhook(
         self,
@@ -9770,7 +9955,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#create-a-repository-webhook"""
 
         from typing import Union
@@ -9816,7 +10001,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     async def async_create_webhook(
@@ -9830,7 +10015,7 @@ class ReposClient:
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     async def async_create_webhook(
         self,
@@ -9840,7 +10025,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#create-a-repository-webhook"""
 
         from typing import Union
@@ -9885,7 +10070,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-repository-webhook"""
 
         from ..models import Hook, BasicError
@@ -9911,7 +10096,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-repository-webhook"""
 
         from ..models import Hook, BasicError
@@ -9989,7 +10174,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     def update_webhook(
@@ -10005,7 +10190,7 @@ class ReposClient:
         add_events: Missing[list[str]] = UNSET,
         remove_events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     def update_webhook(
         self,
@@ -10016,7 +10201,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#update-a-repository-webhook"""
 
         from ..models import (
@@ -10060,7 +10245,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     async def async_update_webhook(
@@ -10076,7 +10261,7 @@ class ReposClient:
         add_events: Missing[list[str]] = UNSET,
         remove_events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     async def async_update_webhook(
         self,
@@ -10087,7 +10272,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#update-a-repository-webhook"""
 
         from ..models import (
@@ -10129,7 +10314,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig
@@ -10152,7 +10337,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig
@@ -10177,7 +10362,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     def update_webhook_config_for_repo(
@@ -10192,7 +10377,7 @@ class ReposClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     def update_webhook_config_for_repo(
         self,
@@ -10203,7 +10388,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#update-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig, ReposOwnerRepoHooksHookIdConfigPatchBody
@@ -10238,7 +10423,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     async def async_update_webhook_config_for_repo(
@@ -10253,7 +10438,7 @@ class ReposClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     async def async_update_webhook_config_for_repo(
         self,
@@ -10264,7 +10449,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#update-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig, ReposOwnerRepoHooksHookIdConfigPatchBody
@@ -10299,7 +10484,7 @@ class ReposClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -10334,7 +10519,7 @@ class ReposClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -10368,7 +10553,7 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -10396,7 +10581,7 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -10424,7 +10609,10 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#redeliver-a-delivery-for-a-repository-webhook"""
 
         from ..models import (
@@ -10456,7 +10644,10 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#redeliver-a-delivery-for-a-repository-webhook"""
 
         from ..models import (
@@ -10588,7 +10779,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations"""
 
         from ..models import RepositoryInvitation
@@ -10618,7 +10809,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations"""
 
         from ..models import RepositoryInvitation
@@ -10689,7 +10880,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     def update_invitation(
@@ -10703,7 +10894,7 @@ class ReposClient:
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     def update_invitation(
         self,
@@ -10714,7 +10905,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#update-a-repository-invitation"""
 
         from ..models import (
@@ -10754,7 +10945,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     async def async_update_invitation(
@@ -10768,7 +10959,7 @@ class ReposClient:
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     async def async_update_invitation(
         self,
@@ -10779,7 +10970,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#update-a-repository-invitation"""
 
         from ..models import (
@@ -10818,7 +11009,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeployKey]]:
+    ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
         from ..models import DeployKey
@@ -10848,7 +11039,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeployKey]]:
+    ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
         from ..models import DeployKey
@@ -10878,7 +11069,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     @overload
     def create_deploy_key(
@@ -10891,7 +11082,7 @@ class ReposClient:
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     def create_deploy_key(
         self,
@@ -10901,7 +11092,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#create-a-deploy-key"""
 
         from ..models import DeployKey, ValidationError, ReposOwnerRepoKeysPostBody
@@ -10938,7 +11129,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     @overload
     async def async_create_deploy_key(
@@ -10951,7 +11142,7 @@ class ReposClient:
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     async def async_create_deploy_key(
         self,
@@ -10961,7 +11152,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#create-a-deploy-key"""
 
         from ..models import DeployKey, ValidationError, ReposOwnerRepoKeysPostBody
@@ -10997,7 +11188,7 @@ class ReposClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
         from ..models import DeployKey, BasicError
@@ -11023,7 +11214,7 @@ class ReposClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
         from ..models import DeployKey, BasicError
@@ -11088,7 +11279,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Language]:
+    ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-languages"""
 
         from ..models import Language
@@ -11110,7 +11301,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Language]:
+    ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-languages"""
 
         from ..models import Language
@@ -11132,7 +11323,10 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/lfs#enable-git-lfs-for-a-repository"""
 
         from ..models import AppHookDeliveriesDeliveryIdAttemptsPostResponse202
@@ -11155,7 +11349,10 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/lfs#enable-git-lfs-for-a-repository"""
 
         from ..models import AppHookDeliveriesDeliveryIdAttemptsPostResponse202
@@ -11218,7 +11415,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     @overload
     def merge_upstream(
@@ -11229,7 +11426,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         branch: str,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     def merge_upstream(
         self,
@@ -11239,7 +11436,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MergedUpstream]:
+    ) -> Response[MergedUpstream, MergedUpstreamType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository"""
 
         from ..models import MergedUpstream, ReposOwnerRepoMergeUpstreamPostBody
@@ -11274,7 +11471,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     @overload
     async def async_merge_upstream(
@@ -11285,7 +11482,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         branch: str,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     async def async_merge_upstream(
         self,
@@ -11295,7 +11492,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MergedUpstream]:
+    ) -> Response[MergedUpstream, MergedUpstreamType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository"""
 
         from ..models import MergedUpstream, ReposOwnerRepoMergeUpstreamPostBody
@@ -11330,7 +11527,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     @overload
     def merge(
@@ -11343,7 +11540,7 @@ class ReposClient:
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     def merge(
         self,
@@ -11353,7 +11550,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#merge-a-branch"""
 
         from ..models import (
@@ -11396,7 +11593,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     @overload
     async def async_merge(
@@ -11409,7 +11606,7 @@ class ReposClient:
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     async def async_merge(
         self,
@@ -11419,7 +11616,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#merge-a-branch"""
 
         from ..models import (
@@ -11460,7 +11657,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-apiname-pages-site"""
 
         from ..models import Page, BasicError
@@ -11485,7 +11682,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-apiname-pages-site"""
 
         from ..models import Page, BasicError
@@ -11875,7 +12072,7 @@ class ReposClient:
             ReposOwnerRepoPagesPostBodyAnyof1Type,
             None,
         ],
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     def create_pages_site(
@@ -11887,7 +12084,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     def create_pages_site(
@@ -11899,7 +12096,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     def create_pages_site(
         self,
@@ -11916,7 +12113,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#create-a-apiname-pages-site"""
 
         from typing import Union
@@ -11975,7 +12172,7 @@ class ReposClient:
             ReposOwnerRepoPagesPostBodyAnyof1Type,
             None,
         ],
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     async def async_create_pages_site(
@@ -11987,7 +12184,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     async def async_create_pages_site(
@@ -11999,7 +12196,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     async def async_create_pages_site(
         self,
@@ -12016,7 +12213,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#create-a-apiname-pages-site"""
 
         from typing import Union
@@ -12122,7 +12319,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PageBuild]]:
+    ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#list-apiname-pages-builds"""
 
         from ..models import PageBuild
@@ -12152,7 +12349,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PageBuild]]:
+    ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#list-apiname-pages-builds"""
 
         from ..models import PageBuild
@@ -12180,7 +12377,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuildStatus]:
+    ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#request-a-apiname-pages-build"""
 
         from ..models import PageBuildStatus
@@ -12202,7 +12399,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuildStatus]:
+    ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#request-a-apiname-pages-build"""
 
         from ..models import PageBuildStatus
@@ -12224,7 +12421,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-latest-pages-build"""
 
         from ..models import PageBuild
@@ -12246,7 +12443,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-latest-pages-build"""
 
         from ..models import PageBuild
@@ -12269,7 +12466,7 @@ class ReposClient:
         build_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-apiname-pages-build"""
 
         from ..models import PageBuild
@@ -12292,7 +12489,7 @@ class ReposClient:
         build_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-apiname-pages-build"""
 
         from ..models import PageBuild
@@ -12316,7 +12513,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     @overload
     def create_pages_deployment(
@@ -12331,7 +12528,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         pages_build_version: str = "GITHUB_SHA",
         oidc_token: str,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     def create_pages_deployment(
         self,
@@ -12341,7 +12538,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PageDeployment]:
+    ) -> Response[PageDeployment, PageDeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#create-a-github-pages-deployment"""
 
         from ..models import (
@@ -12385,7 +12582,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     @overload
     async def async_create_pages_deployment(
@@ -12400,7 +12597,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         pages_build_version: str = "GITHUB_SHA",
         oidc_token: str,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     async def async_create_pages_deployment(
         self,
@@ -12410,7 +12607,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PageDeployment]:
+    ) -> Response[PageDeployment, PageDeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#create-a-github-pages-deployment"""
 
         from ..models import (
@@ -12453,7 +12650,7 @@ class ReposClient:
         pages_deployment_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesDeploymentStatus]:
+    ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
         from ..models import BasicError, PagesDeploymentStatus
@@ -12479,7 +12676,7 @@ class ReposClient:
         pages_deployment_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesDeploymentStatus]:
+    ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
         from ..models import BasicError, PagesDeploymentStatus
@@ -12554,7 +12751,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesHealthCheck]:
+    ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
         from ..models import BasicError, PagesHealthCheck
@@ -12579,7 +12776,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesHealthCheck]:
+    ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
         from ..models import BasicError, PagesHealthCheck
@@ -12604,7 +12801,10 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-private-vulnerability-reporting-is-enabled-for-a-repository"""
 
         from ..models import (
@@ -12632,7 +12832,10 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-private-vulnerability-reporting-is-enabled-for-a-repository"""
 
         from ..models import (
@@ -12756,7 +12959,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomPropertyValue]]:
+    ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
         from ..models import BasicError, CustomPropertyValue
@@ -12782,7 +12985,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomPropertyValue]]:
+    ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
         from ..models import BasicError, CustomPropertyValue
@@ -12935,7 +13138,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -12967,7 +13170,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -13000,7 +13203,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -13033,7 +13236,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -13066,7 +13269,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Release]]:
+    ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#list-releases"""
 
         from ..models import Release, BasicError
@@ -13099,7 +13302,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Release]]:
+    ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#list-releases"""
 
         from ..models import Release, BasicError
@@ -13132,7 +13335,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     def create_release(
@@ -13151,7 +13354,7 @@ class ReposClient:
         discussion_category_name: Missing[str] = UNSET,
         generate_release_notes: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     def create_release(
         self,
@@ -13161,7 +13364,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#create-a-release"""
 
         from ..models import (
@@ -13204,7 +13407,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     async def async_create_release(
@@ -13223,7 +13426,7 @@ class ReposClient:
         discussion_category_name: Missing[str] = UNSET,
         generate_release_notes: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     async def async_create_release(
         self,
@@ -13233,7 +13436,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#create-a-release"""
 
         from ..models import (
@@ -13275,7 +13478,7 @@ class ReposClient:
         asset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#get-a-release-asset"""
 
         from ..models import BasicError, ReleaseAsset
@@ -13301,7 +13504,7 @@ class ReposClient:
         asset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#get-a-release-asset"""
 
         from ..models import BasicError, ReleaseAsset
@@ -13369,7 +13572,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     @overload
     def update_release_asset(
@@ -13383,7 +13586,7 @@ class ReposClient:
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     def update_release_asset(
         self,
@@ -13394,7 +13597,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#update-a-release-asset"""
 
         from ..models import ReleaseAsset, ReposOwnerRepoReleasesAssetsAssetIdPatchBody
@@ -13431,7 +13634,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     @overload
     async def async_update_release_asset(
@@ -13445,7 +13648,7 @@ class ReposClient:
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     async def async_update_release_asset(
         self,
@@ -13456,7 +13659,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#update-a-release-asset"""
 
         from ..models import ReleaseAsset, ReposOwnerRepoReleasesAssetsAssetIdPatchBody
@@ -13492,7 +13695,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     @overload
     def generate_release_notes(
@@ -13506,7 +13709,7 @@ class ReposClient:
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
         configuration_file_path: Missing[str] = UNSET,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     def generate_release_notes(
         self,
@@ -13516,7 +13719,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseNotesContent]:
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#generate-release-notes-content-for-a-release"""
 
         from ..models import (
@@ -13559,7 +13762,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     @overload
     async def async_generate_release_notes(
@@ -13573,7 +13776,7 @@ class ReposClient:
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
         configuration_file_path: Missing[str] = UNSET,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     async def async_generate_release_notes(
         self,
@@ -13583,7 +13786,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseNotesContent]:
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#generate-release-notes-content-for-a-release"""
 
         from ..models import (
@@ -13624,7 +13827,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-the-latest-release"""
 
         from ..models import Release
@@ -13646,7 +13849,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-the-latest-release"""
 
         from ..models import Release
@@ -13669,7 +13872,7 @@ class ReposClient:
         tag: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release-by-tag-name"""
 
         from ..models import Release, BasicError
@@ -13695,7 +13898,7 @@ class ReposClient:
         tag: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release-by-tag-name"""
 
         from ..models import Release, BasicError
@@ -13721,7 +13924,7 @@ class ReposClient:
         release_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release"""
 
         from ..models import Release
@@ -13745,7 +13948,7 @@ class ReposClient:
         release_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release"""
 
         from ..models import Release
@@ -13811,7 +14014,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     def update_release(
@@ -13830,7 +14033,7 @@ class ReposClient:
         prerelease: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
         discussion_category_name: Missing[str] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     def update_release(
         self,
@@ -13841,7 +14044,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#update-a-release"""
 
         from ..models import (
@@ -13883,7 +14086,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     async def async_update_release(
@@ -13902,7 +14105,7 @@ class ReposClient:
         prerelease: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
         discussion_category_name: Missing[str] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     async def async_update_release(
         self,
@@ -13913,7 +14116,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#update-a-release"""
 
         from ..models import (
@@ -13955,7 +14158,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReleaseAsset]]:
+    ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#list-release-assets"""
 
         from ..models import ReleaseAsset
@@ -13986,7 +14189,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReleaseAsset]]:
+    ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#list-release-assets"""
 
         from ..models import ReleaseAsset
@@ -14018,7 +14221,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: FileTypes,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#upload-a-release-asset"""
 
         from ..models import ReleaseAsset
@@ -14058,7 +14261,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: FileTypes,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#upload-a-release-asset"""
 
         from ..models import ReleaseAsset
@@ -14118,7 +14321,28 @@ class ReposClient:
                 RepositoryRuleDetailedOneof15,
                 RepositoryRuleDetailedOneof16,
             ]
-        ]
+        ],
+        list[
+            Union[
+                RepositoryRuleDetailedOneof0Type,
+                RepositoryRuleDetailedOneof1Type,
+                RepositoryRuleDetailedOneof2Type,
+                RepositoryRuleDetailedOneof3Type,
+                RepositoryRuleDetailedOneof4Type,
+                RepositoryRuleDetailedOneof5Type,
+                RepositoryRuleDetailedOneof6Type,
+                RepositoryRuleDetailedOneof7Type,
+                RepositoryRuleDetailedOneof8Type,
+                RepositoryRuleDetailedOneof9Type,
+                RepositoryRuleDetailedOneof10Type,
+                RepositoryRuleDetailedOneof11Type,
+                RepositoryRuleDetailedOneof12Type,
+                RepositoryRuleDetailedOneof13Type,
+                RepositoryRuleDetailedOneof14Type,
+                RepositoryRuleDetailedOneof15Type,
+                RepositoryRuleDetailedOneof16Type,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-rules-for-a-branch"""
 
@@ -14211,7 +14435,28 @@ class ReposClient:
                 RepositoryRuleDetailedOneof15,
                 RepositoryRuleDetailedOneof16,
             ]
-        ]
+        ],
+        list[
+            Union[
+                RepositoryRuleDetailedOneof0Type,
+                RepositoryRuleDetailedOneof1Type,
+                RepositoryRuleDetailedOneof2Type,
+                RepositoryRuleDetailedOneof3Type,
+                RepositoryRuleDetailedOneof4Type,
+                RepositoryRuleDetailedOneof5Type,
+                RepositoryRuleDetailedOneof6Type,
+                RepositoryRuleDetailedOneof7Type,
+                RepositoryRuleDetailedOneof8Type,
+                RepositoryRuleDetailedOneof9Type,
+                RepositoryRuleDetailedOneof10Type,
+                RepositoryRuleDetailedOneof11Type,
+                RepositoryRuleDetailedOneof12Type,
+                RepositoryRuleDetailedOneof13Type,
+                RepositoryRuleDetailedOneof14Type,
+                RepositoryRuleDetailedOneof15Type,
+                RepositoryRuleDetailedOneof16Type,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-rules-for-a-branch"""
 
@@ -14284,7 +14529,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-all-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14322,7 +14567,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-all-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14358,7 +14603,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def create_repo_ruleset(
@@ -14400,7 +14645,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def create_repo_ruleset(
         self,
@@ -14410,7 +14655,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#create-a-repository-ruleset"""
 
         from ..models import (
@@ -14452,7 +14697,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_create_repo_ruleset(
@@ -14494,7 +14739,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_create_repo_ruleset(
         self,
@@ -14504,7 +14749,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#create-a-repository-ruleset"""
 
         from ..models import (
@@ -14550,7 +14795,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#list-repository-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -14592,7 +14837,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#list-repository-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -14629,7 +14874,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#get-a-repository-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -14656,7 +14901,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#get-a-repository-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -14684,7 +14929,7 @@ class ReposClient:
         includes_parents: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-a-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14717,7 +14962,7 @@ class ReposClient:
         includes_parents: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-a-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14751,7 +14996,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def update_repo_ruleset(
@@ -14794,7 +15039,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def update_repo_ruleset(
         self,
@@ -14805,7 +15050,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#update-a-repository-ruleset"""
 
         from ..models import (
@@ -14848,7 +15093,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_update_repo_ruleset(
@@ -14891,7 +15136,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_update_repo_ruleset(
         self,
@@ -14902,7 +15147,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#update-a-repository-ruleset"""
 
         from ..models import (
@@ -14994,7 +15239,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-activity"""
 
         url = f"/repos/{owner}/{repo}/stats/code_frequency"
@@ -15015,7 +15260,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-activity"""
 
         url = f"/repos/{owner}/{repo}/stats/code_frequency"
@@ -15036,7 +15281,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitActivity]]:
+    ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
         from ..models import CommitActivity
@@ -15058,7 +15303,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitActivity]]:
+    ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
         from ..models import CommitActivity
@@ -15080,7 +15325,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContributorActivity]]:
+    ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-all-contributor-commit-activity"""
 
         from ..models import ContributorActivity
@@ -15102,7 +15347,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContributorActivity]]:
+    ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-all-contributor-commit-activity"""
 
         from ..models import ContributorActivity
@@ -15124,7 +15369,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ParticipationStats]:
+    ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-count"""
 
         from ..models import BasicError, ParticipationStats
@@ -15149,7 +15394,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ParticipationStats]:
+    ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-count"""
 
         from ..models import BasicError, ParticipationStats
@@ -15174,7 +15419,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
         url = f"/repos/{owner}/{repo}/stats/punch_card"
@@ -15194,7 +15439,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
         url = f"/repos/{owner}/{repo}/stats/punch_card"
@@ -15217,7 +15462,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     @overload
     def create_commit_status(
@@ -15232,7 +15477,7 @@ class ReposClient:
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     def create_commit_status(
         self,
@@ -15243,7 +15488,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Status]:
+    ) -> Response[Status, StatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#create-a-commit-status"""
 
         from ..models import Status, ReposOwnerRepoStatusesShaPostBody
@@ -15278,7 +15523,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     @overload
     async def async_create_commit_status(
@@ -15293,7 +15538,7 @@ class ReposClient:
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     async def async_create_commit_status(
         self,
@@ -15304,7 +15549,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Status]:
+    ) -> Response[Status, StatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#create-a-commit-status"""
 
         from ..models import Status, ReposOwnerRepoStatusesShaPostBody
@@ -15338,7 +15583,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Tag]]:
+    ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-tags"""
 
         from ..models import Tag
@@ -15368,7 +15613,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Tag]]:
+    ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-tags"""
 
         from ..models import Tag
@@ -15396,7 +15641,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TagProtection]]:
+    ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
         from ..models import BasicError, TagProtection
@@ -15422,7 +15667,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TagProtection]]:
+    ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
         from ..models import BasicError, TagProtection
@@ -15450,7 +15695,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     @overload
     def create_tag_protection(
@@ -15461,7 +15706,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         pattern: str,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     def create_tag_protection(
         self,
@@ -15471,7 +15716,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TagProtection]:
+    ) -> Response[TagProtection, TagProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---create-a-tag-protection-state-for-a-repository"""
 
         from ..models import (
@@ -15513,7 +15758,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     @overload
     async def async_create_tag_protection(
@@ -15524,7 +15769,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         pattern: str,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     async def async_create_tag_protection(
         self,
@@ -15534,7 +15779,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TagProtection]:
+    ) -> Response[TagProtection, TagProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---create-a-tag-protection-state-for-a-repository"""
 
         from ..models import (
@@ -15668,7 +15913,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-teams"""
 
         from ..models import Team, BasicError
@@ -15701,7 +15946,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-teams"""
 
         from ..models import Team, BasicError
@@ -15734,7 +15979,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-all-repository-topics"""
 
         from ..models import Topic, BasicError
@@ -15767,7 +16012,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-all-repository-topics"""
 
         from ..models import Topic, BasicError
@@ -15800,7 +16045,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     @overload
     def replace_all_topics(
@@ -15811,7 +16056,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         names: list[str],
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     def replace_all_topics(
         self,
@@ -15821,7 +16066,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#replace-all-repository-topics"""
 
         from ..models import (
@@ -15864,7 +16109,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     @overload
     async def async_replace_all_topics(
@@ -15875,7 +16120,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         names: list[str],
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     async def async_replace_all_topics(
         self,
@@ -15885,7 +16130,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#replace-all-repository-topics"""
 
         from ..models import (
@@ -15927,7 +16172,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CloneTraffic]:
+    ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-repository-clones"""
 
         from ..models import BasicError, CloneTraffic
@@ -15958,7 +16203,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CloneTraffic]:
+    ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-repository-clones"""
 
         from ..models import BasicError, CloneTraffic
@@ -15988,7 +16233,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContentTraffic]]:
+    ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-paths"""
 
         from ..models import BasicError, ContentTraffic
@@ -16013,7 +16258,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContentTraffic]]:
+    ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-paths"""
 
         from ..models import BasicError, ContentTraffic
@@ -16038,7 +16283,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReferrerTraffic]]:
+    ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-sources"""
 
         from ..models import BasicError, ReferrerTraffic
@@ -16063,7 +16308,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReferrerTraffic]]:
+    ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-sources"""
 
         from ..models import BasicError, ReferrerTraffic
@@ -16089,7 +16334,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ViewTraffic]:
+    ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-page-views"""
 
         from ..models import BasicError, ViewTraffic
@@ -16120,7 +16365,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ViewTraffic]:
+    ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-page-views"""
 
         from ..models import BasicError, ViewTraffic
@@ -16152,7 +16397,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     @overload
     def transfer(
@@ -16165,7 +16410,7 @@ class ReposClient:
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     def transfer(
         self,
@@ -16175,7 +16420,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MinimalRepository]:
+    ) -> Response[MinimalRepository, MinimalRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#transfer-a-repository"""
 
         from ..models import MinimalRepository, ReposOwnerRepoTransferPostBody
@@ -16209,7 +16454,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     @overload
     async def async_transfer(
@@ -16222,7 +16467,7 @@ class ReposClient:
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     async def async_transfer(
         self,
@@ -16232,7 +16477,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MinimalRepository]:
+    ) -> Response[MinimalRepository, MinimalRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#transfer-a-repository"""
 
         from ..models import MinimalRepository, ReposOwnerRepoTransferPostBody
@@ -16422,7 +16667,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_using_template(
@@ -16437,7 +16682,7 @@ class ReposClient:
         description: Missing[str] = UNSET,
         include_all_branches: Missing[bool] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_using_template(
         self,
@@ -16447,7 +16692,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-a-repository-using-a-template"""
 
         from ..models import (
@@ -16486,7 +16731,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_using_template(
@@ -16501,7 +16746,7 @@ class ReposClient:
         description: Missing[str] = UNSET,
         include_all_branches: Missing[bool] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_using_template(
         self,
@@ -16511,7 +16756,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-a-repository-using-a-template"""
 
         from ..models import (
@@ -16547,7 +16792,7 @@ class ReposClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-public-repositories"""
 
         from ..models import ValidationError, MinimalRepository
@@ -16576,7 +16821,7 @@ class ReposClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-public-repositories"""
 
         from ..models import ValidationError, MinimalRepository
@@ -16613,7 +16858,7 @@ class ReposClient:
         before: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
         from ..models import BasicError, Repository, ValidationError
@@ -16660,7 +16905,7 @@ class ReposClient:
         before: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
         from ..models import BasicError, Repository, ValidationError
@@ -16697,7 +16942,7 @@ class ReposClient:
     @overload
     def create_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -16732,7 +16977,7 @@ class ReposClient:
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
         has_downloads: Missing[bool] = UNSET,
         is_template: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_for_authenticated_user(
         self,
@@ -16740,7 +16985,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -16781,7 +17026,7 @@ class ReposClient:
     @overload
     async def async_create_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -16816,7 +17061,7 @@ class ReposClient:
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
         has_downloads: Missing[bool] = UNSET,
         is_template: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_for_authenticated_user(
         self,
@@ -16824,7 +17069,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#create-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -16868,7 +17113,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
         from ..models import BasicError, RepositoryInvitation
@@ -16901,7 +17146,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
         from ..models import BasicError, RepositoryInvitation
@@ -17038,7 +17283,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-a-user"""
 
         from ..models import MinimalRepository
@@ -17073,7 +17318,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-a-user"""
 
         from ..models import MinimalRepository

--- a/githubkit/versions/ghec_v2022_11_28/rest/scim.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/scim.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
     from ..models import ScimUser, ScimUserList
     from ..types import (
+        ScimUserType,
+        ScimUserListType,
         ScimV2OrganizationsOrgUsersPostBodyType,
         ScimV2OrganizationsOrgUsersPostBodyPropNameType,
         ScimV2OrganizationsOrgUsersScimUserIdPutBodyType,
@@ -60,7 +62,7 @@ class ScimClient:
         filter_: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimUserList]:
+    ) -> Response[ScimUserList, ScimUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#list-scim-provisioned-identities"""
 
         from ..models import ScimError, ScimUserList
@@ -97,7 +99,7 @@ class ScimClient:
         filter_: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimUserList]:
+    ) -> Response[ScimUserList, ScimUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#list-scim-provisioned-identities"""
 
         from ..models import ScimError, ScimUserList
@@ -133,7 +135,7 @@ class ScimClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersPostBodyType,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     @overload
     def provision_and_invite_user(
@@ -150,7 +152,7 @@ class ScimClient:
         external_id: Missing[str] = UNSET,
         groups: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     def provision_and_invite_user(
         self,
@@ -159,7 +161,7 @@ class ScimClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#provision-and-invite-a-scim-user"""
 
         from ..models import ScimUser, ScimError, ScimV2OrganizationsOrgUsersPostBody
@@ -199,7 +201,7 @@ class ScimClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersPostBodyType,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     @overload
     async def async_provision_and_invite_user(
@@ -216,7 +218,7 @@ class ScimClient:
         external_id: Missing[str] = UNSET,
         groups: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     async def async_provision_and_invite_user(
         self,
@@ -225,7 +227,7 @@ class ScimClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#provision-and-invite-a-scim-user"""
 
         from ..models import ScimUser, ScimError, ScimV2OrganizationsOrgUsersPostBody
@@ -264,7 +266,7 @@ class ScimClient:
         scim_user_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#get-scim-provisioning-information-for-a-user"""
 
         from ..models import ScimUser, ScimError
@@ -290,7 +292,7 @@ class ScimClient:
         scim_user_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#get-scim-provisioning-information-for-a-user"""
 
         from ..models import ScimUser, ScimError
@@ -318,7 +320,7 @@ class ScimClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPutBodyType,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     @overload
     def set_information_for_provisioned_user(
@@ -336,7 +338,7 @@ class ScimClient:
         user_name: str,
         name: ScimV2OrganizationsOrgUsersScimUserIdPutBodyPropNameType,
         emails: list[ScimV2OrganizationsOrgUsersScimUserIdPutBodyPropEmailsItemsType],
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     def set_information_for_provisioned_user(
         self,
@@ -346,7 +348,7 @@ class ScimClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#update-a-provisioned-organization-membership"""
 
         from ..models import (
@@ -390,7 +392,7 @@ class ScimClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPutBodyType,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     @overload
     async def async_set_information_for_provisioned_user(
@@ -408,7 +410,7 @@ class ScimClient:
         user_name: str,
         name: ScimV2OrganizationsOrgUsersScimUserIdPutBodyPropNameType,
         emails: list[ScimV2OrganizationsOrgUsersScimUserIdPutBodyPropEmailsItemsType],
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     async def async_set_information_for_provisioned_user(
         self,
@@ -418,7 +420,7 @@ class ScimClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#update-a-provisioned-organization-membership"""
 
         from ..models import (
@@ -512,7 +514,7 @@ class ScimClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     @overload
     def update_attribute_for_user(
@@ -526,7 +528,7 @@ class ScimClient:
         operations: list[
             ScimV2OrganizationsOrgUsersScimUserIdPatchBodyPropOperationsItemsType
         ],
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     def update_attribute_for_user(
         self,
@@ -536,7 +538,7 @@ class ScimClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#update-an-attribute-for-a-scim-user"""
 
         from ..models import (
@@ -583,7 +585,7 @@ class ScimClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType,
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     @overload
     async def async_update_attribute_for_user(
@@ -597,7 +599,7 @@ class ScimClient:
         operations: list[
             ScimV2OrganizationsOrgUsersScimUserIdPatchBodyPropOperationsItemsType
         ],
-    ) -> Response[ScimUser]: ...
+    ) -> Response[ScimUser, ScimUserType]: ...
 
     async def async_update_attribute_for_user(
         self,
@@ -607,7 +609,7 @@ class ScimClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ScimUser]:
+    ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#update-an-attribute-for-a-scim-user"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/search.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/search.py
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
         SearchCommitsGetResponse200,
         SearchRepositoriesGetResponse200,
     )
+    from ..types import (
+        SearchCodeGetResponse200Type,
+        SearchUsersGetResponse200Type,
+        SearchIssuesGetResponse200Type,
+        SearchLabelsGetResponse200Type,
+        SearchTopicsGetResponse200Type,
+        SearchCommitsGetResponse200Type,
+        SearchRepositoriesGetResponse200Type,
+    )
 
 
 class SearchClient:
@@ -58,7 +67,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCodeGetResponse200]:
+    ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-code"""
 
         from ..models import (
@@ -102,7 +111,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCodeGetResponse200]:
+    ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-code"""
 
         from ..models import (
@@ -146,7 +155,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCommitsGetResponse200]:
+    ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-commits"""
 
         from ..models import SearchCommitsGetResponse200
@@ -180,7 +189,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCommitsGetResponse200]:
+    ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-commits"""
 
         from ..models import SearchCommitsGetResponse200
@@ -228,7 +237,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchIssuesGetResponse200]:
+    ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-issues-and-pull-requests"""
 
         from ..models import (
@@ -286,7 +295,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchIssuesGetResponse200]:
+    ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-issues-and-pull-requests"""
 
         from ..models import (
@@ -331,7 +340,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchLabelsGetResponse200]:
+    ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-labels"""
 
         from ..models import BasicError, ValidationError, SearchLabelsGetResponse200
@@ -372,7 +381,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchLabelsGetResponse200]:
+    ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-labels"""
 
         from ..models import BasicError, ValidationError, SearchLabelsGetResponse200
@@ -414,7 +423,9 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchRepositoriesGetResponse200]:
+    ) -> Response[
+        SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-repositories"""
 
         from ..models import (
@@ -458,7 +469,9 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchRepositoriesGetResponse200]:
+    ) -> Response[
+        SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-repositories"""
 
         from ..models import (
@@ -498,7 +511,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchTopicsGetResponse200]:
+    ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-topics"""
 
         from ..models import SearchTopicsGetResponse200
@@ -528,7 +541,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchTopicsGetResponse200]:
+    ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-topics"""
 
         from ..models import SearchTopicsGetResponse200
@@ -560,7 +573,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchUsersGetResponse200]:
+    ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-users"""
 
         from ..models import (
@@ -602,7 +615,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchUsersGetResponse200]:
+    ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-users"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/secret_scanning.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/secret_scanning.py
@@ -33,6 +33,10 @@ if TYPE_CHECKING:
         SecretScanningPushProtectionBypass,
     )
     from ..types import (
+        SecretScanningAlertType,
+        SecretScanningLocationType,
+        OrganizationSecretScanningAlertType,
+        SecretScanningPushProtectionBypassType,
         ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
         ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
     )
@@ -69,7 +73,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -124,7 +130,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -180,7 +188,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -237,7 +247,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -295,7 +307,7 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningAlert]]:
+    ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -351,7 +363,7 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningAlert]]:
+    ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -396,7 +408,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
         from ..models import (
@@ -425,7 +437,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
         from ..models import (
@@ -456,7 +468,7 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     @overload
     def update_alert(
@@ -474,7 +486,7 @@ class SecretScanningClient:
             ]
         ] = UNSET,
         resolution_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     def update_alert(
         self,
@@ -487,7 +499,7 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#update-a-secret-scanning-alert"""
 
         from ..models import (
@@ -531,7 +543,7 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     @overload
     async def async_update_alert(
@@ -549,7 +561,7 @@ class SecretScanningClient:
             ]
         ] = UNSET,
         resolution_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     async def async_update_alert(
         self,
@@ -562,7 +574,7 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#update-a-secret-scanning-alert"""
 
         from ..models import (
@@ -606,7 +618,7 @@ class SecretScanningClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningLocation]]:
+    ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
         from ..models import (
@@ -643,7 +655,7 @@ class SecretScanningClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningLocation]]:
+    ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
         from ..models import (
@@ -679,7 +691,9 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     @overload
     def create_push_protection_bypass(
@@ -691,7 +705,9 @@ class SecretScanningClient:
         headers: Optional[dict[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     def create_push_protection_bypass(
         self,
@@ -703,7 +719,9 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningPushProtectionBypass]:
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#create-a-push-protection-bypass"""
 
         from ..models import (
@@ -746,7 +764,9 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     @overload
     async def async_create_push_protection_bypass(
@@ -758,7 +778,9 @@ class SecretScanningClient:
         headers: Optional[dict[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     async def async_create_push_protection_bypass(
         self,
@@ -770,7 +792,9 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningPushProtectionBypass]:
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#create-a-push-protection-bypass"""
 
         from ..models import (

--- a/githubkit/versions/ghec_v2022_11_28/rest/security_advisories.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/security_advisories.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
     )
     from ..types import (
+        FullRepositoryType,
+        GlobalAdvisoryType,
+        RepositoryAdvisoryType,
         RepositoryAdvisoryCreateType,
         RepositoryAdvisoryUpdateType,
         PrivateVulnerabilityReportCreateType,
@@ -40,6 +43,7 @@ if TYPE_CHECKING:
         RepositoryAdvisoryUpdatePropCreditsItemsType,
         RepositoryAdvisoryCreatePropVulnerabilitiesItemsType,
         RepositoryAdvisoryUpdatePropVulnerabilitiesItemsType,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         PrivateVulnerabilityReportCreatePropVulnerabilitiesItemsType,
     )
 
@@ -101,7 +105,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GlobalAdvisory]]:
+    ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#list-global-security-advisories"""
 
         from ..models import BasicError, GlobalAdvisory, ValidationErrorSimple
@@ -185,7 +189,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GlobalAdvisory]]:
+    ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#list-global-security-advisories"""
 
         from ..models import BasicError, GlobalAdvisory, ValidationErrorSimple
@@ -232,7 +236,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GlobalAdvisory]:
+    ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
         from ..models import BasicError, GlobalAdvisory
@@ -256,7 +260,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GlobalAdvisory]:
+    ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
         from ..models import BasicError, GlobalAdvisory
@@ -286,7 +290,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -327,7 +331,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -369,7 +373,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -411,7 +415,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -449,7 +453,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     def create_repository_advisory(
@@ -472,7 +476,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     def create_repository_advisory(
         self,
@@ -482,7 +486,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#create-a-repository-security-advisory"""
 
         from ..models import (
@@ -526,7 +530,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     async def async_create_repository_advisory(
@@ -549,7 +553,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     async def async_create_repository_advisory(
         self,
@@ -559,7 +563,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#create-a-repository-security-advisory"""
 
         from ..models import (
@@ -603,7 +607,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     def create_private_vulnerability_report(
@@ -626,7 +630,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     def create_private_vulnerability_report(
         self,
@@ -636,7 +640,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#privately-report-a-security-vulnerability"""
 
         from ..models import (
@@ -680,7 +684,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     async def async_create_private_vulnerability_report(
@@ -703,7 +707,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     async def async_create_private_vulnerability_report(
         self,
@@ -713,7 +717,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#privately-report-a-security-vulnerability"""
 
         from ..models import (
@@ -756,7 +760,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -783,7 +787,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -812,7 +816,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     def update_repository_advisory(
@@ -840,7 +844,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["published", "closed", "draft"]] = UNSET,
         collaborating_users: Missing[Union[list[str], None]] = UNSET,
         collaborating_teams: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     def update_repository_advisory(
         self,
@@ -851,7 +855,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#update-a-repository-security-advisory"""
 
         from ..models import (
@@ -896,7 +900,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     async def async_update_repository_advisory(
@@ -924,7 +928,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["published", "closed", "draft"]] = UNSET,
         collaborating_users: Missing[Union[list[str], None]] = UNSET,
         collaborating_teams: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     async def async_update_repository_advisory(
         self,
@@ -935,7 +939,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#update-a-repository-security-advisory"""
 
         from ..models import (
@@ -978,7 +982,10 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#request-a-cve-for-a-repository-security-advisory"""
 
         from ..models import (
@@ -1011,7 +1018,10 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#request-a-cve-for-a-repository-security-advisory"""
 
         from ..models import (
@@ -1044,7 +1054,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 
         from ..models import BasicError, FullRepository, ValidationError
@@ -1073,7 +1083,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 
         from ..models import BasicError, FullRepository, ValidationError

--- a/githubkit/versions/ghec_v2022_11_28/rest/server_statistics.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/server_statistics.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import ServerStatisticsItems
+    from ..types import ServerStatisticsItemsType
 
 
 class ServerStatisticsClient:
@@ -46,7 +47,7 @@ class ServerStatisticsClient:
         date_end: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ServerStatisticsItems]]:
+    ) -> Response[list[ServerStatisticsItems], list[ServerStatisticsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/admin-stats#get-github-enterprise-server-statistics"""
 
         from ..models import ServerStatisticsItems
@@ -75,7 +76,7 @@ class ServerStatisticsClient:
         date_end: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ServerStatisticsItems]]:
+    ) -> Response[list[ServerStatisticsItems], list[ServerStatisticsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/admin-stats#get-github-enterprise-server-statistics"""
 
         from ..models import ServerStatisticsItems

--- a/githubkit/versions/ghec_v2022_11_28/rest/teams.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/teams.py
@@ -42,8 +42,21 @@ if TYPE_CHECKING:
         OrganizationInvitation,
     )
     from ..types import (
+        TeamType,
+        TeamFullType,
+        SimpleUserType,
+        TeamProjectType,
+        GroupMappingType,
+        ExternalGroupType,
+        ExternalGroupsType,
+        TeamDiscussionType,
+        TeamMembershipType,
+        TeamRepositoryType,
+        MinimalRepositoryType,
         OrgsOrgTeamsPostBodyType,
         TeamsTeamIdPatchBodyType,
+        TeamDiscussionCommentType,
+        OrganizationInvitationType,
         OrgsOrgTeamsTeamSlugPatchBodyType,
         TeamsTeamIdDiscussionsPostBodyType,
         TeamsTeamIdReposOwnerRepoPutBodyType,
@@ -90,7 +103,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ExternalGroup]:
+    ) -> Response[ExternalGroup, ExternalGroupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#get-an-external-group"""
 
         from ..models import ExternalGroup
@@ -120,7 +133,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ExternalGroup]:
+    ) -> Response[ExternalGroup, ExternalGroupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#get-an-external-group"""
 
         from ..models import ExternalGroup
@@ -150,7 +163,7 @@ class TeamsClient:
         display_name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ExternalGroups]:
+    ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-external-groups-in-an-organization"""
 
         from ..models import ExternalGroups
@@ -181,7 +194,7 @@ class TeamsClient:
         display_name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ExternalGroups]:
+    ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-external-groups-in-an-organization"""
 
         from ..models import ExternalGroups
@@ -212,7 +225,7 @@ class TeamsClient:
         q: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-an-organization"""
 
         from ..models import GroupMapping
@@ -243,7 +256,7 @@ class TeamsClient:
         q: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-an-organization"""
 
         from ..models import GroupMapping
@@ -273,7 +286,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams"""
 
         from ..models import Team, BasicError
@@ -305,7 +318,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams"""
 
         from ..models import Team, BasicError
@@ -337,7 +350,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     def create(
@@ -356,7 +369,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push"]] = UNSET,
         parent_team_id: Missing[int] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     def create(
         self,
@@ -365,7 +378,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#create-a-team"""
 
         from ..models import TeamFull, BasicError, ValidationError, OrgsOrgTeamsPostBody
@@ -402,7 +415,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     async def async_create(
@@ -421,7 +434,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push"]] = UNSET,
         parent_team_id: Missing[int] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     async def async_create(
         self,
@@ -430,7 +443,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#create-a-team"""
 
         from ..models import TeamFull, BasicError, ValidationError, OrgsOrgTeamsPostBody
@@ -466,7 +479,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-by-name"""
 
         from ..models import TeamFull, BasicError
@@ -491,7 +504,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-by-name"""
 
         from ..models import TeamFull, BasicError
@@ -556,7 +569,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     def update_in_org(
@@ -574,7 +587,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     def update_in_org(
         self,
@@ -584,7 +597,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#update-a-team"""
 
         from ..models import (
@@ -628,7 +641,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     async def async_update_in_org(
@@ -646,7 +659,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     async def async_update_in_org(
         self,
@@ -656,7 +669,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#update-a-team"""
 
         from ..models import (
@@ -702,7 +715,7 @@ class TeamsClient:
         pinned: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions"""
 
         from ..models import TeamDiscussion
@@ -736,7 +749,7 @@ class TeamsClient:
         pinned: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions"""
 
         from ..models import TeamDiscussion
@@ -768,7 +781,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def create_discussion_in_org(
@@ -781,7 +794,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def create_discussion_in_org(
         self,
@@ -791,7 +804,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#create-a-discussion"""
 
         from ..models import TeamDiscussion, OrgsOrgTeamsTeamSlugDiscussionsPostBody
@@ -825,7 +838,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_create_discussion_in_org(
@@ -838,7 +851,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_create_discussion_in_org(
         self,
@@ -848,7 +861,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#create-a-discussion"""
 
         from ..models import TeamDiscussion, OrgsOrgTeamsTeamSlugDiscussionsPostBody
@@ -881,7 +894,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion"""
 
         from ..models import TeamDiscussion
@@ -904,7 +917,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion"""
 
         from ..models import TeamDiscussion
@@ -971,7 +984,7 @@ class TeamsClient:
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def update_discussion_in_org(
@@ -984,7 +997,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def update_discussion_in_org(
         self,
@@ -997,7 +1010,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#update-a-discussion"""
 
         from ..models import (
@@ -1039,7 +1052,7 @@ class TeamsClient:
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_update_discussion_in_org(
@@ -1052,7 +1065,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_update_discussion_in_org(
         self,
@@ -1065,7 +1078,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#update-a-discussion"""
 
         from ..models import (
@@ -1106,7 +1119,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments"""
 
         from ..models import TeamDiscussionComment
@@ -1139,7 +1152,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments"""
 
         from ..models import TeamDiscussionComment
@@ -1171,7 +1184,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def create_discussion_comment_in_org(
@@ -1183,7 +1196,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def create_discussion_comment_in_org(
         self,
@@ -1196,7 +1209,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#create-a-discussion-comment"""
 
         from ..models import (
@@ -1236,7 +1249,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_create_discussion_comment_in_org(
@@ -1248,7 +1261,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_create_discussion_comment_in_org(
         self,
@@ -1261,7 +1274,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#create-a-discussion-comment"""
 
         from ..models import (
@@ -1300,7 +1313,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment"""
 
         from ..models import TeamDiscussionComment
@@ -1324,7 +1337,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment"""
 
         from ..models import TeamDiscussionComment
@@ -1392,7 +1405,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def update_discussion_comment_in_org(
@@ -1405,7 +1418,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def update_discussion_comment_in_org(
         self,
@@ -1419,7 +1432,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#update-a-discussion-comment"""
 
         from ..models import (
@@ -1461,7 +1474,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_update_discussion_comment_in_org(
@@ -1474,7 +1487,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_update_discussion_comment_in_org(
         self,
@@ -1488,7 +1501,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#update-a-discussion-comment"""
 
         from ..models import (
@@ -1526,7 +1539,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ExternalGroups]:
+    ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team"""
 
         from ..models import ExternalGroups
@@ -1548,7 +1561,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ExternalGroups]:
+    ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team"""
 
         from ..models import ExternalGroups
@@ -1610,7 +1623,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType,
-    ) -> Response[ExternalGroup]: ...
+    ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
     @overload
     def link_external_idp_group_to_team_for_org(
@@ -1621,7 +1634,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         group_id: int,
-    ) -> Response[ExternalGroup]: ...
+    ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
     def link_external_idp_group_to_team_for_org(
         self,
@@ -1631,7 +1644,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ExternalGroup]:
+    ) -> Response[ExternalGroup, ExternalGroupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#update-the-connection-between-an-external-group-and-a-team"""
 
         from ..models import ExternalGroup, OrgsOrgTeamsTeamSlugExternalGroupsPatchBody
@@ -1667,7 +1680,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType,
-    ) -> Response[ExternalGroup]: ...
+    ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
     @overload
     async def async_link_external_idp_group_to_team_for_org(
@@ -1678,7 +1691,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         group_id: int,
-    ) -> Response[ExternalGroup]: ...
+    ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
     async def async_link_external_idp_group_to_team_for_org(
         self,
@@ -1688,7 +1701,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ExternalGroup]:
+    ) -> Response[ExternalGroup, ExternalGroupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#update-the-connection-between-an-external-group-and-a-team"""
 
         from ..models import ExternalGroup, OrgsOrgTeamsTeamSlugExternalGroupsPatchBody
@@ -1724,7 +1737,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations"""
 
         from ..models import OrganizationInvitation
@@ -1754,7 +1767,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations"""
 
         from ..models import OrganizationInvitation
@@ -1785,7 +1798,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members"""
 
         from ..models import SimpleUser
@@ -1817,7 +1830,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members"""
 
         from ..models import SimpleUser
@@ -1847,7 +1860,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user"""
 
         from ..models import TeamMembership
@@ -1871,7 +1884,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user"""
 
         from ..models import TeamMembership
@@ -1897,7 +1910,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     def add_or_update_membership_for_user_in_org(
@@ -1909,7 +1922,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     def add_or_update_membership_for_user_in_org(
         self,
@@ -1920,7 +1933,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#add-or-update-team-membership-for-a-user"""
 
         from ..models import (
@@ -1961,7 +1974,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     async def async_add_or_update_membership_for_user_in_org(
@@ -1973,7 +1986,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     async def async_add_or_update_membership_for_user_in_org(
         self,
@@ -1984,7 +1997,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#add-or-update-team-membership-for-a-user"""
 
         from ..models import (
@@ -2066,7 +2079,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects"""
 
         from ..models import TeamProject
@@ -2096,7 +2109,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects"""
 
         from ..models import TeamProject
@@ -2125,7 +2138,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project"""
 
         from ..models import TeamProject
@@ -2149,7 +2162,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project"""
 
         from ..models import TeamProject
@@ -2356,7 +2369,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories"""
 
         from ..models import MinimalRepository
@@ -2386,7 +2399,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories"""
 
         from ..models import MinimalRepository
@@ -2416,7 +2429,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository"""
 
         from ..models import TeamRepository
@@ -2441,7 +2454,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository"""
 
         from ..models import TeamRepository
@@ -2626,7 +2639,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team"""
 
         from ..models import GroupMapping
@@ -2648,7 +2661,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team"""
 
         from ..models import GroupMapping
@@ -2672,7 +2685,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     @overload
     def create_or_update_idp_group_connections_in_org(
@@ -2685,7 +2698,7 @@ class TeamsClient:
         groups: Missing[
             list[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyPropGroupsItemsType]
         ] = UNSET,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     def create_or_update_idp_group_connections_in_org(
         self,
@@ -2695,7 +2708,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#create-or-update-idp-group-connections"""
 
         from ..models import (
@@ -2734,7 +2747,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     @overload
     async def async_create_or_update_idp_group_connections_in_org(
@@ -2747,7 +2760,7 @@ class TeamsClient:
         groups: Missing[
             list[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyPropGroupsItemsType]
         ] = UNSET,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     async def async_create_or_update_idp_group_connections_in_org(
         self,
@@ -2757,7 +2770,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#create-or-update-idp-group-connections"""
 
         from ..models import (
@@ -2796,7 +2809,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams"""
 
         from ..models import Team
@@ -2826,7 +2839,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams"""
 
         from ..models import Team
@@ -2853,7 +2866,7 @@ class TeamsClient:
         team_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-legacy"""
 
         from ..models import TeamFull, BasicError
@@ -2877,7 +2890,7 @@ class TeamsClient:
         team_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-legacy"""
 
         from ..models import TeamFull, BasicError
@@ -2951,7 +2964,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     def update_legacy(
@@ -2968,7 +2981,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     def update_legacy(
         self,
@@ -2977,7 +2990,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#update-a-team-legacy"""
 
         from ..models import TeamFull, BasicError, ValidationError, TeamsTeamIdPatchBody
@@ -3015,7 +3028,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     async def async_update_legacy(
@@ -3032,7 +3045,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     async def async_update_legacy(
         self,
@@ -3041,7 +3054,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#update-a-team-legacy"""
 
         from ..models import TeamFull, BasicError, ValidationError, TeamsTeamIdPatchBody
@@ -3080,7 +3093,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions-legacy"""
 
         from ..models import TeamDiscussion
@@ -3111,7 +3124,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions-legacy"""
 
         from ..models import TeamDiscussion
@@ -3141,7 +3154,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def create_discussion_legacy(
@@ -3153,7 +3166,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def create_discussion_legacy(
         self,
@@ -3162,7 +3175,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#create-a-discussion-legacy"""
 
         from ..models import TeamDiscussion, TeamsTeamIdDiscussionsPostBody
@@ -3195,7 +3208,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_create_discussion_legacy(
@@ -3207,7 +3220,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_create_discussion_legacy(
         self,
@@ -3216,7 +3229,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#create-a-discussion-legacy"""
 
         from ..models import TeamDiscussion, TeamsTeamIdDiscussionsPostBody
@@ -3248,7 +3261,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion-legacy"""
 
         from ..models import TeamDiscussion
@@ -3270,7 +3283,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion-legacy"""
 
         from ..models import TeamDiscussion
@@ -3332,7 +3345,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def update_discussion_legacy(
@@ -3344,7 +3357,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def update_discussion_legacy(
         self,
@@ -3354,7 +3367,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#update-a-discussion-legacy"""
 
         from ..models import (
@@ -3393,7 +3406,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_update_discussion_legacy(
@@ -3405,7 +3418,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_update_discussion_legacy(
         self,
@@ -3415,7 +3428,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#update-a-discussion-legacy"""
 
         from ..models import (
@@ -3455,7 +3468,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -3487,7 +3500,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -3518,7 +3531,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def create_discussion_comment_legacy(
@@ -3529,7 +3542,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def create_discussion_comment_legacy(
         self,
@@ -3541,7 +3554,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#create-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3580,7 +3593,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_create_discussion_comment_legacy(
@@ -3591,7 +3604,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_create_discussion_comment_legacy(
         self,
@@ -3603,7 +3616,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#create-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3641,7 +3654,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -3664,7 +3677,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -3729,7 +3742,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def update_discussion_comment_legacy(
@@ -3741,7 +3754,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def update_discussion_comment_legacy(
         self,
@@ -3754,7 +3767,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#update-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3795,7 +3808,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_update_discussion_comment_legacy(
@@ -3807,7 +3820,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_update_discussion_comment_legacy(
         self,
@@ -3820,7 +3833,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#update-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3859,7 +3872,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations-legacy"""
 
         from ..models import OrganizationInvitation
@@ -3888,7 +3901,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations-legacy"""
 
         from ..models import OrganizationInvitation
@@ -3918,7 +3931,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members-legacy"""
 
         from ..models import BasicError, SimpleUser
@@ -3952,7 +3965,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members-legacy"""
 
         from ..models import BasicError, SimpleUser
@@ -4112,7 +4125,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user-legacy"""
 
         from ..models import BasicError, TeamMembership
@@ -4137,7 +4150,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user-legacy"""
 
         from ..models import BasicError, TeamMembership
@@ -4164,7 +4177,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     def add_or_update_membership_for_user_legacy(
@@ -4175,7 +4188,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     def add_or_update_membership_for_user_legacy(
         self,
@@ -4185,7 +4198,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#add-or-update-team-membership-for-a-user-legacy"""
 
         from ..models import (
@@ -4226,7 +4239,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     async def async_add_or_update_membership_for_user_legacy(
@@ -4237,7 +4250,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     async def async_add_or_update_membership_for_user_legacy(
         self,
@@ -4247,7 +4260,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#add-or-update-team-membership-for-a-user-legacy"""
 
         from ..models import (
@@ -4327,7 +4340,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects-legacy"""
 
         from ..models import BasicError, TeamProject
@@ -4359,7 +4372,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects-legacy"""
 
         from ..models import BasicError, TeamProject
@@ -4390,7 +4403,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
         from ..models import TeamProject
@@ -4413,7 +4426,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
         from ..models import TeamProject
@@ -4615,7 +4628,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories-legacy"""
 
         from ..models import BasicError, MinimalRepository
@@ -4647,7 +4660,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories-legacy"""
 
         from ..models import BasicError, MinimalRepository
@@ -4679,7 +4692,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
         from ..models import TeamRepository
@@ -4703,7 +4716,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
         from ..models import TeamRepository
@@ -4895,7 +4908,7 @@ class TeamsClient:
         team_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team-legacy"""
 
         from ..models import BasicError, GroupMapping
@@ -4920,7 +4933,7 @@ class TeamsClient:
         team_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team-legacy"""
 
         from ..models import BasicError, GroupMapping
@@ -4947,7 +4960,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdTeamSyncGroupMappingsPatchBodyType,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     @overload
     def create_or_update_idp_group_connections_legacy(
@@ -4958,7 +4971,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         groups: list[TeamsTeamIdTeamSyncGroupMappingsPatchBodyPropGroupsItemsType],
         synced_at: Missing[str] = UNSET,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     def create_or_update_idp_group_connections_legacy(
         self,
@@ -4967,7 +4980,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#create-or-update-idp-group-connections-legacy"""
 
         from ..models import (
@@ -5009,7 +5022,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdTeamSyncGroupMappingsPatchBodyType,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     @overload
     async def async_create_or_update_idp_group_connections_legacy(
@@ -5020,7 +5033,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         groups: list[TeamsTeamIdTeamSyncGroupMappingsPatchBodyPropGroupsItemsType],
         synced_at: Missing[str] = UNSET,
-    ) -> Response[GroupMapping]: ...
+    ) -> Response[GroupMapping, GroupMappingType]: ...
 
     async def async_create_or_update_idp_group_connections_legacy(
         self,
@@ -5029,7 +5042,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GroupMapping]:
+    ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#create-or-update-idp-group-connections-legacy"""
 
         from ..models import (
@@ -5071,7 +5084,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams-legacy"""
 
         from ..models import Team, BasicError, ValidationError
@@ -5105,7 +5118,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams-legacy"""
 
         from ..models import Team, BasicError, ValidationError
@@ -5138,7 +5151,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamFull]]:
+    ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams-for-the-authenticated-user"""
 
         from ..models import TeamFull, BasicError
@@ -5170,7 +5183,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamFull]]:
+    ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams-for-the-authenticated-user"""
 
         from ..models import TeamFull, BasicError

--- a/githubkit/versions/ghec_v2022_11_28/rest/users.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/users.py
@@ -40,6 +40,16 @@ if TYPE_CHECKING:
         UsersUsernameAttestationsSubjectDigestGetResponse200,
     )
     from ..types import (
+        KeyType,
+        EmailType,
+        GpgKeyType,
+        HovercardType,
+        KeySimpleType,
+        PublicUserType,
+        SimpleUserType,
+        PrivateUserType,
+        SocialAccountType,
+        SshSigningKeyType,
         UserPatchBodyType,
         UserKeysPostBodyType,
         UserGpgKeysPostBodyType,
@@ -49,6 +59,7 @@ if TYPE_CHECKING:
         UserSshSigningKeysPostBodyType,
         UserEmailVisibilityPatchBodyType,
         UserSocialAccountsDeleteBodyType,
+        UsersUsernameAttestationsSubjectDigestGetResponse200Type,
     )
 
 
@@ -71,7 +82,9 @@ class UsersClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-the-authenticated-user"""
 
         from typing import Union
@@ -97,7 +110,9 @@ class UsersClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-the-authenticated-user"""
 
         from typing import Union
@@ -125,7 +140,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     @overload
     def update_authenticated(
@@ -141,7 +156,7 @@ class UsersClient:
         location: Missing[str] = UNSET,
         hireable: Missing[bool] = UNSET,
         bio: Missing[str] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     def update_authenticated(
         self,
@@ -149,7 +164,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PrivateUser]:
+    ) -> Response[PrivateUser, PrivateUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#update-the-authenticated-user"""
 
         from ..models import BasicError, PrivateUser, UserPatchBody, ValidationError
@@ -187,7 +202,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     @overload
     async def async_update_authenticated(
@@ -203,7 +218,7 @@ class UsersClient:
         location: Missing[str] = UNSET,
         hireable: Missing[bool] = UNSET,
         bio: Missing[str] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     async def async_update_authenticated(
         self,
@@ -211,7 +226,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PrivateUser]:
+    ) -> Response[PrivateUser, PrivateUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#update-the-authenticated-user"""
 
         from ..models import BasicError, PrivateUser, UserPatchBody, ValidationError
@@ -249,7 +264,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -282,7 +297,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -467,7 +482,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     def set_primary_email_visibility_for_authenticated_user(
@@ -476,7 +491,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         visibility: Literal["public", "private"],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     def set_primary_email_visibility_for_authenticated_user(
         self,
@@ -484,7 +499,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#set-primary-email-visibility-for-the-authenticated-user"""
 
         from ..models import (
@@ -527,7 +542,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     async def async_set_primary_email_visibility_for_authenticated_user(
@@ -536,7 +551,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         visibility: Literal["public", "private"],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_set_primary_email_visibility_for_authenticated_user(
         self,
@@ -544,7 +559,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#set-primary-email-visibility-for-the-authenticated-user"""
 
         from ..models import (
@@ -587,7 +602,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -620,7 +635,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -653,7 +668,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     def add_email_for_authenticated_user(
@@ -662,7 +677,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         emails: list[str],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     def add_email_for_authenticated_user(
         self,
@@ -670,7 +685,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#add-an-email-address-for-the-authenticated-user"""
 
         from typing import Union
@@ -724,7 +739,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     async def async_add_email_for_authenticated_user(
@@ -733,7 +748,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         emails: list[str],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_add_email_for_authenticated_user(
         self,
@@ -741,7 +756,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#add-an-email-address-for-the-authenticated-user"""
 
         from typing import Union
@@ -925,7 +940,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -957,7 +972,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -989,7 +1004,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
         from ..models import BasicError, SimpleUser
@@ -1021,7 +1036,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
         from ..models import BasicError, SimpleUser
@@ -1203,7 +1218,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1236,7 +1251,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1266,7 +1281,7 @@ class UsersClient:
     @overload
     def create_gpg_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
     def create_gpg_key_for_authenticated_user(
@@ -1276,7 +1291,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     def create_gpg_key_for_authenticated_user(
         self,
@@ -1284,7 +1299,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#create-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError, ValidationError, UserGpgKeysPostBody
@@ -1319,7 +1334,7 @@ class UsersClient:
     @overload
     async def async_create_gpg_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
     async def async_create_gpg_key_for_authenticated_user(
@@ -1329,7 +1344,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     async def async_create_gpg_key_for_authenticated_user(
         self,
@@ -1337,7 +1352,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#create-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError, ValidationError, UserGpgKeysPostBody
@@ -1374,7 +1389,7 @@ class UsersClient:
         gpg_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1400,7 +1415,7 @@ class UsersClient:
         gpg_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1479,7 +1494,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Key]]:
+    ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1512,7 +1527,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Key]]:
+    ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1542,7 +1557,7 @@ class UsersClient:
     @overload
     def create_public_ssh_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     @overload
     def create_public_ssh_key_for_authenticated_user(
@@ -1552,7 +1567,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     def create_public_ssh_key_for_authenticated_user(
         self,
@@ -1560,7 +1575,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError, ValidationError, UserKeysPostBody
@@ -1595,7 +1610,7 @@ class UsersClient:
     @overload
     async def async_create_public_ssh_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     @overload
     async def async_create_public_ssh_key_for_authenticated_user(
@@ -1605,7 +1620,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     async def async_create_public_ssh_key_for_authenticated_user(
         self,
@@ -1613,7 +1628,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError, ValidationError, UserKeysPostBody
@@ -1650,7 +1665,7 @@ class UsersClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1676,7 +1691,7 @@ class UsersClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1753,7 +1768,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -1786,7 +1801,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -1819,7 +1834,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
         from ..models import BasicError, SocialAccount
@@ -1852,7 +1867,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
         from ..models import BasicError, SocialAccount
@@ -1885,7 +1900,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     @overload
     def add_social_account_for_authenticated_user(
@@ -1894,7 +1909,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         account_urls: list[str],
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     def add_social_account_for_authenticated_user(
         self,
@@ -1902,7 +1917,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#add-social-accounts-for-the-authenticated-user"""
 
         from ..models import (
@@ -1945,7 +1960,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     @overload
     async def async_add_social_account_for_authenticated_user(
@@ -1954,7 +1969,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         account_urls: list[str],
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     async def async_add_social_account_for_authenticated_user(
         self,
@@ -1962,7 +1977,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#add-social-accounts-for-the-authenticated-user"""
 
         from ..models import (
@@ -2113,7 +2128,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2146,7 +2161,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2179,7 +2194,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     @overload
     def create_ssh_signing_key_for_authenticated_user(
@@ -2189,7 +2204,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     def create_ssh_signing_key_for_authenticated_user(
         self,
@@ -2197,7 +2212,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import (
@@ -2240,7 +2255,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     @overload
     async def async_create_ssh_signing_key_for_authenticated_user(
@@ -2250,7 +2265,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     async def async_create_ssh_signing_key_for_authenticated_user(
         self,
@@ -2258,7 +2273,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import (
@@ -2300,7 +2315,7 @@ class UsersClient:
         ssh_signing_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2326,7 +2341,7 @@ class UsersClient:
         ssh_signing_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2402,7 +2417,9 @@ class UsersClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-a-user-using-their-id"""
 
         from typing import Union
@@ -2428,7 +2445,9 @@ class UsersClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-a-user-using-their-id"""
 
         from typing import Union
@@ -2455,7 +2474,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#list-users"""
 
         from ..models import SimpleUser
@@ -2483,7 +2502,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#list-users"""
 
         from ..models import SimpleUser
@@ -2510,7 +2529,9 @@ class UsersClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-a-user"""
 
         from typing import Union
@@ -2536,7 +2557,9 @@ class UsersClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-a-user"""
 
         from typing import Union
@@ -2566,7 +2589,10 @@ class UsersClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UsersUsernameAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        UsersUsernameAttestationsSubjectDigestGetResponse200,
+        UsersUsernameAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/attestations#list-attestations"""
 
         from ..models import (
@@ -2604,7 +2630,10 @@ class UsersClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UsersUsernameAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        UsersUsernameAttestationsSubjectDigestGetResponse200,
+        UsersUsernameAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/attestations#list-attestations"""
 
         from ..models import (
@@ -2640,7 +2669,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-a-user"""
 
         from ..models import SimpleUser
@@ -2669,7 +2698,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-a-user"""
 
         from ..models import SimpleUser
@@ -2698,7 +2727,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-a-user-follows"""
 
         from ..models import SimpleUser
@@ -2727,7 +2756,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-a-user-follows"""
 
         from ..models import SimpleUser
@@ -2796,7 +2825,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
         from ..models import GpgKey
@@ -2825,7 +2854,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
         from ..models import GpgKey
@@ -2856,7 +2885,7 @@ class UsersClient:
         subject_id: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hovercard]:
+    ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-contextual-information-for-a-user"""
 
         from ..models import Hovercard, BasicError, ValidationError
@@ -2891,7 +2920,7 @@ class UsersClient:
         subject_id: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hovercard]:
+    ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-contextual-information-for-a-user"""
 
         from ..models import Hovercard, BasicError, ValidationError
@@ -2924,7 +2953,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[KeySimple]]:
+    ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-keys-for-a-user"""
 
         from ..models import KeySimple
@@ -2953,7 +2982,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[KeySimple]]:
+    ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-keys-for-a-user"""
 
         from ..models import KeySimple
@@ -2982,7 +3011,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-a-user"""
 
         from ..models import SocialAccount
@@ -3011,7 +3040,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-a-user"""
 
         from ..models import SocialAccount
@@ -3040,7 +3069,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 
         from ..models import SshSigningKey
@@ -3069,7 +3098,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 
         from ..models import SshSigningKey

--- a/githubkit/versions/v2022_11_28/rest/actions.py
+++ b/githubkit/versions/v2022_11_28/rest/actions.py
@@ -26,44 +26,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        SelectedActionsType,
-        ReviewCustomGatesStateRequiredType,
-        OrgsOrgActionsVariablesPostBodyType,
-        OrgsOrgActionsPermissionsPutBodyType,
-        ReviewCustomGatesCommentRequiredType,
-        ActionsWorkflowAccessToRepositoryType,
-        OrgsOrgActionsRunnerGroupsPostBodyType,
-        ActionsSetDefaultWorkflowPermissionsType,
-        OrgsOrgActionsVariablesNamePatchBodyType,
-        OrgsOrgActionsSecretsSecretNamePutBodyType,
-        ReposOwnerRepoActionsVariablesPostBodyType,
-        ReposOwnerRepoActionsPermissionsPutBodyType,
-        OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
-        OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
-        ReposOwnerRepoActionsJobsJobIdRerunPostBodyType,
-        ReposOwnerRepoActionsRunsRunIdRerunPostBodyType,
-        ReposOwnerRepoActionsVariablesNamePatchBodyType,
-        OrgsOrgActionsPermissionsRepositoriesPutBodyType,
-        ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
-        OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
-        OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
-        OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-        ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
-        ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
-        OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
-        ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
-        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
-        ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
-        ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType,
-        ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
-        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
-        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
-        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
-        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
-        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
-        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType,
-    )
     from ..models import (
         Job,
         Runner,
@@ -121,6 +83,97 @@ if TYPE_CHECKING:
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
     )
+    from ..types import (
+        JobType,
+        RunnerType,
+        ArtifactType,
+        WorkflowType,
+        DeploymentType,
+        EmptyObjectType,
+        WorkflowRunType,
+        ActionsSecretType,
+        WorkflowUsageType,
+        ActionsVariableType,
+        RunnerGroupsOrgType,
+        SelectedActionsType,
+        ActionsCacheListType,
+        ActionsPublicKeyType,
+        WorkflowRunUsageType,
+        OidcCustomSubRepoType,
+        PendingDeploymentType,
+        RunnerApplicationType,
+        AuthenticationTokenType,
+        EnvironmentApprovalsType,
+        OrganizationActionsSecretType,
+        OrganizationActionsVariableType,
+        ActionsRepositoryPermissionsType,
+        ActionsCacheUsageByRepositoryType,
+        ActionsCacheUsageOrgEnterpriseType,
+        ActionsOrganizationPermissionsType,
+        ReviewCustomGatesStateRequiredType,
+        OrgsOrgActionsVariablesPostBodyType,
+        OrgsOrgActionsPermissionsPutBodyType,
+        ReviewCustomGatesCommentRequiredType,
+        ActionsWorkflowAccessToRepositoryType,
+        OrgsOrgActionsRunnerGroupsPostBodyType,
+        OrgsOrgActionsRunnersGetResponse200Type,
+        OrgsOrgActionsSecretsGetResponse200Type,
+        ActionsGetDefaultWorkflowPermissionsType,
+        ActionsSetDefaultWorkflowPermissionsType,
+        OrgsOrgActionsVariablesNamePatchBodyType,
+        OrgsOrgActionsVariablesGetResponse200Type,
+        OrgsOrgActionsSecretsSecretNamePutBodyType,
+        ReposOwnerRepoActionsVariablesPostBodyType,
+        ReposOwnerRepoActionsPermissionsPutBodyType,
+        ReposOwnerRepoActionsRunsGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsGetResponse200Type,
+        OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
+        ReposOwnerRepoActionsRunnersGetResponse200Type,
+        ReposOwnerRepoActionsSecretsGetResponse200Type,
+        OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
+        ReposOwnerRepoActionsJobsJobIdRerunPostBodyType,
+        ReposOwnerRepoActionsRunsRunIdRerunPostBodyType,
+        ReposOwnerRepoActionsVariablesNamePatchBodyType,
+        OrgsOrgActionsPermissionsRepositoriesPutBodyType,
+        ReposOwnerRepoActionsArtifactsGetResponse200Type,
+        ReposOwnerRepoActionsVariablesGetResponse200Type,
+        ReposOwnerRepoActionsWorkflowsGetResponse200Type,
+        ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
+        OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
+        OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
+        ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+        ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
+        OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
+        ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
+        ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
+        ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType,
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
+        ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType,
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
+    )
 
 
 class ActionsClient:
@@ -143,7 +196,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageOrgEnterprise]:
+    ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
         from ..models import ActionsCacheUsageOrgEnterprise
@@ -164,7 +217,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageOrgEnterprise]:
+    ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
         from ..models import ActionsCacheUsageOrgEnterprise
@@ -187,7 +240,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsCacheUsageByRepositoryGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/cache#list-repositories-with-github-actions-cache-usage-for-an-organization"""
 
         from ..models import OrgsOrgActionsCacheUsageByRepositoryGetResponse200
@@ -216,7 +272,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsCacheUsageByRepositoryGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
+        OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/cache#list-repositories-with-github-actions-cache-usage-for-an-organization"""
 
         from ..models import OrgsOrgActionsCacheUsageByRepositoryGetResponse200
@@ -243,7 +302,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsOrganizationPermissions]:
+    ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
         from ..models import ActionsOrganizationPermissions
@@ -264,7 +323,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsOrganizationPermissions]:
+    ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
         from ..models import ActionsOrganizationPermissions
@@ -391,7 +450,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsPermissionsRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200,
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization"""
 
         from ..models import OrgsOrgActionsPermissionsRepositoriesGetResponse200
@@ -420,7 +482,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsPermissionsRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200,
+        OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization"""
 
         from ..models import OrgsOrgActionsPermissionsRepositoriesGetResponse200
@@ -629,7 +694,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
         from ..models import SelectedActions
@@ -650,7 +715,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
         from ..models import SelectedActions
@@ -777,7 +842,9 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#get-default-workflow-permissions-for-an-organization"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -798,7 +865,9 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#get-default-workflow-permissions-for-an-organization"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -926,7 +995,10 @@ class ActionsClient:
         visible_to_repository: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsGetResponse200,
+        OrgsOrgActionsRunnerGroupsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnerGroupsGetResponse200
@@ -957,7 +1029,10 @@ class ActionsClient:
         visible_to_repository: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsGetResponse200,
+        OrgsOrgActionsRunnerGroupsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnerGroupsGetResponse200
@@ -987,7 +1062,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     def create_self_hosted_runner_group_for_org(
@@ -1003,7 +1078,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     def create_self_hosted_runner_group_for_org(
         self,
@@ -1012,7 +1087,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg, OrgsOrgActionsRunnerGroupsPostBody
@@ -1045,7 +1120,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     async def async_create_self_hosted_runner_group_for_org(
@@ -1061,7 +1136,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     async def async_create_self_hosted_runner_group_for_org(
         self,
@@ -1070,7 +1145,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#create-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg, OrgsOrgActionsRunnerGroupsPostBody
@@ -1102,7 +1177,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg
@@ -1124,7 +1199,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import RunnerGroupsOrg
@@ -1186,7 +1261,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     def update_self_hosted_runner_group_for_org(
@@ -1201,7 +1276,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     def update_self_hosted_runner_group_for_org(
         self,
@@ -1211,7 +1286,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import (
@@ -1250,7 +1325,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     @overload
     async def async_update_self_hosted_runner_group_for_org(
@@ -1265,7 +1340,7 @@ class ActionsClient:
         allows_public_repositories: Missing[bool] = UNSET,
         restricted_to_workflows: Missing[bool] = UNSET,
         selected_workflows: Missing[list[str]] = UNSET,
-    ) -> Response[RunnerGroupsOrg]: ...
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
     async def async_update_self_hosted_runner_group_for_org(
         self,
@@ -1275,7 +1350,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RunnerGroupsOrg]:
+    ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#update-a-self-hosted-runner-group-for-an-organization"""
 
         from ..models import (
@@ -1314,7 +1389,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
         from ..models import (
@@ -1346,7 +1424,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
         from ..models import (
@@ -1574,7 +1655,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-organization"""
 
         from ..models import (
@@ -1606,7 +1690,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
+        OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#list-self-hosted-runners-in-a-group-for-an-organization"""
 
         from ..models import (
@@ -1834,7 +1921,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnersGetResponse200
@@ -1865,7 +1954,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization"""
 
         from ..models import OrgsOrgActionsRunnersGetResponse200
@@ -1893,7 +1984,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
         from ..models import RunnerApplication
@@ -1914,7 +2005,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
         from ..models import RunnerApplication
@@ -1937,7 +2028,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     @overload
     def generate_runner_jitconfig_for_org(
@@ -1950,7 +2044,10 @@ class ActionsClient:
         runner_group_id: int,
         labels: list[str],
         work_folder: Missing[str] = UNSET,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     def generate_runner_jitconfig_for_org(
         self,
@@ -1959,7 +2056,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-organization"""
 
         from ..models import (
@@ -2003,7 +2103,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_generate_runner_jitconfig_for_org(
@@ -2016,7 +2119,10 @@ class ActionsClient:
         runner_group_id: int,
         labels: list[str],
         work_folder: Missing[str] = UNSET,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     async def async_generate_runner_jitconfig_for_org(
         self,
@@ -2025,7 +2131,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-an-organization"""
 
         from ..models import (
@@ -2067,7 +2176,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2088,7 +2197,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2109,7 +2218,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2130,7 +2239,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
         from ..models import AuthenticationToken
@@ -2152,7 +2261,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
         from ..models import Runner
@@ -2174,7 +2283,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
         from ..models import Runner
@@ -2234,7 +2343,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2262,7 +2374,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2292,7 +2407,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def set_custom_labels_for_self_hosted_runner_for_org(
@@ -2303,7 +2421,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def set_custom_labels_for_self_hosted_runner_for_org(
         self,
@@ -2313,7 +2434,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2358,7 +2482,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_set_custom_labels_for_self_hosted_runner_for_org(
@@ -2369,7 +2496,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_set_custom_labels_for_self_hosted_runner_for_org(
         self,
@@ -2379,7 +2509,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2424,7 +2557,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def add_custom_labels_to_self_hosted_runner_for_org(
@@ -2435,7 +2571,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def add_custom_labels_to_self_hosted_runner_for_org(
         self,
@@ -2445,7 +2584,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2490,7 +2632,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_add_custom_labels_to_self_hosted_runner_for_org(
@@ -2501,7 +2646,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_add_custom_labels_to_self_hosted_runner_for_org(
         self,
@@ -2511,7 +2659,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2554,7 +2705,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2582,7 +2736,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2611,7 +2768,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2642,7 +2802,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-an-organization"""
 
         from ..models import (
@@ -2673,7 +2836,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgActionsSecretsGetResponse200
@@ -2702,7 +2867,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgActionsSecretsGetResponse200
@@ -2729,7 +2896,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-public-key"""
 
         from ..models import ActionsPublicKey
@@ -2750,7 +2917,7 @@ class ActionsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-public-key"""
 
         from ..models import ActionsPublicKey
@@ -2772,7 +2939,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsSecret]:
+    ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationActionsSecret
@@ -2794,7 +2961,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsSecret]:
+    ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationActionsSecret
@@ -2818,7 +2985,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_org_secret(
@@ -2832,7 +2999,7 @@ class ActionsClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_org_secret(
         self,
@@ -2842,7 +3009,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgActionsSecretsSecretNamePutBody
@@ -2876,7 +3043,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_org_secret(
@@ -2890,7 +3057,7 @@ class ActionsClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_org_secret(
         self,
@@ -2900,7 +3067,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgActionsSecretsSecretNamePutBody
@@ -2972,7 +3139,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200
@@ -3002,7 +3172,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200
@@ -3227,7 +3400,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-organization-variables"""
 
         from ..models import OrgsOrgActionsVariablesGetResponse200
@@ -3256,7 +3431,9 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-organization-variables"""
 
         from ..models import OrgsOrgActionsVariablesGetResponse200
@@ -3285,7 +3462,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_org_variable(
@@ -3298,7 +3475,7 @@ class ActionsClient:
         value: str,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_org_variable(
         self,
@@ -3307,7 +3484,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/variables#create-an-organization-variable"""
 
         from ..models import EmptyObject, OrgsOrgActionsVariablesPostBody
@@ -3340,7 +3517,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_org_variable(
@@ -3353,7 +3530,7 @@ class ActionsClient:
         value: str,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_org_variable(
         self,
@@ -3362,7 +3539,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/variables#create-an-organization-variable"""
 
         from ..models import EmptyObject, OrgsOrgActionsVariablesPostBody
@@ -3394,7 +3571,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsVariable]:
+    ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-organization-variable"""
 
         from ..models import OrganizationActionsVariable
@@ -3416,7 +3593,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationActionsVariable]:
+    ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-organization-variable"""
 
         from ..models import OrganizationActionsVariable
@@ -3590,7 +3767,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-selected-repositories-for-an-organization-variable"""
 
         from ..models import OrgsOrgActionsVariablesNameRepositoriesGetResponse200
@@ -3621,7 +3801,10 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsVariablesNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
+        OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-selected-repositories-for-an-organization-variable"""
 
         from ..models import OrgsOrgActionsVariablesNameRepositoriesGetResponse200
@@ -3851,7 +4034,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsArtifactsGetResponse200,
+        ReposOwnerRepoActionsArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/artifacts#list-artifacts-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsArtifactsGetResponse200
@@ -3883,7 +4069,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsArtifactsGetResponse200,
+        ReposOwnerRepoActionsArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/artifacts#list-artifacts-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsArtifactsGetResponse200
@@ -3913,7 +4102,7 @@ class ActionsClient:
         artifact_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Artifact]:
+    ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/rest/actions/artifacts#get-an-artifact"""
 
         from ..models import Artifact
@@ -3936,7 +4125,7 @@ class ActionsClient:
         artifact_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Artifact]:
+    ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/rest/actions/artifacts#get-an-artifact"""
 
         from ..models import Artifact
@@ -4050,7 +4239,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageByRepository]:
+    ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
         from ..models import ActionsCacheUsageByRepository
@@ -4072,7 +4261,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheUsageByRepository]:
+    ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
         from ..models import ActionsCacheUsageByRepository
@@ -4102,7 +4291,7 @@ class ActionsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
         from ..models import ActionsCacheList
@@ -4142,7 +4331,7 @@ class ActionsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
         from ..models import ActionsCacheList
@@ -4176,7 +4365,7 @@ class ActionsClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
         from ..models import ActionsCacheList
@@ -4206,7 +4395,7 @@ class ActionsClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsCacheList]:
+    ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
         from ..models import ActionsCacheList
@@ -4275,7 +4464,7 @@ class ActionsClient:
         job_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Job]:
+    ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
         from ..models import Job
@@ -4298,7 +4487,7 @@ class ActionsClient:
         job_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Job]:
+    ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
         from ..models import Job
@@ -4365,7 +4554,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def re_run_job_for_workflow_run(
@@ -4377,7 +4566,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def re_run_job_for_workflow_run(
         self,
@@ -4390,7 +4579,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run"""
 
         from typing import Union
@@ -4438,7 +4627,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_re_run_job_for_workflow_run(
@@ -4450,7 +4639,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_re_run_job_for_workflow_run(
         self,
@@ -4463,7 +4652,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#re-run-a-job-from-a-workflow-run"""
 
         from typing import Union
@@ -4506,7 +4695,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSubRepo]:
+    ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import BasicError, OidcCustomSubRepo
@@ -4532,7 +4721,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSubRepo]:
+    ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import BasicError, OidcCustomSubRepo
@@ -4560,7 +4749,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def set_custom_oidc_sub_claim_for_repo(
@@ -4572,7 +4761,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def set_custom_oidc_sub_claim_for_repo(
         self,
@@ -4582,7 +4771,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import (
@@ -4628,7 +4817,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_set_custom_oidc_sub_claim_for_repo(
@@ -4640,7 +4829,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_set_custom_oidc_sub_claim_for_repo(
         self,
@@ -4650,7 +4839,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
         from ..models import (
@@ -4696,7 +4885,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-repository-organization-secrets"""
 
         from ..models import ReposOwnerRepoActionsOrganizationSecretsGetResponse200
@@ -4726,7 +4918,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
+        ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-repository-organization-secrets"""
 
         from ..models import ReposOwnerRepoActionsOrganizationSecretsGetResponse200
@@ -4756,7 +4951,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-repository-organization-variables"""
 
         from ..models import ReposOwnerRepoActionsOrganizationVariablesGetResponse200
@@ -4786,7 +4984,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsOrganizationVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
+        ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-repository-organization-variables"""
 
         from ..models import ReposOwnerRepoActionsOrganizationVariablesGetResponse200
@@ -4814,7 +5015,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsRepositoryPermissions]:
+    ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
         from ..models import ActionsRepositoryPermissions
@@ -4836,7 +5037,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsRepositoryPermissions]:
+    ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
         from ..models import ActionsRepositoryPermissions
@@ -4968,7 +5169,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsWorkflowAccessToRepository]:
+    ) -> Response[
+        ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository"""
 
         from ..models import ActionsWorkflowAccessToRepository
@@ -4990,7 +5193,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsWorkflowAccessToRepository]:
+    ) -> Response[
+        ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository"""
 
         from ..models import ActionsWorkflowAccessToRepository
@@ -5120,7 +5325,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
         from ..models import SelectedActions
@@ -5142,7 +5347,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SelectedActions]:
+    ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
         from ..models import SelectedActions
@@ -5276,7 +5481,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#get-default-workflow-permissions-for-a-repository"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -5298,7 +5505,9 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsGetDefaultWorkflowPermissions]:
+    ) -> Response[
+        ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
+    ]:
         """See also: https://docs.github.com/rest/actions/permissions#get-default-workflow-permissions-for-a-repository"""
 
         from ..models import ActionsGetDefaultWorkflowPermissions
@@ -5435,7 +5644,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunnersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunnersGetResponse200,
+        ReposOwnerRepoActionsRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-self-hosted-runners-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunnersGetResponse200
@@ -5467,7 +5679,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunnersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunnersGetResponse200,
+        ReposOwnerRepoActionsRunnersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-self-hosted-runners-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunnersGetResponse200
@@ -5496,7 +5711,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
         from ..models import RunnerApplication
@@ -5518,7 +5733,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RunnerApplication]]:
+    ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
         from ..models import RunnerApplication
@@ -5542,7 +5757,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     @overload
     def generate_runner_jitconfig_for_repo(
@@ -5556,7 +5774,10 @@ class ActionsClient:
         runner_group_id: int,
         labels: list[str],
         work_folder: Missing[str] = UNSET,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     def generate_runner_jitconfig_for_repo(
         self,
@@ -5568,7 +5789,10 @@ class ActionsClient:
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-a-repository"""
 
         from ..models import (
@@ -5613,7 +5837,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_generate_runner_jitconfig_for_repo(
@@ -5627,7 +5854,10 @@ class ActionsClient:
         runner_group_id: int,
         labels: list[str],
         work_folder: Missing[str] = UNSET,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]: ...
 
     async def async_generate_runner_jitconfig_for_repo(
         self,
@@ -5639,7 +5869,10 @@ class ActionsClient:
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersGenerateJitconfigPostResponse201]:
+    ) -> Response[
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
+        OrgsOrgActionsRunnersGenerateJitconfigPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-configuration-for-a-just-in-time-runner-for-a-repository"""
 
         from ..models import (
@@ -5682,7 +5915,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -5704,7 +5937,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -5726,7 +5959,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -5748,7 +5981,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AuthenticationToken]:
+    ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
         from ..models import AuthenticationToken
@@ -5771,7 +6004,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
         from ..models import Runner
@@ -5794,7 +6027,7 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Runner]:
+    ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
         from ..models import Runner
@@ -5857,7 +6090,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -5886,7 +6122,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -5917,7 +6156,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def set_custom_labels_for_self_hosted_runner_for_repo(
@@ -5929,7 +6171,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def set_custom_labels_for_self_hosted_runner_for_repo(
         self,
@@ -5940,7 +6185,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -5986,7 +6234,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_set_custom_labels_for_self_hosted_runner_for_repo(
@@ -5998,7 +6249,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_set_custom_labels_for_self_hosted_runner_for_repo(
         self,
@@ -6009,7 +6263,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#set-custom-labels-for-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6055,7 +6312,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     def add_custom_labels_to_self_hosted_runner_for_repo(
@@ -6067,7 +6327,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     def add_custom_labels_to_self_hosted_runner_for_repo(
         self,
@@ -6078,7 +6341,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6124,7 +6390,10 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     @overload
     async def async_add_custom_labels_to_self_hosted_runner_for_repo(
@@ -6136,7 +6405,10 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: list[str],
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]: ...
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]: ...
 
     async def async_add_custom_labels_to_self_hosted_runner_for_repo(
         self,
@@ -6147,7 +6419,10 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#add-custom-labels-to-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6191,7 +6466,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6220,7 +6498,10 @@ class ActionsClient:
         runner_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-all-custom-labels-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6250,7 +6531,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6282,7 +6566,10 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200]:
+    ) -> Response[
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
+        OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#remove-a-custom-label-from-a-self-hosted-runner-for-a-repository"""
 
         from ..models import (
@@ -6339,7 +6626,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsGetResponse200,
+        ReposOwnerRepoActionsRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunsGetResponse200
@@ -6402,7 +6692,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsGetResponse200,
+        ReposOwnerRepoActionsRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-repository"""
 
         from ..models import ReposOwnerRepoActionsRunsGetResponse200
@@ -6440,7 +6733,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run"""
 
         from ..models import WorkflowRun
@@ -6469,7 +6762,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run"""
 
         from ..models import WorkflowRun
@@ -6537,7 +6830,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[EnvironmentApprovals]]:
+    ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
         from ..models import EnvironmentApprovals
@@ -6560,7 +6853,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[EnvironmentApprovals]]:
+    ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
         from ..models import EnvironmentApprovals
@@ -6583,7 +6876,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
         from ..models import BasicError, EmptyObject
@@ -6610,7 +6903,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
         from ..models import BasicError, EmptyObject
@@ -6640,7 +6933,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/artifacts#list-workflow-run-artifacts"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200
@@ -6673,7 +6969,10 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/artifacts#list-workflow-run-artifacts"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200
@@ -6705,7 +7004,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
         from ..models import WorkflowRun
@@ -6735,7 +7034,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRun]:
+    ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
         from ..models import WorkflowRun
@@ -6767,7 +7066,8 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt"""
 
@@ -6807,7 +7107,8 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt"""
 
@@ -6885,7 +7186,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -6911,7 +7212,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7109,7 +7410,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7135,7 +7436,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
         from ..models import BasicError, EmptyObject
@@ -7164,7 +7465,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdJobsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdJobsGetResponse200
@@ -7197,7 +7501,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsRunsRunIdJobsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
+        ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run"""
 
         from ..models import ReposOwnerRepoActionsRunsRunIdJobsGetResponse200
@@ -7319,7 +7626,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PendingDeployment]]:
+    ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
         from ..models import PendingDeployment
@@ -7342,7 +7649,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PendingDeployment]]:
+    ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
         from ..models import PendingDeployment
@@ -7367,7 +7674,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     @overload
     def review_pending_deployments_for_run(
@@ -7381,7 +7688,7 @@ class ActionsClient:
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     def review_pending_deployments_for_run(
         self,
@@ -7394,7 +7701,7 @@ class ActionsClient:
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run"""
 
         from ..models import (
@@ -7434,7 +7741,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     @overload
     async def async_review_pending_deployments_for_run(
@@ -7448,7 +7755,7 @@ class ActionsClient:
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
-    ) -> Response[list[Deployment]]: ...
+    ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
     async def async_review_pending_deployments_for_run(
         self,
@@ -7461,7 +7768,7 @@ class ActionsClient:
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run"""
 
         from ..models import (
@@ -7503,7 +7810,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def re_run_workflow(
@@ -7515,7 +7822,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def re_run_workflow(
         self,
@@ -7528,7 +7835,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#re-run-a-workflow"""
 
         from typing import Union
@@ -7569,7 +7876,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_re_run_workflow(
@@ -7581,7 +7888,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_re_run_workflow(
         self,
@@ -7594,7 +7901,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#re-run-a-workflow"""
 
         from typing import Union
@@ -7635,7 +7942,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def re_run_workflow_failed_jobs(
@@ -7647,7 +7954,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def re_run_workflow_failed_jobs(
         self,
@@ -7660,7 +7967,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run"""
 
         from typing import Union
@@ -7704,7 +8011,7 @@ class ActionsClient:
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_re_run_workflow_failed_jobs(
@@ -7716,7 +8023,7 @@ class ActionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_re_run_workflow_failed_jobs(
         self,
@@ -7729,7 +8036,7 @@ class ActionsClient:
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run"""
 
         from typing import Union
@@ -7769,7 +8076,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRunUsage]:
+    ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-workflow-run-usage"""
 
         from ..models import WorkflowRunUsage
@@ -7792,7 +8099,7 @@ class ActionsClient:
         run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowRunUsage]:
+    ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-workflow-run-usage"""
 
         from ..models import WorkflowRunUsage
@@ -7816,7 +8123,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsSecretsGetResponse200,
+        ReposOwnerRepoActionsSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoActionsSecretsGetResponse200
@@ -7846,7 +8156,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsSecretsGetResponse200,
+        ReposOwnerRepoActionsSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoActionsSecretsGetResponse200
@@ -7874,7 +8187,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-public-key"""
 
         from ..models import ActionsPublicKey
@@ -7896,7 +8209,7 @@ class ActionsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-public-key"""
 
         from ..models import ActionsPublicKey
@@ -7919,7 +8232,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-secret"""
 
         from ..models import ActionsSecret
@@ -7942,7 +8255,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-secret"""
 
         from ..models import ActionsSecret
@@ -7967,7 +8280,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_repo_secret(
@@ -7980,7 +8293,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_repo_secret(
         self,
@@ -7991,7 +8304,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/secrets#create-or-update-a-repository-secret"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsSecretsSecretNamePutBody
@@ -8028,7 +8341,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_repo_secret(
@@ -8041,7 +8354,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_repo_secret(
         self,
@@ -8052,7 +8365,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/secrets#create-or-update-a-repository-secret"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsSecretsSecretNamePutBody
@@ -8128,7 +8441,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsVariablesGetResponse200,
+        ReposOwnerRepoActionsVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-repository-variables"""
 
         from ..models import ReposOwnerRepoActionsVariablesGetResponse200
@@ -8158,7 +8474,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsVariablesGetResponse200,
+        ReposOwnerRepoActionsVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-repository-variables"""
 
         from ..models import ReposOwnerRepoActionsVariablesGetResponse200
@@ -8188,7 +8507,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_repo_variable(
@@ -8200,7 +8519,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_repo_variable(
         self,
@@ -8210,7 +8529,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/variables#create-a-repository-variable"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsVariablesPostBody
@@ -8244,7 +8563,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_repo_variable(
@@ -8256,7 +8575,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_repo_variable(
         self,
@@ -8266,7 +8585,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/variables#create-a-repository-variable"""
 
         from ..models import EmptyObject, ReposOwnerRepoActionsVariablesPostBody
@@ -8299,7 +8618,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-a-repository-variable"""
 
         from ..models import ActionsVariable
@@ -8322,7 +8641,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-a-repository-variable"""
 
         from ..models import ActionsVariable
@@ -8504,7 +8823,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflows#list-repository-workflows"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsGetResponse200
@@ -8534,7 +8856,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflows#list-repository-workflows"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsGetResponse200
@@ -8563,7 +8888,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Workflow]:
+    ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-a-workflow"""
 
         from ..models import Workflow
@@ -8586,7 +8911,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Workflow]:
+    ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-a-workflow"""
 
         from ..models import Workflow
@@ -8844,7 +9169,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200
@@ -8908,7 +9236,10 @@ class ActionsClient:
         head_sha: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
+        ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow"""
 
         from ..models import ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200
@@ -8945,7 +9276,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowUsage]:
+    ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-workflow-usage"""
 
         from ..models import WorkflowUsage
@@ -8968,7 +9299,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WorkflowUsage]:
+    ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-workflow-usage"""
 
         from ..models import WorkflowUsage
@@ -8993,7 +9324,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-environment-secrets"""
 
         from ..models import (
@@ -9026,7 +9360,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/secrets#list-environment-secrets"""
 
         from ..models import (
@@ -9057,7 +9394,7 @@ class ActionsClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key"""
 
         from ..models import ActionsPublicKey
@@ -9082,7 +9419,7 @@ class ActionsClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsPublicKey]:
+    ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key"""
 
         from ..models import ActionsPublicKey
@@ -9108,7 +9445,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-secret"""
 
         from ..models import ActionsSecret
@@ -9132,7 +9469,7 @@ class ActionsClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsSecret]:
+    ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-secret"""
 
         from ..models import ActionsSecret
@@ -9158,7 +9495,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_environment_secret(
@@ -9172,7 +9509,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: str,
         key_id: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_environment_secret(
         self,
@@ -9186,7 +9523,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/secrets#create-or-update-an-environment-secret"""
 
         from ..models import (
@@ -9227,7 +9564,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_environment_secret(
@@ -9241,7 +9578,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: str,
         key_id: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_environment_secret(
         self,
@@ -9255,7 +9592,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/secrets#create-or-update-an-environment-secret"""
 
         from ..models import (
@@ -9337,7 +9674,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-environment-variables"""
 
         from ..models import (
@@ -9370,7 +9710,10 @@ class ActionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/actions/variables#list-environment-variables"""
 
         from ..models import (
@@ -9403,7 +9746,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_environment_variable(
@@ -9416,7 +9759,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_environment_variable(
         self,
@@ -9429,7 +9772,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/variables#create-an-environment-variable"""
 
         from ..models import (
@@ -9469,7 +9812,7 @@ class ActionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_environment_variable(
@@ -9482,7 +9825,7 @@ class ActionsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         value: str,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_environment_variable(
         self,
@@ -9495,7 +9838,7 @@ class ActionsClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/variables#create-an-environment-variable"""
 
         from ..models import (
@@ -9534,7 +9877,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-environment-variable"""
 
         from ..models import ActionsVariable
@@ -9558,7 +9901,7 @@ class ActionsClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsVariable]:
+    ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-environment-variable"""
 
         from ..models import ActionsVariable

--- a/githubkit/versions/v2022_11_28/rest/activity.py
+++ b/githubkit/versions/v2022_11_28/rest/activity.py
@@ -27,12 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        NotificationsPutBodyType,
-        ReposOwnerRepoSubscriptionPutBodyType,
-        ReposOwnerRepoNotificationsPutBodyType,
-        NotificationsThreadsThreadIdSubscriptionPutBodyType,
-    )
     from ..models import (
         Feed,
         Event,
@@ -46,6 +40,24 @@ if TYPE_CHECKING:
         RepositorySubscription,
         NotificationsPutResponse202,
         ReposOwnerRepoNotificationsPutResponse202,
+    )
+    from ..types import (
+        FeedType,
+        EventType,
+        ThreadType,
+        StargazerType,
+        RepositoryType,
+        SimpleUserType,
+        MinimalRepositoryType,
+        StarredRepositoryType,
+        ThreadSubscriptionType,
+        NotificationsPutBodyType,
+        RepositorySubscriptionType,
+        NotificationsPutResponse202Type,
+        ReposOwnerRepoSubscriptionPutBodyType,
+        ReposOwnerRepoNotificationsPutBodyType,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+        NotificationsThreadsThreadIdSubscriptionPutBodyType,
     )
 
 
@@ -70,7 +82,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events"""
 
         from ..models import (
@@ -106,7 +118,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events"""
 
         from ..models import (
@@ -140,7 +152,7 @@ class ActivityClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Feed]:
+    ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/rest/activity/feeds#get-feeds"""
 
         from ..models import Feed
@@ -160,7 +172,7 @@ class ActivityClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Feed]:
+    ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/rest/activity/feeds#get-feeds"""
 
         from ..models import Feed
@@ -184,7 +196,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
         from ..models import Event, BasicError
@@ -218,7 +230,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
         from ..models import Event, BasicError
@@ -254,7 +266,7 @@ class ActivityClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
         from ..models import Thread, BasicError, ValidationError
@@ -295,7 +307,7 @@ class ActivityClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
         from ..models import Thread, BasicError, ValidationError
@@ -332,7 +344,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     @overload
     def mark_notifications_as_read(
@@ -342,7 +354,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     def mark_notifications_as_read(
         self,
@@ -350,7 +362,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[NotificationsPutResponse202]:
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
         """See also: https://docs.github.com/rest/activity/notifications#mark-notifications-as-read"""
 
         from ..models import (
@@ -390,7 +402,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     @overload
     async def async_mark_notifications_as_read(
@@ -400,7 +412,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
-    ) -> Response[NotificationsPutResponse202]: ...
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
     async def async_mark_notifications_as_read(
         self,
@@ -408,7 +420,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[NotificationsPutResponse202]:
+    ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
         """See also: https://docs.github.com/rest/activity/notifications#mark-notifications-as-read"""
 
         from ..models import (
@@ -447,7 +459,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Thread]:
+    ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread"""
 
         from ..models import Thread, BasicError
@@ -472,7 +484,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Thread]:
+    ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread"""
 
         from ..models import Thread, BasicError
@@ -579,7 +591,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
         from ..models import BasicError, ThreadSubscription
@@ -604,7 +616,7 @@ class ActivityClient:
         thread_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
         from ..models import BasicError, ThreadSubscription
@@ -631,7 +643,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     @overload
     def set_thread_subscription(
@@ -641,7 +653,7 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     def set_thread_subscription(
         self,
@@ -650,7 +662,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/rest/activity/notifications#set-a-thread-subscription"""
 
         from ..models import (
@@ -693,7 +705,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     @overload
     async def async_set_thread_subscription(
@@ -703,7 +715,7 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[ThreadSubscription]: ...
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
     async def async_set_thread_subscription(
         self,
@@ -712,7 +724,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ThreadSubscription]:
+    ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/rest/activity/notifications#set-a-thread-subscription"""
 
         from ..models import (
@@ -803,7 +815,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-organization-events"""
 
         from ..models import Event
@@ -832,7 +844,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-organization-events"""
 
         from ..models import Event
@@ -862,7 +874,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-repository-events"""
 
         from ..models import Event
@@ -892,7 +904,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-repository-events"""
 
         from ..models import Event
@@ -926,7 +938,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
         from ..models import Thread
@@ -964,7 +976,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Thread]]:
+    ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
         from ..models import Thread
@@ -998,7 +1010,10 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     @overload
     def mark_repo_notifications_as_read(
@@ -1009,7 +1024,10 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     def mark_repo_notifications_as_read(
         self,
@@ -1019,7 +1037,10 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/activity/notifications#mark-repository-notifications-as-read"""
 
         from ..models import (
@@ -1056,7 +1077,10 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     @overload
     async def async_mark_repo_notifications_as_read(
@@ -1067,7 +1091,10 @@ class ActivityClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]: ...
 
     async def async_mark_repo_notifications_as_read(
         self,
@@ -1077,7 +1104,10 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoNotificationsPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoNotificationsPutResponse202,
+        ReposOwnerRepoNotificationsPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/activity/notifications#mark-repository-notifications-as-read"""
 
         from ..models import (
@@ -1114,7 +1144,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[SimpleUser], list[Stargazer]]]:
+    ) -> Response[
+        Union[list[SimpleUser], list[Stargazer]],
+        Union[list[SimpleUserType], list[StargazerType]],
+    ]:
         """See also: https://docs.github.com/rest/activity/starring#list-stargazers"""
 
         from typing import Union
@@ -1149,7 +1182,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[SimpleUser], list[Stargazer]]]:
+    ) -> Response[
+        Union[list[SimpleUser], list[Stargazer]],
+        Union[list[SimpleUserType], list[StargazerType]],
+    ]:
         """See also: https://docs.github.com/rest/activity/starring#list-stargazers"""
 
         from typing import Union
@@ -1184,7 +1220,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-watchers"""
 
         from ..models import SimpleUser
@@ -1214,7 +1250,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-watchers"""
 
         from ..models import SimpleUser
@@ -1242,7 +1278,7 @@ class ActivityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/rest/activity/watching#get-a-repository-subscription"""
 
         from ..models import BasicError, RepositorySubscription
@@ -1267,7 +1303,7 @@ class ActivityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/rest/activity/watching#get-a-repository-subscription"""
 
         from ..models import BasicError, RepositorySubscription
@@ -1294,7 +1330,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     @overload
     def set_repo_subscription(
@@ -1306,7 +1342,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     def set_repo_subscription(
         self,
@@ -1316,7 +1352,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/rest/activity/watching#set-a-repository-subscription"""
 
         from ..models import RepositorySubscription, ReposOwnerRepoSubscriptionPutBody
@@ -1350,7 +1386,7 @@ class ActivityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     @overload
     async def async_set_repo_subscription(
@@ -1362,7 +1398,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
-    ) -> Response[RepositorySubscription]: ...
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
     async def async_set_repo_subscription(
         self,
@@ -1372,7 +1408,7 @@ class ActivityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositorySubscription]:
+    ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/rest/activity/watching#set-a-repository-subscription"""
 
         from ..models import RepositorySubscription, ReposOwnerRepoSubscriptionPutBody
@@ -1444,7 +1480,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
         from ..models import BasicError, Repository
@@ -1480,7 +1516,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
         from ..models import BasicError, Repository
@@ -1670,7 +1706,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
         from ..models import BasicError, MinimalRepository
@@ -1702,7 +1738,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
         from ..models import BasicError, MinimalRepository
@@ -1735,7 +1771,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1764,7 +1800,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1794,7 +1830,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1824,7 +1860,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
         from ..models import Event
@@ -1853,7 +1889,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-user"""
 
         from ..models import Event
@@ -1882,7 +1918,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-user"""
 
         from ..models import Event
@@ -1911,7 +1947,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-received-by-the-authenticated-user"""
 
         from ..models import Event
@@ -1940,7 +1976,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-received-by-the-authenticated-user"""
 
         from ..models import Event
@@ -1969,7 +2005,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-received-by-a-user"""
 
         from ..models import Event
@@ -1998,7 +2034,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Event]]:
+    ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-received-by-a-user"""
 
         from ..models import Event
@@ -2029,7 +2065,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[StarredRepository], list[Repository]]]:
+    ) -> Response[
+        Union[list[StarredRepository], list[Repository]],
+        Union[list[StarredRepositoryType], list[RepositoryType]],
+    ]:
         """See also: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-a-user"""
 
         from typing import Union
@@ -2064,7 +2103,10 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[list[StarredRepository], list[Repository]]]:
+    ) -> Response[
+        Union[list[StarredRepository], list[Repository]],
+        Union[list[StarredRepositoryType], list[RepositoryType]],
+    ]:
         """See also: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-a-user"""
 
         from typing import Union
@@ -2097,7 +2139,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-a-user"""
 
         from ..models import MinimalRepository
@@ -2126,7 +2168,7 @@ class ActivityClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-a-user"""
 
         from ..models import MinimalRepository

--- a/githubkit/versions/v2022_11_28/rest/apps.py
+++ b/githubkit/versions/v2022_11_28/rest/apps.py
@@ -27,16 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        AppPermissionsType,
-        AppHookConfigPatchBodyType,
-        ApplicationsClientIdTokenPostBodyType,
-        ApplicationsClientIdTokenPatchBodyType,
-        ApplicationsClientIdGrantDeleteBodyType,
-        ApplicationsClientIdTokenDeleteBodyType,
-        ApplicationsClientIdTokenScopedPostBodyType,
-        AppInstallationsInstallationIdAccessTokensPostBodyType,
-    )
     from ..models import (
         Integration,
         HookDelivery,
@@ -54,6 +44,32 @@ if TYPE_CHECKING:
         AppManifestsCodeConversionsPostResponse201,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         UserInstallationsInstallationIdRepositoriesGetResponse200,
+    )
+    from ..types import (
+        IntegrationType,
+        HookDeliveryType,
+        InstallationType,
+        AuthorizationType,
+        WebhookConfigType,
+        AppPermissionsType,
+        HookDeliveryItemType,
+        InstallationTokenType,
+        MarketplacePurchaseType,
+        AppHookConfigPatchBodyType,
+        MarketplaceListingPlanType,
+        UserMarketplacePurchaseType,
+        IntegrationInstallationRequestType,
+        UserInstallationsGetResponse200Type,
+        ApplicationsClientIdTokenPostBodyType,
+        ApplicationsClientIdTokenPatchBodyType,
+        ApplicationsClientIdGrantDeleteBodyType,
+        ApplicationsClientIdTokenDeleteBodyType,
+        InstallationRepositoriesGetResponse200Type,
+        ApplicationsClientIdTokenScopedPostBodyType,
+        AppManifestsCodeConversionsPostResponse201Type,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+        AppInstallationsInstallationIdAccessTokensPostBodyType,
+        UserInstallationsInstallationIdRepositoriesGetResponse200Type,
     )
 
 
@@ -76,7 +92,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-the-authenticated-app"""
 
         from typing import Union
@@ -98,7 +114,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-the-authenticated-app"""
 
         from typing import Union
@@ -121,7 +137,10 @@ class AppsClient:
         code: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppManifestsCodeConversionsPostResponse201]:
+    ) -> Response[
+        AppManifestsCodeConversionsPostResponse201,
+        AppManifestsCodeConversionsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/apps#create-a-github-app-from-a-manifest"""
 
         from ..models import (
@@ -150,7 +169,10 @@ class AppsClient:
         code: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppManifestsCodeConversionsPostResponse201]:
+    ) -> Response[
+        AppManifestsCodeConversionsPostResponse201,
+        AppManifestsCodeConversionsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/apps#create-a-github-app-from-a-manifest"""
 
         from ..models import (
@@ -178,7 +200,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig
@@ -198,7 +220,7 @@ class AppsClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig
@@ -220,7 +242,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AppHookConfigPatchBodyType,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     def update_webhook_config_for_app(
@@ -232,7 +254,7 @@ class AppsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     def update_webhook_config_for_app(
         self,
@@ -240,7 +262,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/apps/webhooks#update-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig, AppHookConfigPatchBody
@@ -272,7 +294,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: AppHookConfigPatchBodyType,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     async def async_update_webhook_config_for_app(
@@ -284,7 +306,7 @@ class AppsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     async def async_update_webhook_config_for_app(
         self,
@@ -292,7 +314,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/apps/webhooks#update-a-webhook-configuration-for-an-app"""
 
         from ..models import WebhookConfig, AppHookConfigPatchBody
@@ -324,7 +346,7 @@ class AppsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -356,7 +378,7 @@ class AppsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -387,7 +409,7 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -412,7 +434,7 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -437,7 +459,10 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook"""
 
         from ..models import (
@@ -466,7 +491,10 @@ class AppsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/webhooks#redeliver-a-delivery-for-an-app-webhook"""
 
         from ..models import (
@@ -496,7 +524,9 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IntegrationInstallationRequest]]:
+    ) -> Response[
+        list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
+    ]:
         """See also: https://docs.github.com/rest/apps/apps#list-installation-requests-for-the-authenticated-app"""
 
         from ..models import BasicError, IntegrationInstallationRequest
@@ -527,7 +557,9 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IntegrationInstallationRequest]]:
+    ) -> Response[
+        list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
+    ]:
         """See also: https://docs.github.com/rest/apps/apps#list-installation-requests-for-the-authenticated-app"""
 
         from ..models import BasicError, IntegrationInstallationRequest
@@ -560,7 +592,7 @@ class AppsClient:
         outdated: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Installation]]:
+    ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/rest/apps/apps#list-installations-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -592,7 +624,7 @@ class AppsClient:
         outdated: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Installation]]:
+    ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/rest/apps/apps#list-installations-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -621,7 +653,7 @@ class AppsClient:
         installation_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -645,7 +677,7 @@ class AppsClient:
         installation_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -717,7 +749,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     @overload
     def create_installation_access_token(
@@ -729,7 +761,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     def create_installation_access_token(
         self,
@@ -738,7 +770,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[InstallationToken]:
+    ) -> Response[InstallationToken, InstallationTokenType]:
         """See also: https://docs.github.com/rest/apps/apps#create-an-installation-access-token-for-an-app"""
 
         from ..models import (
@@ -784,7 +816,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     @overload
     async def async_create_installation_access_token(
@@ -796,7 +828,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[InstallationToken]: ...
+    ) -> Response[InstallationToken, InstallationTokenType]: ...
 
     async def async_create_installation_access_token(
         self,
@@ -805,7 +837,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[InstallationToken]:
+    ) -> Response[InstallationToken, InstallationTokenType]:
         """See also: https://docs.github.com/rest/apps/apps#create-an-installation-access-token-for-an-app"""
 
         from ..models import (
@@ -1051,7 +1083,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     def check_token(
@@ -1061,7 +1093,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     def check_token(
         self,
@@ -1070,7 +1102,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/rest/apps/oauth-applications#check-a-token"""
 
         from ..models import (
@@ -1112,7 +1144,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     async def async_check_token(
@@ -1122,7 +1154,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     async def async_check_token(
         self,
@@ -1131,7 +1163,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/rest/apps/oauth-applications#check-a-token"""
 
         from ..models import (
@@ -1281,7 +1313,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     def reset_token(
@@ -1291,7 +1323,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     def reset_token(
         self,
@@ -1300,7 +1332,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/rest/apps/oauth-applications#reset-a-token"""
 
         from ..models import (
@@ -1340,7 +1372,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     async def async_reset_token(
@@ -1350,7 +1382,7 @@ class AppsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         access_token: str,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     async def async_reset_token(
         self,
@@ -1359,7 +1391,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/rest/apps/oauth-applications#reset-a-token"""
 
         from ..models import (
@@ -1399,7 +1431,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     def scope_token(
@@ -1414,7 +1446,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     def scope_token(
         self,
@@ -1423,7 +1455,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/rest/apps/apps#create-a-scoped-access-token"""
 
         from ..models import (
@@ -1467,7 +1499,7 @@ class AppsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     @overload
     async def async_scope_token(
@@ -1482,7 +1514,7 @@ class AppsClient:
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
-    ) -> Response[Authorization]: ...
+    ) -> Response[Authorization, AuthorizationType]: ...
 
     async def async_scope_token(
         self,
@@ -1491,7 +1523,7 @@ class AppsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Authorization]:
+    ) -> Response[Authorization, AuthorizationType]:
         """See also: https://docs.github.com/rest/apps/apps#create-a-scoped-access-token"""
 
         from ..models import (
@@ -1533,7 +1565,7 @@ class AppsClient:
         app_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-app"""
 
         from typing import Union
@@ -1560,7 +1592,7 @@ class AppsClient:
         app_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[Integration, None]]:
+    ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-app"""
 
         from typing import Union
@@ -1588,7 +1620,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[InstallationRepositoriesGetResponse200]:
+    ) -> Response[
+        InstallationRepositoriesGetResponse200,
+        InstallationRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-app-installation"""
 
         from ..models import BasicError, InstallationRepositoriesGetResponse200
@@ -1620,7 +1655,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[InstallationRepositoriesGetResponse200]:
+    ) -> Response[
+        InstallationRepositoriesGetResponse200,
+        InstallationRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-app-installation"""
 
         from ..models import BasicError, InstallationRepositoriesGetResponse200
@@ -1685,7 +1723,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1710,7 +1748,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1736,7 +1774,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1768,7 +1806,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1803,7 +1841,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan"""
 
         from ..models import BasicError, ValidationError, MarketplacePurchase
@@ -1841,7 +1879,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan"""
 
         from ..models import BasicError, ValidationError, MarketplacePurchase
@@ -1875,7 +1913,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1899,7 +1937,7 @@ class AppsClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[MarketplacePurchase]:
+    ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -1924,7 +1962,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans-stubbed"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1955,7 +1993,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplaceListingPlan]]:
+    ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans-stubbed"""
 
         from ..models import BasicError, MarketplaceListingPlan
@@ -1989,7 +2027,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -2025,7 +2063,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MarketplacePurchase]]:
+    ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
         from ..models import BasicError, MarketplacePurchase
@@ -2057,7 +2095,7 @@ class AppsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -2078,7 +2116,7 @@ class AppsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -2100,7 +2138,7 @@ class AppsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -2125,7 +2163,7 @@ class AppsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
         from ..models import BasicError, Installation
@@ -2150,7 +2188,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsGetResponse200]:
+    ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
         from ..models import BasicError, UserInstallationsGetResponse200
@@ -2182,7 +2220,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsGetResponse200]:
+    ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
         from ..models import BasicError, UserInstallationsGetResponse200
@@ -2215,7 +2253,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsInstallationIdRepositoriesGetResponse200]:
+    ) -> Response[
+        UserInstallationsInstallationIdRepositoriesGetResponse200,
+        UserInstallationsInstallationIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-user-access-token"""
 
         from ..models import (
@@ -2251,7 +2292,10 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserInstallationsInstallationIdRepositoriesGetResponse200]:
+    ) -> Response[
+        UserInstallationsInstallationIdRepositoriesGetResponse200,
+        UserInstallationsInstallationIdRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/apps/installations#list-repositories-accessible-to-the-user-access-token"""
 
         from ..models import (
@@ -2386,7 +2430,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2418,7 +2462,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2450,7 +2494,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2481,7 +2525,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserMarketplacePurchase]]:
+    ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
         from ..models import BasicError, UserMarketplacePurchase
@@ -2511,7 +2555,7 @@ class AppsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 
         from ..models import Installation
@@ -2532,7 +2576,7 @@ class AppsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Installation]:
+    ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 
         from ..models import Installation

--- a/githubkit/versions/v2022_11_28/rest/billing.py
+++ b/githubkit/versions/v2022_11_28/rest/billing.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import ActionsBillingUsage, CombinedBillingUsage, PackagesBillingUsage
+    from ..types import (
+        ActionsBillingUsageType,
+        CombinedBillingUsageType,
+        PackagesBillingUsageType,
+    )
 
 
 class BillingClient:
@@ -41,7 +46,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
         from ..models import ActionsBillingUsage
@@ -62,7 +67,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
         from ..models import ActionsBillingUsage
@@ -83,7 +88,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
         from ..models import PackagesBillingUsage
@@ -104,7 +109,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
         from ..models import PackagesBillingUsage
@@ -125,7 +130,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
         from ..models import CombinedBillingUsage
@@ -146,7 +151,7 @@ class BillingClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
         from ..models import CombinedBillingUsage
@@ -167,7 +172,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-a-user"""
 
         from ..models import ActionsBillingUsage
@@ -188,7 +193,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ActionsBillingUsage]:
+    ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-a-user"""
 
         from ..models import ActionsBillingUsage
@@ -209,7 +214,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-a-user"""
 
         from ..models import PackagesBillingUsage
@@ -230,7 +235,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackagesBillingUsage]:
+    ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-a-user"""
 
         from ..models import PackagesBillingUsage
@@ -251,7 +256,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-a-user"""
 
         from ..models import CombinedBillingUsage
@@ -272,7 +277,7 @@ class BillingClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedBillingUsage]:
+    ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-a-user"""
 
         from ..models import CombinedBillingUsage

--- a/githubkit/versions/v2022_11_28/rest/checks.py
+++ b/githubkit/versions/v2022_11_28/rest/checks.py
@@ -38,16 +38,24 @@ if TYPE_CHECKING:
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
     )
     from ..types import (
+        CheckRunType,
+        CheckSuiteType,
+        EmptyObjectType,
+        CheckAnnotationType,
+        CheckSuitePreferenceType,
         ReposOwnerRepoCheckSuitesPostBodyType,
         ReposOwnerRepoCheckRunsPostBodyOneof0Type,
         ReposOwnerRepoCheckRunsPostBodyOneof1Type,
         ReposOwnerRepoCheckRunsPostBodyPropOutputType,
         ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
         ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType,
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropOutputType,
         ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType,
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
         ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType,
     )
 
@@ -78,7 +86,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def create(
@@ -109,7 +117,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def create(
@@ -144,7 +152,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     def create(
         self,
@@ -159,7 +167,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#create-a-check-run"""
 
         from typing import Union
@@ -208,7 +216,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_create(
@@ -239,7 +247,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_create(
@@ -274,7 +282,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsPostBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     async def async_create(
         self,
@@ -289,7 +297,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#create-a-check-run"""
 
         from typing import Union
@@ -334,7 +342,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#get-a-check-run"""
 
         from ..models import CheckRun
@@ -357,7 +365,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#get-a-check-run"""
 
         from ..models import CheckRun
@@ -385,7 +393,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def update(
@@ -418,7 +426,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     def update(
@@ -453,7 +461,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     def update(
         self,
@@ -469,7 +477,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#update-a-check-run"""
 
         from typing import Union
@@ -519,7 +527,7 @@ class ChecksClient:
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
         ],
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_update(
@@ -552,7 +560,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     @overload
     async def async_update(
@@ -587,7 +595,7 @@ class ChecksClient:
         actions: Missing[
             list[ReposOwnerRepoCheckRunsCheckRunIdPatchBodyPropActionsItemsType]
         ] = UNSET,
-    ) -> Response[CheckRun]: ...
+    ) -> Response[CheckRun, CheckRunType]: ...
 
     async def async_update(
         self,
@@ -603,7 +611,7 @@ class ChecksClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CheckRun]:
+    ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#update-a-check-run"""
 
         from typing import Union
@@ -650,7 +658,7 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CheckAnnotation]]:
+    ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-run-annotations"""
 
         from ..models import CheckAnnotation
@@ -681,7 +689,7 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CheckAnnotation]]:
+    ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-run-annotations"""
 
         from ..models import CheckAnnotation
@@ -710,7 +718,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/runs#rerequest-a-check-run"""
 
         from ..models import BasicError, EmptyObject
@@ -738,7 +746,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/runs#rerequest-a-check-run"""
 
         from ..models import BasicError, EmptyObject
@@ -767,7 +775,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     @overload
     def create_suite(
@@ -778,7 +786,7 @@ class ChecksClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         head_sha: str,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     def create_suite(
         self,
@@ -788,7 +796,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/rest/checks/suites#create-a-check-suite"""
 
         from ..models import CheckSuite, ReposOwnerRepoCheckSuitesPostBody
@@ -822,7 +830,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     @overload
     async def async_create_suite(
@@ -833,7 +841,7 @@ class ChecksClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         head_sha: str,
-    ) -> Response[CheckSuite]: ...
+    ) -> Response[CheckSuite, CheckSuiteType]: ...
 
     async def async_create_suite(
         self,
@@ -843,7 +851,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/rest/checks/suites#create-a-check-suite"""
 
         from ..models import CheckSuite, ReposOwnerRepoCheckSuitesPostBody
@@ -877,7 +885,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     @overload
     def set_suites_preferences(
@@ -892,7 +900,7 @@ class ChecksClient:
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     def set_suites_preferences(
         self,
@@ -902,7 +910,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuitePreference]:
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
         """See also: https://docs.github.com/rest/checks/suites#update-repository-preferences-for-check-suites"""
 
         from ..models import (
@@ -941,7 +949,7 @@ class ChecksClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     @overload
     async def async_set_suites_preferences(
@@ -956,7 +964,7 @@ class ChecksClient:
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[CheckSuitePreference]: ...
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
     async def async_set_suites_preferences(
         self,
@@ -966,7 +974,7 @@ class ChecksClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CheckSuitePreference]:
+    ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
         """See also: https://docs.github.com/rest/checks/suites#update-repository-preferences-for-check-suites"""
 
         from ..models import (
@@ -1004,7 +1012,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/rest/checks/suites#get-a-check-suite"""
 
         from ..models import CheckSuite
@@ -1027,7 +1035,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckSuite]:
+    ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/rest/checks/suites#get-a-check-suite"""
 
         from ..models import CheckSuite
@@ -1055,7 +1063,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-runs-in-a-check-suite"""
 
         from ..models import (
@@ -1094,7 +1105,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
+        ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-runs-in-a-check-suite"""
 
         from ..models import (
@@ -1128,7 +1142,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/suites#rerequest-a-check-suite"""
 
         from ..models import EmptyObject
@@ -1151,7 +1165,7 @@ class ChecksClient:
         check_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/suites#rerequest-a-check-suite"""
 
         from ..models import EmptyObject
@@ -1180,7 +1194,10 @@ class ChecksClient:
         app_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-runs-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckRunsGetResponse200
@@ -1219,7 +1236,10 @@ class ChecksClient:
         app_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckRunsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
+        ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-runs-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckRunsGetResponse200
@@ -1256,7 +1276,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckSuitesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/checks/suites#list-check-suites-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckSuitesGetResponse200
@@ -1291,7 +1314,10 @@ class ChecksClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCommitsRefCheckSuitesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
+        ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/checks/suites#list-check-suites-for-a-git-reference"""
 
         from ..models import ReposOwnerRepoCommitsRefCheckSuitesGetResponse200

--- a/githubkit/versions/v2022_11_28/rest/classroom.py
+++ b/githubkit/versions/v2022_11_28/rest/classroom.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
         SimpleClassroomAssignment,
         ClassroomAcceptedAssignment,
     )
+    from ..types import (
+        ClassroomType,
+        SimpleClassroomType,
+        ClassroomAssignmentType,
+        ClassroomAssignmentGradeType,
+        SimpleClassroomAssignmentType,
+        ClassroomAcceptedAssignmentType,
+    )
 
 
 class ClassroomClient:
@@ -51,7 +59,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ClassroomAssignment]:
+    ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-an-assignment"""
 
         from ..models import BasicError, ClassroomAssignment
@@ -75,7 +83,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ClassroomAssignment]:
+    ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-an-assignment"""
 
         from ..models import BasicError, ClassroomAssignment
@@ -101,7 +109,9 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAcceptedAssignment]]:
+    ) -> Response[
+        list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
+    ]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-accepted-assignments-for-an-assignment"""
 
         from ..models import ClassroomAcceptedAssignment
@@ -130,7 +140,9 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAcceptedAssignment]]:
+    ) -> Response[
+        list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
+    ]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-accepted-assignments-for-an-assignment"""
 
         from ..models import ClassroomAcceptedAssignment
@@ -157,7 +169,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAssignmentGrade]]:
+    ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-assignment-grades"""
 
         from ..models import BasicError, ClassroomAssignmentGrade
@@ -181,7 +193,7 @@ class ClassroomClient:
         assignment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ClassroomAssignmentGrade]]:
+    ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-assignment-grades"""
 
         from ..models import BasicError, ClassroomAssignmentGrade
@@ -206,7 +218,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroom]]:
+    ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-classrooms"""
 
         from ..models import SimpleClassroom
@@ -234,7 +246,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroom]]:
+    ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-classrooms"""
 
         from ..models import SimpleClassroom
@@ -261,7 +273,7 @@ class ClassroomClient:
         classroom_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Classroom]:
+    ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-a-classroom"""
 
         from ..models import Classroom, BasicError
@@ -285,7 +297,7 @@ class ClassroomClient:
         classroom_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Classroom]:
+    ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-a-classroom"""
 
         from ..models import Classroom, BasicError
@@ -311,7 +323,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroomAssignment]]:
+    ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-assignments-for-a-classroom"""
 
         from ..models import SimpleClassroomAssignment
@@ -340,7 +352,7 @@ class ClassroomClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleClassroomAssignment]]:
+    ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-assignments-for-a-classroom"""
 
         from ..models import SimpleClassroomAssignment

--- a/githubkit/versions/v2022_11_28/rest/code_scanning.py
+++ b/githubkit/versions/v2022_11_28/rest/code_scanning.py
@@ -27,14 +27,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        CodeScanningDefaultSetupUpdateType,
-        ReposOwnerRepoCodeScanningSarifsPostBodyType,
-        ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
-        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
-        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
-        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
-    )
     from ..models import (
         EmptyObject,
         CodeScanningAlert,
@@ -49,6 +41,27 @@ if TYPE_CHECKING:
         CodeScanningAnalysisDeletion,
         CodeScanningOrganizationAlertItems,
         CodeScanningVariantAnalysisRepoTask,
+    )
+    from ..types import (
+        EmptyObjectType,
+        CodeScanningAlertType,
+        CodeScanningAnalysisType,
+        CodeScanningAlertItemsType,
+        CodeScanningDefaultSetupType,
+        CodeScanningSarifsStatusType,
+        CodeScanningAlertInstanceType,
+        CodeScanningSarifsReceiptType,
+        CodeScanningCodeqlDatabaseType,
+        CodeScanningVariantAnalysisType,
+        CodeScanningAnalysisDeletionType,
+        CodeScanningDefaultSetupUpdateType,
+        CodeScanningOrganizationAlertItemsType,
+        CodeScanningVariantAnalysisRepoTaskType,
+        ReposOwnerRepoCodeScanningSarifsPostBodyType,
+        ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
+        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
+        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
+        ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
     )
 
 
@@ -84,7 +97,10 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningOrganizationAlertItems]]:
+    ) -> Response[
+        list[CodeScanningOrganizationAlertItems],
+        list[CodeScanningOrganizationAlertItemsType],
+    ]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -139,7 +155,10 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningOrganizationAlertItems]]:
+    ) -> Response[
+        list[CodeScanningOrganizationAlertItems],
+        list[CodeScanningOrganizationAlertItemsType],
+    ]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -197,7 +216,7 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertItems]]:
+    ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -258,7 +277,7 @@ class CodeScanningClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertItems]]:
+    ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -306,7 +325,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
         from ..models import (
@@ -338,7 +357,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
         from ..models import (
@@ -372,7 +391,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     @overload
     def update_alert(
@@ -388,7 +407,7 @@ class CodeScanningClient:
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
         ] = UNSET,
         dismissed_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     def update_alert(
         self,
@@ -399,7 +418,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#update-a-code-scanning-alert"""
 
         from ..models import (
@@ -446,7 +465,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     @overload
     async def async_update_alert(
@@ -462,7 +481,7 @@ class CodeScanningClient:
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
         ] = UNSET,
         dismissed_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[CodeScanningAlert]: ...
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
     async def async_update_alert(
         self,
@@ -473,7 +492,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningAlert]:
+    ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#update-a-code-scanning-alert"""
 
         from ..models import (
@@ -522,7 +541,7 @@ class CodeScanningClient:
         pr: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertInstance]]:
+    ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
         from ..models import (
@@ -566,7 +585,7 @@ class CodeScanningClient:
         pr: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAlertInstance]]:
+    ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
         from ..models import (
@@ -614,7 +633,7 @@ class CodeScanningClient:
         sort: Missing[Literal["created"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAnalysis]]:
+    ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
         from ..models import (
@@ -667,7 +686,7 @@ class CodeScanningClient:
         sort: Missing[Literal["created"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningAnalysis]]:
+    ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
         from ..models import (
@@ -712,7 +731,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysis]:
+    ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
         from ..models import (
@@ -744,7 +763,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysis]:
+    ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
         from ..models import (
@@ -777,7 +796,7 @@ class CodeScanningClient:
         confirm_delete: Missing[Union[str, None]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysisDeletion]:
+    ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
         from ..models import (
@@ -816,7 +835,7 @@ class CodeScanningClient:
         confirm_delete: Missing[Union[str, None]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningAnalysisDeletion]:
+    ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
         from ..models import (
@@ -853,7 +872,9 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningCodeqlDatabase]]:
+    ) -> Response[
+        list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
+    ]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-codeql-databases-for-a-repository"""
 
         from ..models import (
@@ -884,7 +905,9 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeScanningCodeqlDatabase]]:
+    ) -> Response[
+        list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
+    ]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-codeql-databases-for-a-repository"""
 
         from ..models import (
@@ -916,7 +939,7 @@ class CodeScanningClient:
         language: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningCodeqlDatabase]:
+    ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
         from ..models import (
@@ -948,7 +971,7 @@ class CodeScanningClient:
         language: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningCodeqlDatabase]:
+    ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
         from ..models import (
@@ -1045,7 +1068,7 @@ class CodeScanningClient:
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
         ],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     def create_variant_analysis(
@@ -1062,7 +1085,7 @@ class CodeScanningClient:
         repositories: list[str],
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     def create_variant_analysis(
@@ -1079,7 +1102,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: list[str],
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     def create_variant_analysis(
@@ -1096,7 +1119,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: list[str],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     def create_variant_analysis(
         self,
@@ -1112,7 +1135,7 @@ class CodeScanningClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#create-a-codeql-variant-analysis"""
 
         from typing import Union
@@ -1171,7 +1194,7 @@ class CodeScanningClient:
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof2Type,
         ],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     async def async_create_variant_analysis(
@@ -1188,7 +1211,7 @@ class CodeScanningClient:
         repositories: list[str],
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     async def async_create_variant_analysis(
@@ -1205,7 +1228,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: list[str],
         repository_owners: Missing[list[str]] = UNSET,
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     @overload
     async def async_create_variant_analysis(
@@ -1222,7 +1245,7 @@ class CodeScanningClient:
         repositories: Missing[list[str]] = UNSET,
         repository_lists: Missing[list[str]] = UNSET,
         repository_owners: list[str],
-    ) -> Response[CodeScanningVariantAnalysis]: ...
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]: ...
 
     async def async_create_variant_analysis(
         self,
@@ -1238,7 +1261,7 @@ class CodeScanningClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#create-a-codeql-variant-analysis"""
 
         from typing import Union
@@ -1292,7 +1315,7 @@ class CodeScanningClient:
         codeql_variant_analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1323,7 +1346,7 @@ class CodeScanningClient:
         codeql_variant_analysis_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysis]:
+    ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1356,7 +1379,9 @@ class CodeScanningClient:
         repo_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysisRepoTask]:
+    ) -> Response[
+        CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
+    ]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-analysis-status-of-a-repository-in-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1389,7 +1414,9 @@ class CodeScanningClient:
         repo_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningVariantAnalysisRepoTask]:
+    ) -> Response[
+        CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
+    ]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-analysis-status-of-a-repository-in-a-codeql-variant-analysis"""
 
         from ..models import (
@@ -1419,7 +1446,7 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningDefaultSetup]:
+    ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1450,7 +1477,7 @@ class CodeScanningClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningDefaultSetup]:
+    ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1483,7 +1510,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def update_default_setup(
@@ -1509,7 +1536,7 @@ class CodeScanningClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def update_default_setup(
         self,
@@ -1519,7 +1546,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1564,7 +1591,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_update_default_setup(
@@ -1590,7 +1617,7 @@ class CodeScanningClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_update_default_setup(
         self,
@@ -1600,7 +1627,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration"""
 
         from ..models import (
@@ -1645,7 +1672,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     @overload
     def upload_sarif(
@@ -1662,7 +1689,7 @@ class CodeScanningClient:
         started_at: Missing[datetime] = UNSET,
         tool_name: Missing[str] = UNSET,
         validate_: Missing[bool] = UNSET,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     def upload_sarif(
         self,
@@ -1672,7 +1699,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningSarifsReceipt]:
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data"""
 
         from ..models import (
@@ -1716,7 +1743,7 @@ class CodeScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     @overload
     async def async_upload_sarif(
@@ -1733,7 +1760,7 @@ class CodeScanningClient:
         started_at: Missing[datetime] = UNSET,
         tool_name: Missing[str] = UNSET,
         validate_: Missing[bool] = UNSET,
-    ) -> Response[CodeScanningSarifsReceipt]: ...
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
     async def async_upload_sarif(
         self,
@@ -1743,7 +1770,7 @@ class CodeScanningClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeScanningSarifsReceipt]:
+    ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data"""
 
         from ..models import (
@@ -1786,7 +1813,7 @@ class CodeScanningClient:
         sarif_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningSarifsStatus]:
+    ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 
         from ..models import (
@@ -1817,7 +1844,7 @@ class CodeScanningClient:
         sarif_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeScanningSarifsStatus]:
+    ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 
         from ..models import (

--- a/githubkit/versions/v2022_11_28/rest/code_security.py
+++ b/githubkit/versions/v2022_11_28/rest/code_security.py
@@ -35,11 +35,17 @@ if TYPE_CHECKING:
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
     )
     from ..types import (
+        CodeSecurityConfigurationType,
+        CodeSecurityConfigurationRepositoriesType,
+        CodeSecurityConfigurationForRepositoryType,
+        CodeSecurityDefaultConfigurationsItemsType,
         OrgsOrgCodeSecurityConfigurationsPostBodyType,
         OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
         OrgsOrgCodeSecurityConfigurationsPostBodyPropSecretScanningDelegatedBypassOptionsType,
         OrgsOrgCodeSecurityConfigurationsPostBodyPropDependencyGraphAutosubmitActionOptionsType,
         OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyPropSecretScanningDelegatedBypassOptionsType,
@@ -71,7 +77,7 @@ class CodeSecurityClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfiguration]]:
+    ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -108,7 +114,7 @@ class CodeSecurityClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfiguration]]:
+    ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -143,7 +149,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     def create_configuration(
@@ -189,7 +195,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     def create_configuration(
         self,
@@ -198,7 +204,7 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#create-a-code-security-configuration"""
 
         from ..models import (
@@ -234,7 +240,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     async def async_create_configuration(
@@ -280,7 +286,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     async def async_create_configuration(
         self,
@@ -289,7 +295,7 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#create-a-code-security-configuration"""
 
         from ..models import (
@@ -323,7 +329,10 @@ class CodeSecurityClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityDefaultConfigurationsItems]]:
+    ) -> Response[
+        list[CodeSecurityDefaultConfigurationsItems],
+        list[CodeSecurityDefaultConfigurationsItemsType],
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-default-code-security-configurations"""
 
         from ..models import BasicError, CodeSecurityDefaultConfigurationsItems
@@ -348,7 +357,10 @@ class CodeSecurityClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityDefaultConfigurationsItems]]:
+    ) -> Response[
+        list[CodeSecurityDefaultConfigurationsItems],
+        list[CodeSecurityDefaultConfigurationsItemsType],
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-default-code-security-configurations"""
 
         from ..models import BasicError, CodeSecurityDefaultConfigurationsItems
@@ -498,7 +510,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -524,7 +536,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfiguration
@@ -606,7 +618,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     def update_configuration(
@@ -653,7 +665,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     def update_configuration(
         self,
@@ -665,7 +677,7 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#update-a-code-security-configuration"""
 
         from ..models import (
@@ -704,7 +716,7 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     @overload
     async def async_update_configuration(
@@ -751,7 +763,7 @@ class CodeSecurityClient:
             Literal["enabled", "disabled", "not_set"]
         ] = UNSET,
         enforcement: Missing[Literal["enforced", "unenforced"]] = UNSET,
-    ) -> Response[CodeSecurityConfiguration]: ...
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
     async def async_update_configuration(
         self,
@@ -763,7 +775,7 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[CodeSecurityConfiguration]:
+    ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#update-a-code-security-configuration"""
 
         from ..models import (
@@ -802,7 +814,10 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     def attach_configuration(
@@ -820,7 +835,10 @@ class CodeSecurityClient:
             "selected",
         ],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     def attach_configuration(
         self,
@@ -832,7 +850,10 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#attach-a-configuration-to-repositories"""
 
         from ..models import (
@@ -871,7 +892,10 @@ class CodeSecurityClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     async def async_attach_configuration(
@@ -889,7 +913,10 @@ class CodeSecurityClient:
             "selected",
         ],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     async def async_attach_configuration(
         self,
@@ -901,7 +928,10 @@ class CodeSecurityClient:
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#attach-a-configuration-to-repositories"""
 
         from ..models import (
@@ -941,7 +971,8 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     @overload
@@ -956,7 +987,8 @@ class CodeSecurityClient:
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     def set_configuration_as_default(
@@ -970,7 +1002,8 @@ class CodeSecurityClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/code-security/configurations#set-a-code-security-configuration-as-a-default-for-an-organization"""
 
@@ -1016,7 +1049,8 @@ class CodeSecurityClient:
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     @overload
@@ -1031,7 +1065,8 @@ class CodeSecurityClient:
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]: ...
 
     async def async_set_configuration_as_default(
@@ -1045,7 +1080,8 @@ class CodeSecurityClient:
         ] = UNSET,
         **kwargs,
     ) -> Response[
-        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
+        OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/code-security/configurations#set-a-code-security-configuration-as-a-default-for-an-organization"""
 
@@ -1092,7 +1128,10 @@ class CodeSecurityClient:
         status: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfigurationRepositories]]:
+    ) -> Response[
+        list[CodeSecurityConfigurationRepositories],
+        list[CodeSecurityConfigurationRepositoriesType],
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-repositories-associated-with-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfigurationRepositories
@@ -1132,7 +1171,10 @@ class CodeSecurityClient:
         status: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeSecurityConfigurationRepositories]]:
+    ) -> Response[
+        list[CodeSecurityConfigurationRepositories],
+        list[CodeSecurityConfigurationRepositoriesType],
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-repositories-associated-with-a-code-security-configuration"""
 
         from ..models import BasicError, CodeSecurityConfigurationRepositories
@@ -1168,7 +1210,10 @@ class CodeSecurityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfigurationForRepository]:
+    ) -> Response[
+        CodeSecurityConfigurationForRepository,
+        CodeSecurityConfigurationForRepositoryType,
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-the-code-security-configuration-associated-with-a-repository"""
 
         from ..models import BasicError, CodeSecurityConfigurationForRepository
@@ -1194,7 +1239,10 @@ class CodeSecurityClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeSecurityConfigurationForRepository]:
+    ) -> Response[
+        CodeSecurityConfigurationForRepository,
+        CodeSecurityConfigurationForRepositoryType,
+    ]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-the-code-security-configuration-associated-with-a-repository"""
 
         from ..models import BasicError, CodeSecurityConfigurationForRepository

--- a/githubkit/versions/v2022_11_28/rest/codes_of_conduct.py
+++ b/githubkit/versions/v2022_11_28/rest/codes_of_conduct.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import CodeOfConduct
+    from ..types import CodeOfConductType
 
 
 class CodesOfConductClient:
@@ -40,7 +41,7 @@ class CodesOfConductClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeOfConduct]]:
+    ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
         from ..models import CodeOfConduct
@@ -60,7 +61,7 @@ class CodesOfConductClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CodeOfConduct]]:
+    ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
         from ..models import CodeOfConduct
@@ -81,7 +82,7 @@ class CodesOfConductClient:
         key: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeOfConduct]:
+    ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 
         from ..models import BasicError, CodeOfConduct
@@ -105,7 +106,7 @@ class CodesOfConductClient:
         key: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeOfConduct]:
+    ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 
         from ..models import BasicError, CodeOfConduct

--- a/githubkit/versions/v2022_11_28/rest/codespaces.py
+++ b/githubkit/versions/v2022_11_28/rest/codespaces.py
@@ -26,23 +26,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        UserCodespacesPostBodyOneof0Type,
-        UserCodespacesPostBodyOneof1Type,
-        OrgsOrgCodespacesAccessPutBodyType,
-        ReposOwnerRepoCodespacesPostBodyType,
-        UserCodespacesCodespaceNamePatchBodyType,
-        UserCodespacesSecretsSecretNamePutBodyType,
-        OrgsOrgCodespacesSecretsSecretNamePutBodyType,
-        UserCodespacesCodespaceNamePublishPostBodyType,
-        UserCodespacesPostBodyOneof1PropPullRequestType,
-        OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
-        OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
-        ReposOwnerRepoPullsPullNumberCodespacesPostBodyType,
-        ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
-        UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
-        OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
-    )
     from ..models import (
         Codespace,
         EmptyObject,
@@ -69,6 +52,47 @@ if TYPE_CHECKING:
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
     )
+    from ..types import (
+        CodespaceType,
+        EmptyObjectType,
+        CodespacesSecretType,
+        CodespacesOrgSecretType,
+        CodespacesPublicKeyType,
+        RepoCodespacesSecretType,
+        CodespaceExportDetailsType,
+        CodespacesUserPublicKeyType,
+        CodespaceWithFullRepositoryType,
+        UserCodespacesGetResponse200Type,
+        UserCodespacesPostBodyOneof0Type,
+        UserCodespacesPostBodyOneof1Type,
+        OrgsOrgCodespacesAccessPutBodyType,
+        OrgsOrgCodespacesGetResponse200Type,
+        ReposOwnerRepoCodespacesPostBodyType,
+        UserCodespacesSecretsGetResponse200Type,
+        UserCodespacesCodespaceNamePatchBodyType,
+        OrgsOrgCodespacesSecretsGetResponse200Type,
+        ReposOwnerRepoCodespacesGetResponse200Type,
+        UserCodespacesSecretsSecretNamePutBodyType,
+        CodespacesPermissionsCheckForDevcontainerType,
+        OrgsOrgCodespacesSecretsSecretNamePutBodyType,
+        ReposOwnerRepoCodespacesNewGetResponse200Type,
+        UserCodespacesCodespaceNamePublishPostBodyType,
+        UserCodespacesPostBodyOneof1PropPullRequestType,
+        OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
+        ReposOwnerRepoCodespacesSecretsGetResponse200Type,
+        OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
+        OrgsOrgMembersUsernameCodespacesGetResponse200Type,
+        ReposOwnerRepoCodespacesMachinesGetResponse200Type,
+        ReposOwnerRepoPullsPullNumberCodespacesPostBodyType,
+        ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
+        UserCodespacesCodespaceNameMachinesGetResponse200Type,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+        UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    )
 
 
 class CodespacesClient:
@@ -93,7 +117,7 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesGetResponse200]:
+    ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
         from ..models import BasicError, OrgsOrgCodespacesGetResponse200
@@ -128,7 +152,7 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesGetResponse200]:
+    ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
         from ..models import BasicError, OrgsOrgCodespacesGetResponse200
@@ -535,7 +559,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsGetResponse200,
+        OrgsOrgCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgCodespacesSecretsGetResponse200
@@ -564,7 +591,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsGetResponse200,
+        OrgsOrgCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgCodespacesSecretsGetResponse200
@@ -591,7 +621,7 @@ class CodespacesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -612,7 +642,7 @@ class CodespacesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -634,7 +664,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesOrgSecret]:
+    ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-secret"""
 
         from ..models import CodespacesOrgSecret
@@ -656,7 +686,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesOrgSecret]:
+    ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-secret"""
 
         from ..models import CodespacesOrgSecret
@@ -680,7 +710,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_org_secret(
@@ -694,7 +724,7 @@ class CodespacesClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_org_secret(
         self,
@@ -704,7 +734,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#create-or-update-an-organization-secret"""
 
         from ..models import (
@@ -747,7 +777,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_org_secret(
@@ -761,7 +791,7 @@ class CodespacesClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[int]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_org_secret(
         self,
@@ -771,7 +801,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#create-or-update-an-organization-secret"""
 
         from ..models import (
@@ -862,7 +892,10 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -898,7 +931,10 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -1174,7 +1210,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgMembersUsernameCodespacesGetResponse200]:
+    ) -> Response[
+        OrgsOrgMembersUsernameCodespacesGetResponse200,
+        OrgsOrgMembersUsernameCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-a-user-in-organization"""
 
         from ..models import BasicError, OrgsOrgMembersUsernameCodespacesGetResponse200
@@ -1210,7 +1249,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgMembersUsernameCodespacesGetResponse200]:
+    ) -> Response[
+        OrgsOrgMembersUsernameCodespacesGetResponse200,
+        OrgsOrgMembersUsernameCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-a-user-in-organization"""
 
         from ..models import BasicError, OrgsOrgMembersUsernameCodespacesGetResponse200
@@ -1245,7 +1287,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organizations#delete-a-codespace-from-the-organization"""
 
         from ..models import (
@@ -1277,7 +1322,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/organizations#delete-a-codespace-from-the-organization"""
 
         from ..models import (
@@ -1309,7 +1357,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
         from ..models import Codespace, BasicError
@@ -1338,7 +1386,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
         from ..models import Codespace, BasicError
@@ -1368,7 +1416,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesGetResponse200,
+        ReposOwnerRepoCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-in-a-repository-for-the-authenticated-user"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesGetResponse200
@@ -1404,7 +1455,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesGetResponse200,
+        ReposOwnerRepoCodespacesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-in-a-repository-for-the-authenticated-user"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesGetResponse200
@@ -1440,7 +1494,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_with_repo_for_authenticated_user(
@@ -1463,7 +1517,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def create_with_repo_for_authenticated_user(
         self,
@@ -1473,7 +1527,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-in-a-repository"""
 
         from typing import Union
@@ -1523,7 +1577,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_with_repo_for_authenticated_user(
@@ -1546,7 +1600,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_create_with_repo_for_authenticated_user(
         self,
@@ -1556,7 +1610,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-in-a-repository"""
 
         from typing import Union
@@ -1606,7 +1660,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesDevcontainersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200,
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-devcontainer-configurations-in-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -1646,7 +1703,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesDevcontainersGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200,
+        ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-devcontainer-configurations-in-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -1687,7 +1747,10 @@ class CodespacesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesMachinesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesMachinesGetResponse200,
+        ReposOwnerRepoCodespacesMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/machines#list-available-machine-types-for-a-repository"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesMachinesGetResponse200
@@ -1725,7 +1788,10 @@ class CodespacesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesMachinesGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesMachinesGetResponse200,
+        ReposOwnerRepoCodespacesMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/machines#list-available-machine-types-for-a-repository"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesMachinesGetResponse200
@@ -1762,7 +1828,10 @@ class CodespacesClient:
         client_ip: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesNewGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesNewGetResponse200,
+        ReposOwnerRepoCodespacesNewGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-default-attributes-for-a-codespace"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesNewGetResponse200
@@ -1797,7 +1866,10 @@ class CodespacesClient:
         client_ip: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesNewGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesNewGetResponse200,
+        ReposOwnerRepoCodespacesNewGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-default-attributes-for-a-codespace"""
 
         from ..models import BasicError, ReposOwnerRepoCodespacesNewGetResponse200
@@ -1832,7 +1904,10 @@ class CodespacesClient:
         devcontainer_path: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPermissionsCheckForDevcontainer]:
+    ) -> Response[
+        CodespacesPermissionsCheckForDevcontainer,
+        CodespacesPermissionsCheckForDevcontainerType,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#check-if-permissions-defined-by-a-devcontainer-have-been-accepted-by-the-authenticated-user"""
 
         from ..models import (
@@ -1874,7 +1949,10 @@ class CodespacesClient:
         devcontainer_path: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPermissionsCheckForDevcontainer]:
+    ) -> Response[
+        CodespacesPermissionsCheckForDevcontainer,
+        CodespacesPermissionsCheckForDevcontainerType,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#check-if-permissions-defined-by-a-devcontainer-have-been-accepted-by-the-authenticated-user"""
 
         from ..models import (
@@ -1916,7 +1994,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesSecretsGetResponse200,
+        ReposOwnerRepoCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoCodespacesSecretsGetResponse200
@@ -1946,7 +2027,10 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoCodespacesSecretsGetResponse200,
+        ReposOwnerRepoCodespacesSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoCodespacesSecretsGetResponse200
@@ -1974,7 +2058,7 @@ class CodespacesClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -1996,7 +2080,7 @@ class CodespacesClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesPublicKey]:
+    ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
         from ..models import CodespacesPublicKey
@@ -2019,7 +2103,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepoCodespacesSecret]:
+    ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-secret"""
 
         from ..models import RepoCodespacesSecret
@@ -2042,7 +2126,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepoCodespacesSecret]:
+    ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-secret"""
 
         from ..models import RepoCodespacesSecret
@@ -2067,7 +2151,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_repo_secret(
@@ -2080,7 +2164,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_repo_secret(
         self,
@@ -2091,7 +2175,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#create-or-update-a-repository-secret"""
 
         from ..models import (
@@ -2131,7 +2215,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_repo_secret(
@@ -2144,7 +2228,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_repo_secret(
         self,
@@ -2155,7 +2239,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#create-or-update-a-repository-secret"""
 
         from ..models import (
@@ -2235,7 +2319,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_with_pr_for_authenticated_user(
@@ -2258,7 +2342,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def create_with_pr_for_authenticated_user(
         self,
@@ -2271,7 +2355,7 @@ class CodespacesClient:
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-from-a-pull-request"""
 
         from typing import Union
@@ -2321,7 +2405,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_with_pr_for_authenticated_user(
@@ -2344,7 +2428,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_create_with_pr_for_authenticated_user(
         self,
@@ -2357,7 +2441,7 @@ class CodespacesClient:
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-from-a-pull-request"""
 
         from typing import Union
@@ -2405,7 +2489,7 @@ class CodespacesClient:
         repository_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesGetResponse200]:
+    ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
         from ..models import BasicError, UserCodespacesGetResponse200
@@ -2441,7 +2525,7 @@ class CodespacesClient:
         repository_id: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesGetResponse200]:
+    ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
         from ..models import BasicError, UserCodespacesGetResponse200
@@ -2476,7 +2560,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -2498,7 +2582,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -2515,7 +2599,7 @@ class CodespacesClient:
         devcontainer_path: Missing[str] = UNSET,
         working_directory: Missing[str] = UNSET,
         idle_timeout_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def create_for_authenticated_user(
         self,
@@ -2525,7 +2609,7 @@ class CodespacesClient:
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-for-the-authenticated-user"""
 
         from typing import Union
@@ -2573,7 +2657,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -2595,7 +2679,7 @@ class CodespacesClient:
         idle_timeout_minutes: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
         retention_period_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -2612,7 +2696,7 @@ class CodespacesClient:
         devcontainer_path: Missing[str] = UNSET,
         working_directory: Missing[str] = UNSET,
         idle_timeout_minutes: Missing[int] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_create_for_authenticated_user(
         self,
@@ -2622,7 +2706,7 @@ class CodespacesClient:
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-codespace-for-the-authenticated-user"""
 
         from typing import Union
@@ -2670,7 +2754,9 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/codespaces/secrets#list-secrets-for-the-authenticated-user"""
 
         from ..models import UserCodespacesSecretsGetResponse200
@@ -2698,7 +2784,9 @@ class CodespacesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/codespaces/secrets#list-secrets-for-the-authenticated-user"""
 
         from ..models import UserCodespacesSecretsGetResponse200
@@ -2724,7 +2812,7 @@ class CodespacesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesUserPublicKey]:
+    ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
         from ..models import CodespacesUserPublicKey
@@ -2744,7 +2832,7 @@ class CodespacesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesUserPublicKey]:
+    ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
         from ..models import CodespacesUserPublicKey
@@ -2765,7 +2853,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesSecret]:
+    ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
         from ..models import CodespacesSecret
@@ -2786,7 +2874,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespacesSecret]:
+    ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
         from ..models import CodespacesSecret
@@ -2809,7 +2897,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_secret_for_authenticated_user(
@@ -2821,7 +2909,7 @@ class CodespacesClient:
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_secret_for_authenticated_user(
         self,
@@ -2830,7 +2918,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#create-or-update-a-secret-for-the-authenticated-user"""
 
         from ..models import (
@@ -2872,7 +2960,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_secret_for_authenticated_user(
@@ -2884,7 +2972,7 @@ class CodespacesClient:
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_secret_for_authenticated_user(
         self,
@@ -2893,7 +2981,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#create-or-update-a-secret-for-the-authenticated-user"""
 
         from ..models import (
@@ -2969,7 +3057,10 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/secrets#list-selected-repositories-for-a-user-secret"""
 
         from ..models import (
@@ -2999,7 +3090,10 @@ class CodespacesClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
+        UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/secrets#list-selected-repositories-for-a-user-secret"""
 
         from ..models import (
@@ -3261,7 +3355,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3288,7 +3382,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3315,7 +3409,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#delete-a-codespace-for-the-authenticated-user"""
 
         from ..models import (
@@ -3345,7 +3442,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#delete-a-codespace-for-the-authenticated-user"""
 
         from ..models import (
@@ -3377,7 +3477,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     def update_for_authenticated_user(
@@ -3389,7 +3489,7 @@ class CodespacesClient:
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     def update_for_authenticated_user(
         self,
@@ -3398,7 +3498,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#update-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError, UserCodespacesCodespaceNamePatchBody
@@ -3436,7 +3536,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     @overload
     async def async_update_for_authenticated_user(
@@ -3448,7 +3548,7 @@ class CodespacesClient:
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
-    ) -> Response[Codespace]: ...
+    ) -> Response[Codespace, CodespaceType]: ...
 
     async def async_update_for_authenticated_user(
         self,
@@ -3457,7 +3557,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#update-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError, UserCodespacesCodespaceNamePatchBody
@@ -3493,7 +3593,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
         from ..models import BasicError, ValidationError, CodespaceExportDetails
@@ -3521,7 +3621,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
         from ..models import BasicError, ValidationError, CodespaceExportDetails
@@ -3550,7 +3650,7 @@ class CodespacesClient:
         export_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
         from ..models import BasicError, CodespaceExportDetails
@@ -3575,7 +3675,7 @@ class CodespacesClient:
         export_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodespaceExportDetails]:
+    ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
         from ..models import BasicError, CodespaceExportDetails
@@ -3599,7 +3699,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesCodespaceNameMachinesGetResponse200]:
+    ) -> Response[
+        UserCodespacesCodespaceNameMachinesGetResponse200,
+        UserCodespacesCodespaceNameMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/machines#list-machine-types-for-a-codespace"""
 
         from ..models import (
@@ -3629,7 +3732,10 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UserCodespacesCodespaceNameMachinesGetResponse200]:
+    ) -> Response[
+        UserCodespacesCodespaceNameMachinesGetResponse200,
+        UserCodespacesCodespaceNameMachinesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/codespaces/machines#list-machine-types-for-a-codespace"""
 
         from ..models import (
@@ -3661,7 +3767,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     @overload
     def publish_for_authenticated_user(
@@ -3672,7 +3778,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     def publish_for_authenticated_user(
         self,
@@ -3681,7 +3787,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodespaceWithFullRepository]:
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-repository-from-an-unpublished-codespace"""
 
         from ..models import (
@@ -3727,7 +3833,7 @@ class CodespacesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     @overload
     async def async_publish_for_authenticated_user(
@@ -3738,7 +3844,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[CodespaceWithFullRepository]: ...
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
     async def async_publish_for_authenticated_user(
         self,
@@ -3747,7 +3853,7 @@ class CodespacesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CodespaceWithFullRepository]:
+    ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#create-a-repository-from-an-unpublished-codespace"""
 
         from ..models import (
@@ -3791,7 +3897,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3821,7 +3927,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3851,7 +3957,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError
@@ -3878,7 +3984,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Codespace]:
+    ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 
         from ..models import Codespace, BasicError

--- a/githubkit/versions/v2022_11_28/rest/copilot.py
+++ b/githubkit/versions/v2022_11_28/rest/copilot.py
@@ -24,12 +24,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
-        OrgsOrgCopilotBillingSelectedUsersPostBodyType,
-        OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
-        OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
-    )
     from ..models import (
         CopilotSeatDetails,
         CopilotUsageMetrics,
@@ -41,6 +35,22 @@ if TYPE_CHECKING:
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
         EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
+    )
+    from ..types import (
+        CopilotSeatDetailsType,
+        CopilotUsageMetricsType,
+        CopilotUsageMetricsDayType,
+        CopilotOrganizationDetailsType,
+        OrgsOrgCopilotBillingSeatsGetResponse200Type,
+        OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
+        OrgsOrgCopilotBillingSelectedUsersPostBodyType,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
+        OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
     )
 
 
@@ -66,7 +76,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-enterprise"""
 
         from ..models import (
@@ -104,7 +117,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EnterprisesEnterpriseCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
+        EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-enterprise"""
 
         from ..models import (
@@ -144,7 +160,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -183,7 +199,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -222,7 +238,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-enterprise-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -261,7 +277,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-enterprise-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -301,7 +317,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -341,7 +357,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -381,7 +397,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -421,7 +437,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-an-enterprise-team"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -456,7 +472,7 @@ class CopilotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotOrganizationDetails]:
+    ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
         from ..models import BasicError, CopilotOrganizationDetails
@@ -483,7 +499,7 @@ class CopilotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotOrganizationDetails]:
+    ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
         from ..models import BasicError, CopilotOrganizationDetails
@@ -512,7 +528,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSeatsGetResponse200,
+        OrgsOrgCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-organization"""
 
         from ..models import BasicError, OrgsOrgCopilotBillingSeatsGetResponse200
@@ -547,7 +566,10 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgCopilotBillingSeatsGetResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSeatsGetResponse200,
+        OrgsOrgCopilotBillingSeatsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#list-all-copilot-seat-assignments-for-an-organization"""
 
         from ..models import BasicError, OrgsOrgCopilotBillingSeatsGetResponse200
@@ -582,7 +604,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     @overload
     def add_copilot_seats_for_teams(
@@ -592,7 +617,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     def add_copilot_seats_for_teams(
         self,
@@ -601,7 +629,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#add-teams-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -646,7 +677,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_add_copilot_seats_for_teams(
@@ -656,7 +690,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]: ...
 
     async def async_add_copilot_seats_for_teams(
         self,
@@ -665,7 +702,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
+        OrgsOrgCopilotBillingSelectedTeamsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#add-teams-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -710,7 +750,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     @overload
     def cancel_copilot_seat_assignment_for_teams(
@@ -720,7 +763,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     def cancel_copilot_seat_assignment_for_teams(
         self,
@@ -729,7 +775,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#remove-teams-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -774,7 +823,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     @overload
     async def async_cancel_copilot_seat_assignment_for_teams(
@@ -784,7 +836,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_teams: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]: ...
 
     async def async_cancel_copilot_seat_assignment_for_teams(
         self,
@@ -793,7 +848,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#remove-teams-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -838,7 +896,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     @overload
     def add_copilot_seats_for_users(
@@ -848,7 +909,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     def add_copilot_seats_for_users(
         self,
@@ -857,7 +921,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#add-users-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -902,7 +969,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_add_copilot_seats_for_users(
@@ -912,7 +982,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]: ...
 
     async def async_add_copilot_seats_for_users(
         self,
@@ -921,7 +994,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersPostResponse201]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201,
+        OrgsOrgCopilotBillingSelectedUsersPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#add-users-to-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -966,7 +1042,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     @overload
     def cancel_copilot_seat_assignment_for_users(
@@ -976,7 +1055,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     def cancel_copilot_seat_assignment_for_users(
         self,
@@ -985,7 +1067,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#remove-users-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -1030,7 +1115,10 @@ class CopilotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     @overload
     async def async_cancel_copilot_seat_assignment_for_users(
@@ -1040,7 +1128,10 @@ class CopilotClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         selected_usernames: list[str],
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]: ...
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]: ...
 
     async def async_cancel_copilot_seat_assignment_for_users(
         self,
@@ -1049,7 +1140,10 @@ class CopilotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgCopilotBillingSelectedUsersDeleteResponse200]:
+    ) -> Response[
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
+        OrgsOrgCopilotBillingSelectedUsersDeleteResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#remove-users-from-the-copilot-subscription-for-an-organization"""
 
         from ..models import (
@@ -1096,7 +1190,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1135,7 +1229,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1174,7 +1268,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -1213,7 +1307,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -1249,7 +1343,7 @@ class CopilotClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotSeatDetails]:
+    ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
         from ..models import BasicError, CopilotSeatDetails
@@ -1277,7 +1371,7 @@ class CopilotClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CopilotSeatDetails]:
+    ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
         from ..models import BasicError, CopilotSeatDetails
@@ -1309,7 +1403,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1349,7 +1443,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetricsDay]]:
+    ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetricsDay
@@ -1389,7 +1483,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetrics
@@ -1429,7 +1523,7 @@ class CopilotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CopilotUsageMetrics]]:
+    ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 
         from ..models import BasicError, CopilotUsageMetrics

--- a/githubkit/versions/v2022_11_28/rest/dependabot.py
+++ b/githubkit/versions/v2022_11_28/rest/dependabot.py
@@ -26,12 +26,6 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import (
-        OrgsOrgDependabotSecretsSecretNamePutBodyType,
-        ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
-        ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
-        OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
-    )
     from ..models import (
         EmptyObject,
         DependabotAlert,
@@ -42,6 +36,21 @@ if TYPE_CHECKING:
         OrgsOrgDependabotSecretsGetResponse200,
         ReposOwnerRepoDependabotSecretsGetResponse200,
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
+    )
+    from ..types import (
+        EmptyObjectType,
+        DependabotAlertType,
+        DependabotSecretType,
+        DependabotPublicKeyType,
+        OrganizationDependabotSecretType,
+        DependabotAlertWithRepositoryType,
+        OrgsOrgDependabotSecretsGetResponse200Type,
+        OrgsOrgDependabotSecretsSecretNamePutBodyType,
+        ReposOwnerRepoDependabotSecretsGetResponse200Type,
+        ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
+        ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
     )
 
 
@@ -77,7 +86,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -135,7 +146,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -193,7 +206,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-an-organization"""
 
         from ..models import (
@@ -252,7 +267,9 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlertWithRepository]]:
+    ) -> Response[
+        list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
+    ]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-an-organization"""
 
         from ..models import (
@@ -301,7 +318,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsGetResponse200,
+        OrgsOrgDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/dependabot/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgDependabotSecretsGetResponse200
@@ -330,7 +350,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsGetResponse200,
+        OrgsOrgDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/dependabot/secrets#list-organization-secrets"""
 
         from ..models import OrgsOrgDependabotSecretsGetResponse200
@@ -357,7 +380,7 @@ class DependabotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-public-key"""
 
         from ..models import DependabotPublicKey
@@ -378,7 +401,7 @@ class DependabotClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-public-key"""
 
         from ..models import DependabotPublicKey
@@ -400,7 +423,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationDependabotSecret]:
+    ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationDependabotSecret
@@ -422,7 +445,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationDependabotSecret]:
+    ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-secret"""
 
         from ..models import OrganizationDependabotSecret
@@ -446,7 +469,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_org_secret(
@@ -460,7 +483,7 @@ class DependabotClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_org_secret(
         self,
@@ -470,7 +493,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgDependabotSecretsSecretNamePutBody
@@ -504,7 +527,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_org_secret(
@@ -518,7 +541,7 @@ class DependabotClient:
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
         selected_repository_ids: Missing[list[str]] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_org_secret(
         self,
@@ -528,7 +551,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#create-or-update-an-organization-secret"""
 
         from ..models import EmptyObject, OrgsOrgDependabotSecretsSecretNamePutBody
@@ -600,7 +623,10 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -632,7 +658,10 @@ class DependabotClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200]:
+    ) -> Response[
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
+        OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/dependabot/secrets#list-selected-repositories-for-an-organization-secret"""
 
         from ..models import (
@@ -884,7 +913,7 @@ class DependabotClient:
         last: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlert]]:
+    ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
         from ..models import BasicError, DependabotAlert, ValidationErrorSimple
@@ -944,7 +973,7 @@ class DependabotClient:
         last: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependabotAlert]]:
+    ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
         from ..models import BasicError, DependabotAlert, ValidationErrorSimple
@@ -991,7 +1020,7 @@ class DependabotClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/rest/dependabot/alerts#get-a-dependabot-alert"""
 
         from ..models import BasicError, DependabotAlert
@@ -1018,7 +1047,7 @@ class DependabotClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/rest/dependabot/alerts#get-a-dependabot-alert"""
 
         from ..models import BasicError, DependabotAlert
@@ -1047,7 +1076,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     @overload
     def update_alert(
@@ -1069,7 +1098,7 @@ class DependabotClient:
             ]
         ] = UNSET,
         dismissed_comment: Missing[str] = UNSET,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     def update_alert(
         self,
@@ -1080,7 +1109,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/rest/dependabot/alerts#update-a-dependabot-alert"""
 
         from ..models import (
@@ -1129,7 +1158,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     @overload
     async def async_update_alert(
@@ -1151,7 +1180,7 @@ class DependabotClient:
             ]
         ] = UNSET,
         dismissed_comment: Missing[str] = UNSET,
-    ) -> Response[DependabotAlert]: ...
+    ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
     async def async_update_alert(
         self,
@@ -1162,7 +1191,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DependabotAlert]:
+    ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/rest/dependabot/alerts#update-a-dependabot-alert"""
 
         from ..models import (
@@ -1210,7 +1239,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoDependabotSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoDependabotSecretsGetResponse200,
+        ReposOwnerRepoDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/dependabot/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoDependabotSecretsGetResponse200
@@ -1240,7 +1272,10 @@ class DependabotClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoDependabotSecretsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoDependabotSecretsGetResponse200,
+        ReposOwnerRepoDependabotSecretsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/dependabot/secrets#list-repository-secrets"""
 
         from ..models import ReposOwnerRepoDependabotSecretsGetResponse200
@@ -1268,7 +1303,7 @@ class DependabotClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-public-key"""
 
         from ..models import DependabotPublicKey
@@ -1290,7 +1325,7 @@ class DependabotClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotPublicKey]:
+    ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-public-key"""
 
         from ..models import DependabotPublicKey
@@ -1313,7 +1348,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotSecret]:
+    ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-secret"""
 
         from ..models import DependabotSecret
@@ -1336,7 +1371,7 @@ class DependabotClient:
         secret_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependabotSecret]:
+    ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-secret"""
 
         from ..models import DependabotSecret
@@ -1361,7 +1396,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def create_or_update_repo_secret(
@@ -1374,7 +1409,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def create_or_update_repo_secret(
         self,
@@ -1385,7 +1420,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#create-or-update-a-repository-secret"""
 
         from ..models import (
@@ -1425,7 +1460,7 @@ class DependabotClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_create_or_update_repo_secret(
@@ -1438,7 +1473,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_create_or_update_repo_secret(
         self,
@@ -1449,7 +1484,7 @@ class DependabotClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#create-or-update-a-repository-secret"""
 
         from ..models import (

--- a/githubkit/versions/v2022_11_28/rest/dependency_graph.py
+++ b/githubkit/versions/v2022_11_28/rest/dependency_graph.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
         SnapshotPropJobType,
         SnapshotPropDetectorType,
         SnapshotPropManifestsType,
+        DependencyGraphSpdxSbomType,
+        DependencyGraphDiffItemsType,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
     )
 
 
@@ -63,7 +66,7 @@ class DependencyGraphClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependencyGraphDiffItems]]:
+    ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
         from ..models import BasicError, DependencyGraphDiffItems
@@ -96,7 +99,7 @@ class DependencyGraphClient:
         name: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DependencyGraphDiffItems]]:
+    ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
         from ..models import BasicError, DependencyGraphDiffItems
@@ -127,7 +130,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependencyGraphSpdxSbom]:
+    ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
         from ..models import BasicError, DependencyGraphSpdxSbom
@@ -153,7 +156,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DependencyGraphSpdxSbom]:
+    ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
         from ..models import BasicError, DependencyGraphSpdxSbom
@@ -181,7 +184,10 @@ class DependencyGraphClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: SnapshotType,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     @overload
     def create_repository_snapshot(
@@ -199,7 +205,10 @@ class DependencyGraphClient:
         metadata: Missing[MetadataType] = UNSET,
         manifests: Missing[SnapshotPropManifestsType] = UNSET,
         scanned: datetime,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     def create_repository_snapshot(
         self,
@@ -209,7 +218,10 @@ class DependencyGraphClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository"""
 
         from ..models import (
@@ -246,7 +258,10 @@ class DependencyGraphClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: SnapshotType,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_create_repository_snapshot(
@@ -264,7 +279,10 @@ class DependencyGraphClient:
         metadata: Missing[MetadataType] = UNSET,
         manifests: Missing[SnapshotPropManifestsType] = UNSET,
         scanned: datetime,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]: ...
 
     async def async_create_repository_snapshot(
         self,
@@ -274,7 +292,10 @@ class DependencyGraphClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoDependencyGraphSnapshotsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
+        ReposOwnerRepoDependencyGraphSnapshotsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository"""
 
         from ..models import (

--- a/githubkit/versions/v2022_11_28/rest/emojis.py
+++ b/githubkit/versions/v2022_11_28/rest/emojis.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import EmojisGetResponse200
+    from ..types import EmojisGetResponse200Type
 
 
 class EmojisClient:
@@ -40,7 +41,7 @@ class EmojisClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmojisGetResponse200]:
+    ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/rest/emojis/emojis#get-emojis"""
 
         from ..models import EmojisGetResponse200
@@ -60,7 +61,7 @@ class EmojisClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[EmojisGetResponse200]:
+    ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/rest/emojis/emojis#get-emojis"""
 
         from ..models import EmojisGetResponse200

--- a/githubkit/versions/v2022_11_28/rest/gists.py
+++ b/githubkit/versions/v2022_11_28/rest/gists.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
 
     from ..models import BaseGist, GistCommit, GistSimple, GistComment
     from ..types import (
+        BaseGistType,
+        GistCommitType,
+        GistSimpleType,
+        GistCommentType,
         GistsPostBodyType,
         GistsGistIdPatchBodyType,
         GistsPostBodyPropFilesType,
@@ -60,7 +64,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-the-authenticated-user"""
 
         from ..models import BaseGist, BasicError
@@ -93,7 +97,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-the-authenticated-user"""
 
         from ..models import BaseGist, BasicError
@@ -122,7 +126,7 @@ class GistsClient:
     @overload
     def create(
         self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     def create(
@@ -133,7 +137,7 @@ class GistsClient:
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     def create(
         self,
@@ -141,7 +145,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#create-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsPostBody, ValidationError
@@ -175,7 +179,7 @@ class GistsClient:
     @overload
     async def async_create(
         self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     async def async_create(
@@ -186,7 +190,7 @@ class GistsClient:
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     async def async_create(
         self,
@@ -194,7 +198,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#create-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsPostBody, ValidationError
@@ -232,7 +236,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-public-gists"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -266,7 +270,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-public-gists"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -300,7 +304,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-starred-gists"""
 
         from ..models import BaseGist, BasicError
@@ -334,7 +338,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-starred-gists"""
 
         from ..models import BaseGist, BasicError
@@ -366,7 +370,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsGistIdGetResponse403
@@ -391,7 +395,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist"""
 
         from ..models import BasicError, GistSimple, GistsGistIdGetResponse403
@@ -466,7 +470,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     def update(
@@ -477,7 +481,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     def update(
         self,
@@ -486,7 +490,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#update-a-gist"""
 
         from typing import Union
@@ -530,7 +534,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
     async def async_update(
@@ -541,7 +545,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
-    ) -> Response[GistSimple]: ...
+    ) -> Response[GistSimple, GistSimpleType]: ...
 
     async def async_update(
         self,
@@ -550,7 +554,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#update-a-gist"""
 
         from typing import Union
@@ -594,7 +598,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistComment]]:
+    ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/rest/gists/comments#list-gist-comments"""
 
         from ..models import BasicError, GistComment
@@ -627,7 +631,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistComment]]:
+    ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/rest/gists/comments#list-gist-comments"""
 
         from ..models import BasicError, GistComment
@@ -660,7 +664,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     def create_comment(
@@ -670,7 +674,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     def create_comment(
         self,
@@ -679,7 +683,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#create-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdCommentsPostBody
@@ -716,7 +720,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     async def async_create_comment(
@@ -726,7 +730,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     async def async_create_comment(
         self,
@@ -735,7 +739,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#create-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdCommentsPostBody
@@ -771,7 +775,7 @@ class GistsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#get-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdGetResponse403
@@ -797,7 +801,7 @@ class GistsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#get-a-gist-comment"""
 
         from ..models import BasicError, GistComment, GistsGistIdGetResponse403
@@ -875,7 +879,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     def update_comment(
@@ -886,7 +890,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     def update_comment(
         self,
@@ -896,7 +900,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#update-a-gist-comment"""
 
         from ..models import (
@@ -937,7 +941,7 @@ class GistsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     @overload
     async def async_update_comment(
@@ -948,7 +952,7 @@ class GistsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[GistComment]: ...
+    ) -> Response[GistComment, GistCommentType]: ...
 
     async def async_update_comment(
         self,
@@ -958,7 +962,7 @@ class GistsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GistComment]:
+    ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#update-a-gist-comment"""
 
         from ..models import (
@@ -998,7 +1002,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistCommit]]:
+    ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-commits"""
 
         from ..models import BasicError, GistCommit
@@ -1031,7 +1035,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistCommit]]:
+    ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-commits"""
 
         from ..models import BasicError, GistCommit
@@ -1064,7 +1068,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistSimple]]:
+    ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-forks"""
 
         from ..models import BasicError, GistSimple
@@ -1097,7 +1101,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GistSimple]]:
+    ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-forks"""
 
         from ..models import BasicError, GistSimple
@@ -1128,7 +1132,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BaseGist]:
+    ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/rest/gists/gists#fork-a-gist"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -1154,7 +1158,7 @@ class GistsClient:
         gist_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BaseGist]:
+    ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/rest/gists/gists#fork-a-gist"""
 
         from ..models import BaseGist, BasicError, ValidationError
@@ -1325,7 +1329,7 @@ class GistsClient:
         sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist-revision"""
 
         from ..models import BasicError, GistSimple, ValidationError
@@ -1352,7 +1356,7 @@ class GistsClient:
         sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GistSimple]:
+    ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist-revision"""
 
         from ..models import BasicError, GistSimple, ValidationError
@@ -1381,7 +1385,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-a-user"""
 
         from ..models import BaseGist, ValidationError
@@ -1415,7 +1419,7 @@ class GistsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BaseGist]]:
+    ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-a-user"""
 
         from ..models import BaseGist, ValidationError

--- a/githubkit/versions/v2022_11_28/rest/git.py
+++ b/githubkit/versions/v2022_11_28/rest/git.py
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
 
     from ..models import Blob, GitRef, GitTag, GitTree, GitCommit, ShortBlob
     from ..types import (
+        BlobType,
+        GitRefType,
+        GitTagType,
+        GitTreeType,
+        GitCommitType,
+        ShortBlobType,
         ReposOwnerRepoGitRefsPostBodyType,
         ReposOwnerRepoGitTagsPostBodyType,
         ReposOwnerRepoGitBlobsPostBodyType,
@@ -64,7 +70,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     @overload
     def create_blob(
@@ -76,7 +82,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     def create_blob(
         self,
@@ -86,7 +92,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ShortBlob]:
+    ) -> Response[ShortBlob, ShortBlobType]:
         """See also: https://docs.github.com/rest/git/blobs#create-a-blob"""
 
         from typing import Union
@@ -134,7 +140,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     @overload
     async def async_create_blob(
@@ -146,7 +152,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
-    ) -> Response[ShortBlob]: ...
+    ) -> Response[ShortBlob, ShortBlobType]: ...
 
     async def async_create_blob(
         self,
@@ -156,7 +162,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ShortBlob]:
+    ) -> Response[ShortBlob, ShortBlobType]:
         """See also: https://docs.github.com/rest/git/blobs#create-a-blob"""
 
         from typing import Union
@@ -203,7 +209,7 @@ class GitClient:
         file_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Blob]:
+    ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/rest/git/blobs#get-a-blob"""
 
         from ..models import Blob, BasicError, ValidationError
@@ -232,7 +238,7 @@ class GitClient:
         file_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Blob]:
+    ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/rest/git/blobs#get-a-blob"""
 
         from ..models import Blob, BasicError, ValidationError
@@ -262,7 +268,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     @overload
     def create_commit(
@@ -278,7 +284,7 @@ class GitClient:
         author: Missing[ReposOwnerRepoGitCommitsPostBodyPropAuthorType] = UNSET,
         committer: Missing[ReposOwnerRepoGitCommitsPostBodyPropCommitterType] = UNSET,
         signature: Missing[str] = UNSET,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     def create_commit(
         self,
@@ -288,7 +294,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/rest/git/commits#create-a-commit"""
 
         from ..models import (
@@ -332,7 +338,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     @overload
     async def async_create_commit(
@@ -348,7 +354,7 @@ class GitClient:
         author: Missing[ReposOwnerRepoGitCommitsPostBodyPropAuthorType] = UNSET,
         committer: Missing[ReposOwnerRepoGitCommitsPostBodyPropCommitterType] = UNSET,
         signature: Missing[str] = UNSET,
-    ) -> Response[GitCommit]: ...
+    ) -> Response[GitCommit, GitCommitType]: ...
 
     async def async_create_commit(
         self,
@@ -358,7 +364,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/rest/git/commits#create-a-commit"""
 
         from ..models import (
@@ -401,7 +407,7 @@ class GitClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/rest/git/commits#get-a-commit-object"""
 
         from ..models import GitCommit, BasicError
@@ -428,7 +434,7 @@ class GitClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitCommit]:
+    ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/rest/git/commits#get-a-commit-object"""
 
         from ..models import GitCommit, BasicError
@@ -455,7 +461,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GitRef]]:
+    ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/rest/git/refs#list-matching-references"""
 
         from ..models import GitRef, BasicError
@@ -481,7 +487,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GitRef]]:
+    ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/rest/git/refs#list-matching-references"""
 
         from ..models import GitRef, BasicError
@@ -507,7 +513,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#get-a-reference"""
 
         from ..models import GitRef, BasicError
@@ -534,7 +540,7 @@ class GitClient:
         ref: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#get-a-reference"""
 
         from ..models import GitRef, BasicError
@@ -562,7 +568,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     def create_ref(
@@ -574,7 +580,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         ref: str,
         sha: str,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     def create_ref(
         self,
@@ -584,7 +590,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#create-a-reference"""
 
         from ..models import (
@@ -627,7 +633,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     async def async_create_ref(
@@ -639,7 +645,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         ref: str,
         sha: str,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     async def async_create_ref(
         self,
@@ -649,7 +655,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#create-a-reference"""
 
         from ..models import (
@@ -745,7 +751,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     def update_ref(
@@ -758,7 +764,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     def update_ref(
         self,
@@ -769,7 +775,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#update-a-reference"""
 
         from ..models import (
@@ -813,7 +819,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     @overload
     async def async_update_ref(
@@ -826,7 +832,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
-    ) -> Response[GitRef]: ...
+    ) -> Response[GitRef, GitRefType]: ...
 
     async def async_update_ref(
         self,
@@ -837,7 +843,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitRef]:
+    ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#update-a-reference"""
 
         from ..models import (
@@ -880,7 +886,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     @overload
     def create_tag(
@@ -895,7 +901,7 @@ class GitClient:
         object_: str,
         type: Literal["commit", "tree", "blob"],
         tagger: Missing[ReposOwnerRepoGitTagsPostBodyPropTaggerType] = UNSET,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     def create_tag(
         self,
@@ -905,7 +911,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/rest/git/tags#create-a-tag-object"""
 
         from ..models import (
@@ -948,7 +954,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     @overload
     async def async_create_tag(
@@ -963,7 +969,7 @@ class GitClient:
         object_: str,
         type: Literal["commit", "tree", "blob"],
         tagger: Missing[ReposOwnerRepoGitTagsPostBodyPropTaggerType] = UNSET,
-    ) -> Response[GitTag]: ...
+    ) -> Response[GitTag, GitTagType]: ...
 
     async def async_create_tag(
         self,
@@ -973,7 +979,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/rest/git/tags#create-a-tag-object"""
 
         from ..models import (
@@ -1015,7 +1021,7 @@ class GitClient:
         tag_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/rest/git/tags#get-a-tag"""
 
         from ..models import GitTag, BasicError
@@ -1042,7 +1048,7 @@ class GitClient:
         tag_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTag]:
+    ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/rest/git/tags#get-a-tag"""
 
         from ..models import GitTag, BasicError
@@ -1070,7 +1076,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     @overload
     def create_tree(
@@ -1082,7 +1088,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     def create_tree(
         self,
@@ -1092,7 +1098,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/rest/git/trees#create-a-tree"""
 
         from ..models import (
@@ -1137,7 +1143,7 @@ class GitClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     @overload
     async def async_create_tree(
@@ -1149,7 +1155,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
-    ) -> Response[GitTree]: ...
+    ) -> Response[GitTree, GitTreeType]: ...
 
     async def async_create_tree(
         self,
@@ -1159,7 +1165,7 @@ class GitClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/rest/git/trees#create-a-tree"""
 
         from ..models import (
@@ -1204,7 +1210,7 @@ class GitClient:
         recursive: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/rest/git/trees#get-a-tree"""
 
         from ..models import GitTree, BasicError, ValidationError
@@ -1238,7 +1244,7 @@ class GitClient:
         recursive: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitTree]:
+    ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/rest/git/trees#get-a-tree"""
 
         from ..models import GitTree, BasicError, ValidationError

--- a/githubkit/versions/v2022_11_28/rest/gitignore.py
+++ b/githubkit/versions/v2022_11_28/rest/gitignore.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import GitignoreTemplate
+    from ..types import GitignoreTemplateType
 
 
 class GitignoreClient:
@@ -40,7 +41,7 @@ class GitignoreClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-all-gitignore-templates"""
 
         url = "/gitignore/templates"
@@ -58,7 +59,7 @@ class GitignoreClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-all-gitignore-templates"""
 
         url = "/gitignore/templates"
@@ -77,7 +78,7 @@ class GitignoreClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitignoreTemplate]:
+    ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-a-gitignore-template"""
 
         from ..models import GitignoreTemplate
@@ -98,7 +99,7 @@ class GitignoreClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GitignoreTemplate]:
+    ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-a-gitignore-template"""
 
         from ..models import GitignoreTemplate

--- a/githubkit/versions/v2022_11_28/rest/interactions.py
+++ b/githubkit/versions/v2022_11_28/rest/interactions.py
@@ -26,12 +26,18 @@ if TYPE_CHECKING:
     from githubkit.typing import Missing
     from githubkit.response import Response
 
-    from ..types import InteractionLimitType
     from ..models import (
         InteractionLimitResponse,
         UserInteractionLimitsGetResponse200Anyof1,
         OrgsOrgInteractionLimitsGetResponse200Anyof1,
         ReposOwnerRepoInteractionLimitsGetResponse200Anyof1,
+    )
+    from ..types import (
+        InteractionLimitType,
+        InteractionLimitResponseType,
+        UserInteractionLimitsGetResponse200Anyof1Type,
+        OrgsOrgInteractionLimitsGetResponse200Anyof1Type,
+        ReposOwnerRepoInteractionLimitsGetResponse200Anyof1Type,
     )
 
 
@@ -56,7 +62,11 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType,
+            OrgsOrgInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/rest/interactions/orgs#get-interaction-restrictions-for-an-organization"""
 
@@ -86,7 +96,11 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType,
+            OrgsOrgInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/rest/interactions/orgs#get-interaction-restrictions-for-an-organization"""
 
@@ -117,7 +131,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     def set_restrictions_for_org(
@@ -130,7 +144,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     def set_restrictions_for_org(
         self,
@@ -139,7 +153,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/rest/interactions/orgs#set-interaction-restrictions-for-an-organization"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse
@@ -175,7 +189,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     async def async_set_restrictions_for_org(
@@ -188,7 +202,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     async def async_set_restrictions_for_org(
         self,
@@ -197,7 +211,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/rest/interactions/orgs#set-interaction-restrictions-for-an-organization"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse
@@ -272,7 +286,11 @@ class InteractionsClient:
         Union[
             InteractionLimitResponse,
             ReposOwnerRepoInteractionLimitsGetResponse200Anyof1,
-        ]
+        ],
+        Union[
+            InteractionLimitResponseType,
+            ReposOwnerRepoInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/rest/interactions/repos#get-interaction-restrictions-for-a-repository"""
 
@@ -307,7 +325,11 @@ class InteractionsClient:
         Union[
             InteractionLimitResponse,
             ReposOwnerRepoInteractionLimitsGetResponse200Anyof1,
-        ]
+        ],
+        Union[
+            InteractionLimitResponseType,
+            ReposOwnerRepoInteractionLimitsGetResponse200Anyof1Type,
+        ],
     ]:
         """See also: https://docs.github.com/rest/interactions/repos#get-interaction-restrictions-for-a-repository"""
 
@@ -340,7 +362,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     def set_restrictions_for_repo(
@@ -354,7 +376,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     def set_restrictions_for_repo(
         self,
@@ -364,7 +386,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/rest/interactions/repos#set-interaction-restrictions-for-a-repository"""
 
         from ..models import InteractionLimit, InteractionLimitResponse
@@ -399,7 +421,7 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: InteractionLimitType,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     async def async_set_restrictions_for_repo(
@@ -413,7 +435,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     async def async_set_restrictions_for_repo(
         self,
@@ -423,7 +445,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/rest/interactions/repos#set-interaction-restrictions-for-a-repository"""
 
         from ..models import InteractionLimit, InteractionLimitResponse
@@ -495,7 +517,10 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType, UserInteractionLimitsGetResponse200Anyof1Type
+        ],
     ]:
         """See also: https://docs.github.com/rest/interactions/user#get-interaction-restrictions-for-your-public-repositories"""
 
@@ -524,7 +549,10 @@ class InteractionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1]
+        Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
+        Union[
+            InteractionLimitResponseType, UserInteractionLimitsGetResponse200Anyof1Type
+        ],
     ]:
         """See also: https://docs.github.com/rest/interactions/user#get-interaction-restrictions-for-your-public-repositories"""
 
@@ -551,7 +579,7 @@ class InteractionsClient:
     @overload
     def set_restrictions_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     def set_restrictions_for_authenticated_user(
@@ -563,7 +591,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     def set_restrictions_for_authenticated_user(
         self,
@@ -571,7 +599,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/rest/interactions/user#set-interaction-restrictions-for-your-public-repositories"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse
@@ -603,7 +631,7 @@ class InteractionsClient:
     @overload
     async def async_set_restrictions_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
     async def async_set_restrictions_for_authenticated_user(
@@ -615,7 +643,7 @@ class InteractionsClient:
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
         ] = UNSET,
-    ) -> Response[InteractionLimitResponse]: ...
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     async def async_set_restrictions_for_authenticated_user(
         self,
@@ -623,7 +651,7 @@ class InteractionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
-    ) -> Response[InteractionLimitResponse]:
+    ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
         """See also: https://docs.github.com/rest/interactions/user#set-interaction-restrictions-for-your-public-repositories"""
 
         from ..models import ValidationError, InteractionLimit, InteractionLimitResponse

--- a/githubkit/versions/v2022_11_28/rest/issues.py
+++ b/githubkit/versions/v2022_11_28/rest/issues.py
@@ -60,8 +60,38 @@ if TYPE_CHECKING:
         ReviewRequestRemovedIssueEvent,
     )
     from ..types import (
+        IssueType,
+        LabelType,
+        MilestoneType,
+        IssueEventType,
+        SimpleUserType,
+        IssueCommentType,
+        LockedIssueEventType,
+        LabeledIssueEventType,
+        RenamedIssueEventType,
+        AssignedIssueEventType,
+        UnlabeledIssueEventType,
+        MilestonedIssueEventType,
+        TimelineCommentEventType,
+        UnassignedIssueEventType,
+        StateChangeIssueEventType,
+        TimelineReviewedEventType,
+        DemilestonedIssueEventType,
+        TimelineCommittedEventType,
+        AddedToProjectIssueEventType,
+        ReviewDismissedIssueEventType,
+        ReviewRequestedIssueEventType,
+        TimelineAssignedIssueEventType,
+        TimelineLineCommentedEventType,
+        RemovedFromProjectIssueEventType,
         ReposOwnerRepoIssuesPostBodyType,
         ReposOwnerRepoLabelsPostBodyType,
+        TimelineCommitCommentedEventType,
+        TimelineCrossReferencedEventType,
+        TimelineUnassignedIssueEventType,
+        ConvertedNoteToIssueIssueEventType,
+        MovedColumnInProjectIssueEventType,
+        ReviewRequestRemovedIssueEventType,
         ReposOwnerRepoMilestonesPostBodyType,
         ReposOwnerRepoLabelsNamePatchBodyType,
         ReposOwnerRepoIssuesIssueNumberPatchBodyType,
@@ -117,7 +147,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -171,7 +201,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -222,7 +252,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError
@@ -268,7 +298,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError
@@ -307,7 +337,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/issues/assignees#list-assignees"""
 
         from ..models import BasicError, SimpleUser
@@ -340,7 +370,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/issues/assignees#list-assignees"""
 
         from ..models import BasicError, SimpleUser
@@ -432,7 +462,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-repository-issues"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -484,7 +514,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-repository-issues"""
 
         from ..models import Issue, BasicError, ValidationError
@@ -527,7 +557,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def create(
@@ -545,7 +575,7 @@ class IssuesClient:
             list[Union[str, ReposOwnerRepoIssuesPostBodyPropLabelsItemsOneof1Type]]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def create(
         self,
@@ -555,7 +585,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#create-an-issue"""
 
         from ..models import (
@@ -603,7 +633,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_create(
@@ -621,7 +651,7 @@ class IssuesClient:
             list[Union[str, ReposOwnerRepoIssuesPostBodyPropLabelsItemsOneof1Type]]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_create(
         self,
@@ -631,7 +661,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#create-an-issue"""
 
         from ..models import (
@@ -682,7 +712,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments-for-a-repository"""
 
         from ..models import BasicError, IssueComment, ValidationError
@@ -722,7 +752,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments-for-a-repository"""
 
         from ..models import BasicError, IssueComment, ValidationError
@@ -758,7 +788,7 @@ class IssuesClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#get-an-issue-comment"""
 
         from ..models import BasicError, IssueComment
@@ -784,7 +814,7 @@ class IssuesClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#get-an-issue-comment"""
 
         from ..models import BasicError, IssueComment
@@ -852,7 +882,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     def update_comment(
@@ -864,7 +894,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     def update_comment(
         self,
@@ -875,7 +905,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#update-an-issue-comment"""
 
         from ..models import (
@@ -919,7 +949,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     async def async_update_comment(
@@ -931,7 +961,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     async def async_update_comment(
         self,
@@ -942,7 +972,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#update-an-issue-comment"""
 
         from ..models import (
@@ -985,7 +1015,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueEvent]]:
+    ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/rest/issues/events#list-issue-events-for-a-repository"""
 
         from ..models import IssueEvent, ValidationError
@@ -1018,7 +1048,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueEvent]]:
+    ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/rest/issues/events#list-issue-events-for-a-repository"""
 
         from ..models import IssueEvent, ValidationError
@@ -1050,7 +1080,7 @@ class IssuesClient:
         event_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueEvent]:
+    ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/rest/issues/events#get-an-issue-event"""
 
         from ..models import BasicError, IssueEvent
@@ -1078,7 +1108,7 @@ class IssuesClient:
         event_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[IssueEvent]:
+    ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/rest/issues/events#get-an-issue-event"""
 
         from ..models import BasicError, IssueEvent
@@ -1106,7 +1136,7 @@ class IssuesClient:
         issue_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#get-an-issue"""
 
         from ..models import Issue, BasicError
@@ -1133,7 +1163,7 @@ class IssuesClient:
         issue_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#get-an-issue"""
 
         from ..models import Issue, BasicError
@@ -1162,7 +1192,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def update(
@@ -1190,7 +1220,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def update(
         self,
@@ -1201,7 +1231,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#update-an-issue"""
 
         from ..models import (
@@ -1249,7 +1279,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_update(
@@ -1277,7 +1307,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_update(
         self,
@@ -1288,7 +1318,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#update-an-issue"""
 
         from ..models import (
@@ -1336,7 +1366,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def add_assignees(
@@ -1348,7 +1378,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def add_assignees(
         self,
@@ -1359,7 +1389,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesPostBody
@@ -1396,7 +1426,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_add_assignees(
@@ -1408,7 +1438,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_add_assignees(
         self,
@@ -1419,7 +1449,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesPostBody
@@ -1456,7 +1486,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     def remove_assignees(
@@ -1468,7 +1498,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     def remove_assignees(
         self,
@@ -1479,7 +1509,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/assignees#remove-assignees-from-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBody
@@ -1516,7 +1546,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     @overload
     async def async_remove_assignees(
@@ -1528,7 +1558,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
-    ) -> Response[Issue]: ...
+    ) -> Response[Issue, IssueType]: ...
 
     async def async_remove_assignees(
         self,
@@ -1539,7 +1569,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Issue]:
+    ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/assignees#remove-assignees-from-an-issue"""
 
         from ..models import Issue, ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBody
@@ -1629,7 +1659,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments"""
 
         from ..models import BasicError, IssueComment
@@ -1666,7 +1696,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[IssueComment]]:
+    ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments"""
 
         from ..models import BasicError, IssueComment
@@ -1702,7 +1732,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     def create_comment(
@@ -1714,7 +1744,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     def create_comment(
         self,
@@ -1725,7 +1755,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#create-an-issue-comment"""
 
         from ..models import (
@@ -1773,7 +1803,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     @overload
     async def async_create_comment(
@@ -1785,7 +1815,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[IssueComment]: ...
+    ) -> Response[IssueComment, IssueCommentType]: ...
 
     async def async_create_comment(
         self,
@@ -1796,7 +1826,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[IssueComment]:
+    ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#create-an-issue-comment"""
 
         from ..models import (
@@ -1863,7 +1893,26 @@ class IssuesClient:
                 RemovedFromProjectIssueEvent,
                 ConvertedNoteToIssueIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                AssignedIssueEventType,
+                UnassignedIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/rest/issues/events#list-issue-events"""
 
@@ -1954,7 +2003,26 @@ class IssuesClient:
                 RemovedFromProjectIssueEvent,
                 ConvertedNoteToIssueIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                AssignedIssueEventType,
+                UnassignedIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/rest/issues/events#list-issue-events"""
 
@@ -2026,7 +2094,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-an-issue"""
 
         from ..models import Label, BasicError
@@ -2061,7 +2129,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-an-issue"""
 
         from ..models import Label, BasicError
@@ -2104,7 +2172,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def set_labels(
@@ -2116,7 +2184,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def set_labels(
@@ -2130,7 +2198,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     def set_labels(
         self,
@@ -2149,7 +2217,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#set-labels-for-an-issue"""
 
         from typing import Union
@@ -2220,7 +2288,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_set_labels(
@@ -2232,7 +2300,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_set_labels(
@@ -2246,7 +2314,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     async def async_set_labels(
         self,
@@ -2265,7 +2333,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#set-labels-for-an-issue"""
 
         from typing import Union
@@ -2336,7 +2404,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def add_labels(
@@ -2348,7 +2416,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     def add_labels(
@@ -2362,7 +2430,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     def add_labels(
         self,
@@ -2381,7 +2449,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#add-labels-to-an-issue"""
 
         from typing import Union
@@ -2452,7 +2520,7 @@ class IssuesClient:
                 str,
             ]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_add_labels(
@@ -2464,7 +2532,7 @@ class IssuesClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     @overload
     async def async_add_labels(
@@ -2478,7 +2546,7 @@ class IssuesClient:
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
-    ) -> Response[list[Label]]: ...
+    ) -> Response[list[Label], list[LabelType]]: ...
 
     async def async_add_labels(
         self,
@@ -2497,7 +2565,7 @@ class IssuesClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#add-labels-to-an-issue"""
 
         from typing import Union
@@ -2611,7 +2679,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue"""
 
         from ..models import Label, BasicError
@@ -2639,7 +2707,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue"""
 
         from ..models import Label, BasicError
@@ -2900,7 +2968,33 @@ class IssuesClient:
                 TimelineUnassignedIssueEvent,
                 StateChangeIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+                TimelineCommentEventType,
+                TimelineCrossReferencedEventType,
+                TimelineCommittedEventType,
+                TimelineReviewedEventType,
+                TimelineLineCommentedEventType,
+                TimelineCommitCommentedEventType,
+                TimelineAssignedIssueEventType,
+                TimelineUnassignedIssueEventType,
+                StateChangeIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/rest/issues/timeline#list-timeline-events-for-an-issue"""
 
@@ -3013,7 +3107,33 @@ class IssuesClient:
                 TimelineUnassignedIssueEvent,
                 StateChangeIssueEvent,
             ]
-        ]
+        ],
+        list[
+            Union[
+                LabeledIssueEventType,
+                UnlabeledIssueEventType,
+                MilestonedIssueEventType,
+                DemilestonedIssueEventType,
+                RenamedIssueEventType,
+                ReviewRequestedIssueEventType,
+                ReviewRequestRemovedIssueEventType,
+                ReviewDismissedIssueEventType,
+                LockedIssueEventType,
+                AddedToProjectIssueEventType,
+                MovedColumnInProjectIssueEventType,
+                RemovedFromProjectIssueEventType,
+                ConvertedNoteToIssueIssueEventType,
+                TimelineCommentEventType,
+                TimelineCrossReferencedEventType,
+                TimelineCommittedEventType,
+                TimelineReviewedEventType,
+                TimelineLineCommentedEventType,
+                TimelineCommitCommentedEventType,
+                TimelineAssignedIssueEventType,
+                TimelineUnassignedIssueEventType,
+                StateChangeIssueEventType,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/rest/issues/timeline#list-timeline-events-for-an-issue"""
 
@@ -3099,7 +3219,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-a-repository"""
 
         from ..models import Label, BasicError
@@ -3132,7 +3252,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-a-repository"""
 
         from ..models import Label, BasicError
@@ -3165,7 +3285,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     def create_label(
@@ -3178,7 +3298,7 @@ class IssuesClient:
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     def create_label(
         self,
@@ -3188,7 +3308,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#create-a-label"""
 
         from ..models import (
@@ -3231,7 +3351,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     async def async_create_label(
@@ -3244,7 +3364,7 @@ class IssuesClient:
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     async def async_create_label(
         self,
@@ -3254,7 +3374,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#create-a-label"""
 
         from ..models import (
@@ -3296,7 +3416,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#get-a-label"""
 
         from ..models import Label, BasicError
@@ -3322,7 +3442,7 @@ class IssuesClient:
         name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#get-a-label"""
 
         from ..models import Label, BasicError
@@ -3390,7 +3510,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     def update_label(
@@ -3404,7 +3524,7 @@ class IssuesClient:
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     def update_label(
         self,
@@ -3415,7 +3535,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#update-a-label"""
 
         from ..models import Label, ReposOwnerRepoLabelsNamePatchBody
@@ -3450,7 +3570,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     @overload
     async def async_update_label(
@@ -3464,7 +3584,7 @@ class IssuesClient:
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
-    ) -> Response[Label]: ...
+    ) -> Response[Label, LabelType]: ...
 
     async def async_update_label(
         self,
@@ -3475,7 +3595,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Label]:
+    ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#update-a-label"""
 
         from ..models import Label, ReposOwnerRepoLabelsNamePatchBody
@@ -3512,7 +3632,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Milestone]]:
+    ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/rest/issues/milestones#list-milestones"""
 
         from ..models import Milestone, BasicError
@@ -3551,7 +3671,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Milestone]]:
+    ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/rest/issues/milestones#list-milestones"""
 
         from ..models import Milestone, BasicError
@@ -3587,7 +3707,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     def create_milestone(
@@ -3601,7 +3721,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     def create_milestone(
         self,
@@ -3611,7 +3731,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#create-a-milestone"""
 
         from ..models import (
@@ -3654,7 +3774,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     async def async_create_milestone(
@@ -3668,7 +3788,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     async def async_create_milestone(
         self,
@@ -3678,7 +3798,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#create-a-milestone"""
 
         from ..models import (
@@ -3720,7 +3840,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#get-a-milestone"""
 
         from ..models import Milestone, BasicError
@@ -3746,7 +3866,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#get-a-milestone"""
 
         from ..models import Milestone, BasicError
@@ -3824,7 +3944,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     def update_milestone(
@@ -3839,7 +3959,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     def update_milestone(
         self,
@@ -3850,7 +3970,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#update-a-milestone"""
 
         from ..models import Milestone, ReposOwnerRepoMilestonesMilestoneNumberPatchBody
@@ -3887,7 +4007,7 @@ class IssuesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     @overload
     async def async_update_milestone(
@@ -3902,7 +4022,7 @@ class IssuesClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
         due_on: Missing[datetime] = UNSET,
-    ) -> Response[Milestone]: ...
+    ) -> Response[Milestone, MilestoneType]: ...
 
     async def async_update_milestone(
         self,
@@ -3913,7 +4033,7 @@ class IssuesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Milestone]:
+    ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#update-a-milestone"""
 
         from ..models import Milestone, ReposOwnerRepoMilestonesMilestoneNumberPatchBody
@@ -3950,7 +4070,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
         from ..models import Label
@@ -3981,7 +4101,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Label]]:
+    ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
         from ..models import Label
@@ -4017,7 +4137,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError
@@ -4062,7 +4182,7 @@ class IssuesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Issue]]:
+    ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 
         from ..models import Issue, BasicError

--- a/githubkit/versions/v2022_11_28/rest/licenses.py
+++ b/githubkit/versions/v2022_11_28/rest/licenses.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import License, LicenseSimple, LicenseContent
+    from ..types import LicenseType, LicenseSimpleType, LicenseContentType
 
 
 class LicensesClient:
@@ -46,7 +47,7 @@ class LicensesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[LicenseSimple]]:
+    ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-all-commonly-used-licenses"""
 
         from ..models import LicenseSimple
@@ -76,7 +77,7 @@ class LicensesClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[LicenseSimple]]:
+    ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-all-commonly-used-licenses"""
 
         from ..models import LicenseSimple
@@ -104,7 +105,7 @@ class LicensesClient:
         license_: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[License]:
+    ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-a-license"""
 
         from ..models import License, BasicError
@@ -129,7 +130,7 @@ class LicensesClient:
         license_: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[License]:
+    ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-a-license"""
 
         from ..models import License, BasicError
@@ -156,7 +157,7 @@ class LicensesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[LicenseContent]:
+    ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-the-license-for-a-repository"""
 
         from ..models import BasicError, LicenseContent
@@ -187,7 +188,7 @@ class LicensesClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[LicenseContent]:
+    ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-the-license-for-a-repository"""
 
         from ..models import BasicError, LicenseContent

--- a/githubkit/versions/v2022_11_28/rest/markdown.py
+++ b/githubkit/versions/v2022_11_28/rest/markdown.py
@@ -47,7 +47,7 @@ class MarkdownClient:
     @overload
     def render(
         self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     @overload
     def render(
@@ -58,7 +58,7 @@ class MarkdownClient:
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     def render(
         self,
@@ -66,7 +66,7 @@ class MarkdownClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document"""
 
         from ..models import MarkdownPostBody
@@ -95,7 +95,7 @@ class MarkdownClient:
     @overload
     async def async_render(
         self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     @overload
     async def async_render(
@@ -106,7 +106,7 @@ class MarkdownClient:
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[str]: ...
+    ) -> Response[str, str]: ...
 
     async def async_render(
         self,
@@ -114,7 +114,7 @@ class MarkdownClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document"""
 
         from ..models import MarkdownPostBody
@@ -145,7 +145,7 @@ class MarkdownClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: str,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""
 
         url = "/markdown/raw"
@@ -171,7 +171,7 @@ class MarkdownClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: str,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""
 
         url = "/markdown/raw"

--- a/githubkit/versions/v2022_11_28/rest/meta.py
+++ b/githubkit/versions/v2022_11_28/rest/meta.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import Root, ApiOverview
+    from ..types import RootType, ApiOverviewType
 
 
 class MetaClient:
@@ -45,7 +46,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Root]:
+    ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/rest/meta/meta#github-api-root"""
 
         from ..models import Root
@@ -65,7 +66,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Root]:
+    ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/rest/meta/meta#github-api-root"""
 
         from ..models import Root
@@ -85,7 +86,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiOverview]:
+    ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/rest/meta/meta#get-apiname-meta-information"""
 
         from ..models import ApiOverview
@@ -105,7 +106,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiOverview]:
+    ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/rest/meta/meta#get-apiname-meta-information"""
 
         from ..models import ApiOverview
@@ -126,7 +127,7 @@ class MetaClient:
         s: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-octocat"""
 
         url = "/octocat"
@@ -150,7 +151,7 @@ class MetaClient:
         s: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-octocat"""
 
         url = "/octocat"
@@ -173,7 +174,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[date]]:
+    ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/rest/meta/meta#get-all-api-versions"""
 
         from datetime import date
@@ -198,7 +199,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[date]]:
+    ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/rest/meta/meta#get-all-api-versions"""
 
         from datetime import date
@@ -223,7 +224,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-the-zen-of-github"""
 
         url = "/zen"
@@ -241,7 +242,7 @@ class MetaClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[str]:
+    ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-the-zen-of-github"""
 
         url = "/zen"

--- a/githubkit/versions/v2022_11_28/rest/migrations.py
+++ b/githubkit/versions/v2022_11_28/rest/migrations.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
         MinimalRepository,
     )
     from ..types import (
+        ImportType,
+        MigrationType,
+        PorterAuthorType,
+        PorterLargeFileType,
+        MinimalRepositoryType,
         UserMigrationsPostBodyType,
         OrgsOrgMigrationsPostBodyType,
         ReposOwnerRepoImportPutBodyType,
@@ -66,7 +71,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-organization-migrations"""
 
         from ..models import Migration
@@ -97,7 +102,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-organization-migrations"""
 
         from ..models import Migration
@@ -127,7 +132,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     def start_for_org(
@@ -145,7 +150,7 @@ class MigrationsClient:
         exclude_owner_projects: Missing[bool] = UNSET,
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     def start_for_org(
         self,
@@ -154,7 +159,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/orgs#start-an-organization-migration"""
 
         from ..models import (
@@ -196,7 +201,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     async def async_start_for_org(
@@ -214,7 +219,7 @@ class MigrationsClient:
         exclude_owner_projects: Missing[bool] = UNSET,
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     async def async_start_for_org(
         self,
@@ -223,7 +228,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/orgs#start-an-organization-migration"""
 
         from ..models import (
@@ -265,7 +270,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/orgs#get-an-organization-migration-status"""
 
         from ..models import Migration, BasicError
@@ -296,7 +301,7 @@ class MigrationsClient:
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/orgs#get-an-organization-migration-status"""
 
         from ..models import Migration, BasicError
@@ -474,7 +479,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
         from ..models import BasicError, MinimalRepository
@@ -507,7 +512,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
         from ..models import BasicError, MinimalRepository
@@ -538,7 +543,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-an-import-status"""
 
         from ..models import Import, BasicError
@@ -564,7 +569,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-an-import-status"""
 
         from ..models import Import, BasicError
@@ -592,7 +597,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     def start_import(
@@ -607,7 +612,7 @@ class MigrationsClient:
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     def start_import(
         self,
@@ -617,7 +622,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#start-an-import"""
 
         from ..models import (
@@ -661,7 +666,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     async def async_start_import(
@@ -676,7 +681,7 @@ class MigrationsClient:
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     async def async_start_import(
         self,
@@ -686,7 +691,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#start-an-import"""
 
         from ..models import (
@@ -778,7 +783,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     def update_import(
@@ -792,7 +797,7 @@ class MigrationsClient:
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     def update_import(
         self,
@@ -802,7 +807,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#update-an-import"""
 
         from typing import Union
@@ -843,7 +848,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     async def async_update_import(
@@ -857,7 +862,7 @@ class MigrationsClient:
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
         tfvc_project: Missing[str] = UNSET,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     async def async_update_import(
         self,
@@ -867,7 +872,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#update-an-import"""
 
         from typing import Union
@@ -907,7 +912,7 @@ class MigrationsClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterAuthor]]:
+    ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-commit-authors"""
 
         from ..models import BasicError, PorterAuthor
@@ -939,7 +944,7 @@ class MigrationsClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterAuthor]]:
+    ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-commit-authors"""
 
         from ..models import BasicError, PorterAuthor
@@ -973,7 +978,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     @overload
     def map_commit_author(
@@ -986,7 +991,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     def map_commit_author(
         self,
@@ -997,7 +1002,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PorterAuthor]:
+    ) -> Response[PorterAuthor, PorterAuthorType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#map-a-commit-author"""
 
         from ..models import (
@@ -1044,7 +1049,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     @overload
     async def async_map_commit_author(
@@ -1057,7 +1062,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[PorterAuthor]: ...
+    ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
     async def async_map_commit_author(
         self,
@@ -1068,7 +1073,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PorterAuthor]:
+    ) -> Response[PorterAuthor, PorterAuthorType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#map-a-commit-author"""
 
         from ..models import (
@@ -1112,7 +1117,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterLargeFile]]:
+    ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-large-files"""
 
         from ..models import BasicError, PorterLargeFile
@@ -1137,7 +1142,7 @@ class MigrationsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PorterLargeFile]]:
+    ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-large-files"""
 
         from ..models import BasicError, PorterLargeFile
@@ -1164,7 +1169,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     def set_lfs_preference(
@@ -1175,7 +1180,7 @@ class MigrationsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     def set_lfs_preference(
         self,
@@ -1185,7 +1190,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#update-git-lfs-preference"""
 
         from ..models import (
@@ -1228,7 +1233,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     @overload
     async def async_set_lfs_preference(
@@ -1239,7 +1244,7 @@ class MigrationsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
-    ) -> Response[Import]: ...
+    ) -> Response[Import, ImportType]: ...
 
     async def async_set_lfs_preference(
         self,
@@ -1249,7 +1254,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Import]:
+    ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#update-git-lfs-preference"""
 
         from ..models import (
@@ -1290,7 +1295,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-user-migrations"""
 
         from ..models import Migration, BasicError
@@ -1322,7 +1327,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Migration]]:
+    ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-user-migrations"""
 
         from ..models import Migration, BasicError
@@ -1354,7 +1359,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     def start_for_authenticated_user(
@@ -1371,7 +1376,7 @@ class MigrationsClient:
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         repositories: list[str],
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     def start_for_authenticated_user(
         self,
@@ -1379,7 +1384,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/users#start-a-user-migration"""
 
         from ..models import (
@@ -1421,7 +1426,7 @@ class MigrationsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMigrationsPostBodyType,
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     @overload
     async def async_start_for_authenticated_user(
@@ -1438,7 +1443,7 @@ class MigrationsClient:
         org_metadata_only: Missing[bool] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
         repositories: list[str],
-    ) -> Response[Migration]: ...
+    ) -> Response[Migration, MigrationType]: ...
 
     async def async_start_for_authenticated_user(
         self,
@@ -1446,7 +1451,7 @@ class MigrationsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/users#start-a-user-migration"""
 
         from ..models import (
@@ -1488,7 +1493,7 @@ class MigrationsClient:
         exclude: Missing[list[str]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/users#get-a-user-migration-status"""
 
         from ..models import Migration, BasicError
@@ -1520,7 +1525,7 @@ class MigrationsClient:
         exclude: Missing[list[str]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Migration]:
+    ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/users#get-a-user-migration-status"""
 
         from ..models import Migration, BasicError
@@ -1703,7 +1708,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-repositories-for-a-user-migration"""
 
         from ..models import BasicError, MinimalRepository
@@ -1735,7 +1740,7 @@ class MigrationsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-repositories-for-a-user-migration"""
 
         from ..models import BasicError, MinimalRepository

--- a/githubkit/versions/v2022_11_28/rest/oidc.py
+++ b/githubkit/versions/v2022_11_28/rest/oidc.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from githubkit import GitHubCore
     from githubkit.response import Response
 
-    from ..types import OidcCustomSubType
     from ..models import EmptyObject, OidcCustomSub
+    from ..types import EmptyObjectType, OidcCustomSubType
 
 
 class OidcClient:
@@ -46,7 +46,7 @@ class OidcClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSub]:
+    ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import OidcCustomSub
@@ -67,7 +67,7 @@ class OidcClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OidcCustomSub]:
+    ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import OidcCustomSub
@@ -90,7 +90,7 @@ class OidcClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OidcCustomSubType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     def update_oidc_custom_sub_template_for_org(
@@ -100,7 +100,7 @@ class OidcClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         include_claim_keys: list[str],
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     def update_oidc_custom_sub_template_for_org(
         self,
@@ -109,7 +109,7 @@ class OidcClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import BasicError, EmptyObject, OidcCustomSub
@@ -146,7 +146,7 @@ class OidcClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OidcCustomSubType,
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     @overload
     async def async_update_oidc_custom_sub_template_for_org(
@@ -156,7 +156,7 @@ class OidcClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         include_claim_keys: list[str],
-    ) -> Response[EmptyObject]: ...
+    ) -> Response[EmptyObject, EmptyObjectType]: ...
 
     async def async_update_oidc_custom_sub_template_for_org(
         self,
@@ -165,7 +165,7 @@ class OidcClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
-    ) -> Response[EmptyObject]:
+    ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
         from ..models import BasicError, EmptyObject, OidcCustomSub

--- a/githubkit/versions/v2022_11_28/rest/orgs.py
+++ b/githubkit/versions/v2022_11_28/rest/orgs.py
@@ -59,25 +59,53 @@ if TYPE_CHECKING:
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
     )
     from ..types import (
+        TeamType,
+        OrgHookType,
+        SimpleUserType,
+        TeamSimpleType,
+        HookDeliveryType,
+        OrgMembershipType,
+        WebhookConfigType,
         CustomPropertyType,
+        HookDeliveryItemType,
+        OrganizationFullType,
+        OrganizationRoleType,
         OrgsOrgPatchBodyType,
+        MinimalRepositoryType,
+        OrganizationSimpleType,
+        TeamRoleAssignmentType,
+        UserRoleAssignmentType,
         CustomPropertyValueType,
         OrgsOrgHooksPostBodyType,
+        OrganizationInvitationType,
+        ApiInsightsSummaryStatsType,
+        ApiInsightsTimeStatsItemsType,
+        ApiInsightsUserStatsItemsType,
+        ApiInsightsRouteStatsItemsType,
         OrgsOrgInvitationsPostBodyType,
+        OrgRepoCustomPropertyValuesType,
         OrgsOrgHooksHookIdPatchBodyType,
+        ApiInsightsSubjectStatsItemsType,
         OrgsOrgHooksPostBodyPropConfigType,
         UserMembershipsOrgsOrgPatchBodyType,
         OrgsOrgPropertiesSchemaPatchBodyType,
         OrgsOrgPropertiesValuesPatchBodyType,
         OrgsOrgHooksHookIdConfigPatchBodyType,
         OrgsOrgMembershipsUsernamePutBodyType,
+        OrgsOrgInstallationsGetResponse200Type,
+        OrganizationProgrammaticAccessGrantType,
         OrgsOrgPersonalAccessTokensPostBodyType,
         OrgsOrgHooksHookIdPatchBodyPropConfigType,
+        OrgsOrgOrganizationRolesGetResponse200Type,
         OrgsOrgPersonalAccessTokensPatIdPostBodyType,
         OrgsOrgSecurityProductEnablementPostBodyType,
+        OrganizationProgrammaticAccessGrantRequestType,
         OrgsOrgOutsideCollaboratorsUsernamePutBodyType,
         OrgsOrgPersonalAccessTokenRequestsPostBodyType,
+        OrgsOrgAttestationsSubjectDigestGetResponse200Type,
         OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
     )
 
@@ -103,7 +131,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations"""
 
         from ..models import OrganizationSimple
@@ -131,7 +159,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations"""
 
         from ..models import OrganizationSimple
@@ -158,7 +186,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/rest/orgs/orgs#get-an-organization"""
 
         from ..models import BasicError, OrganizationFull
@@ -182,7 +210,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/rest/orgs/orgs#get-an-organization"""
 
         from ..models import BasicError, OrganizationFull
@@ -206,7 +234,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/orgs#delete-an-organization"""
 
         from ..models import (
@@ -234,7 +265,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/orgs#delete-an-organization"""
 
         from ..models import (
@@ -264,7 +298,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     @overload
     def update(
@@ -308,7 +342,7 @@ class OrgsClient:
         ] = UNSET,
         secret_scanning_push_protection_custom_link_enabled: Missing[bool] = UNSET,
         secret_scanning_push_protection_custom_link: Missing[str] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     def update(
         self,
@@ -317,7 +351,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/rest/orgs/orgs#update-an-organization"""
 
         from typing import Union
@@ -362,7 +396,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     @overload
     async def async_update(
@@ -406,7 +440,7 @@ class OrgsClient:
         ] = UNSET,
         secret_scanning_push_protection_custom_link_enabled: Missing[bool] = UNSET,
         secret_scanning_push_protection_custom_link: Missing[str] = UNSET,
-    ) -> Response[OrganizationFull]: ...
+    ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
     async def async_update(
         self,
@@ -415,7 +449,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationFull]:
+    ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/rest/orgs/orgs#update-an-organization"""
 
         from typing import Union
@@ -462,7 +496,10 @@ class OrgsClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        OrgsOrgAttestationsSubjectDigestGetResponse200,
+        OrgsOrgAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-attestations"""
 
         from ..models import OrgsOrgAttestationsSubjectDigestGetResponse200
@@ -494,7 +531,10 @@ class OrgsClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        OrgsOrgAttestationsSubjectDigestGetResponse200,
+        OrgsOrgAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-attestations"""
 
         from ..models import OrgsOrgAttestationsSubjectDigestGetResponse200
@@ -524,7 +564,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
         from ..models import SimpleUser
@@ -553,7 +593,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
         from ..models import SimpleUser
@@ -716,7 +756,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-failed-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -748,7 +788,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-failed-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -780,7 +820,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgHook]]:
+    ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-organization-webhooks"""
 
         from ..models import OrgHook, BasicError
@@ -812,7 +852,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgHook]]:
+    ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-organization-webhooks"""
 
         from ..models import OrgHook, BasicError
@@ -844,7 +884,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     def create_webhook(
@@ -857,7 +897,7 @@ class OrgsClient:
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     def create_webhook(
         self,
@@ -866,7 +906,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#create-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError, ValidationError, OrgsOrgHooksPostBody
@@ -903,7 +943,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     async def async_create_webhook(
@@ -916,7 +956,7 @@ class OrgsClient:
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     async def async_create_webhook(
         self,
@@ -925,7 +965,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#create-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError, ValidationError, OrgsOrgHooksPostBody
@@ -961,7 +1001,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError
@@ -986,7 +1026,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-an-organization-webhook"""
 
         from ..models import OrgHook, BasicError
@@ -1061,7 +1101,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     def update_webhook(
@@ -1075,7 +1115,7 @@ class OrgsClient:
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     def update_webhook(
         self,
@@ -1085,7 +1125,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#update-an-organization-webhook"""
 
         from ..models import (
@@ -1128,7 +1168,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     @overload
     async def async_update_webhook(
@@ -1142,7 +1182,7 @@ class OrgsClient:
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
         name: Missing[str] = UNSET,
-    ) -> Response[OrgHook]: ...
+    ) -> Response[OrgHook, OrgHookType]: ...
 
     async def async_update_webhook(
         self,
@@ -1152,7 +1192,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgHook]:
+    ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#update-an-organization-webhook"""
 
         from ..models import (
@@ -1193,7 +1233,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig
@@ -1215,7 +1255,7 @@ class OrgsClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig
@@ -1239,7 +1279,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     def update_webhook_config_for_org(
@@ -1253,7 +1293,7 @@ class OrgsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     def update_webhook_config_for_org(
         self,
@@ -1263,7 +1303,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#update-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig, OrgsOrgHooksHookIdConfigPatchBody
@@ -1297,7 +1337,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     async def async_update_webhook_config_for_org(
@@ -1311,7 +1351,7 @@ class OrgsClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     async def async_update_webhook_config_for_org(
         self,
@@ -1321,7 +1361,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#update-a-webhook-configuration-for-an-organization"""
 
         from ..models import WebhookConfig, OrgsOrgHooksHookIdConfigPatchBody
@@ -1355,7 +1395,7 @@ class OrgsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -1389,7 +1429,7 @@ class OrgsClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -1422,7 +1462,7 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -1449,7 +1489,7 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -1476,7 +1516,10 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/webhooks#redeliver-a-delivery-for-an-organization-webhook"""
 
         from ..models import (
@@ -1507,7 +1550,10 @@ class OrgsClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/webhooks#redeliver-a-delivery-for-an-organization-webhook"""
 
         from ..models import (
@@ -1609,7 +1655,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsRouteStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
+    ]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-route-stats-by-actor"""
 
         from ..models import ApiInsightsRouteStatsItems
@@ -1665,7 +1713,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsRouteStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
+    ]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-route-stats-by-actor"""
 
         from ..models import ApiInsightsRouteStatsItems
@@ -1712,7 +1762,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsSubjectStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
+    ]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-subject-stats"""
 
         from ..models import ApiInsightsSubjectStatsItems
@@ -1759,7 +1811,9 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsSubjectStatsItems]]:
+    ) -> Response[
+        list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
+    ]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-subject-stats"""
 
         from ..models import ApiInsightsSubjectStatsItems
@@ -1792,7 +1846,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats"""
 
         from ..models import ApiInsightsSummaryStats
@@ -1821,7 +1875,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats"""
 
         from ..models import ApiInsightsSummaryStats
@@ -1851,7 +1905,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-user"""
 
         from ..models import ApiInsightsSummaryStats
@@ -1881,7 +1935,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-user"""
 
         from ..models import ApiInsightsSummaryStats
@@ -1918,7 +1972,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-actor"""
 
         from ..models import ApiInsightsSummaryStats
@@ -1955,7 +2009,7 @@ class OrgsClient:
         max_timestamp: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ApiInsightsSummaryStats]:
+    ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-actor"""
 
         from ..models import ApiInsightsSummaryStats
@@ -1985,7 +2039,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -2016,7 +2070,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -2048,7 +2102,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-user"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -2080,7 +2134,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-user"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -2119,7 +2173,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-actor"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -2158,7 +2212,7 @@ class OrgsClient:
         timestamp_increment: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsTimeStatsItems]]:
+    ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-actor"""
 
         from ..models import ApiInsightsTimeStatsItems
@@ -2203,7 +2257,7 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsUserStatsItems]]:
+    ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-user-stats"""
 
         from ..models import ApiInsightsUserStatsItems
@@ -2251,7 +2305,7 @@ class OrgsClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ApiInsightsUserStatsItems]]:
+    ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-user-stats"""
 
         from ..models import ApiInsightsUserStatsItems
@@ -2284,7 +2338,9 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgInstallationsGetResponse200]:
+    ) -> Response[
+        OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-app-installations-for-an-organization"""
 
         from ..models import OrgsOrgInstallationsGetResponse200
@@ -2313,7 +2369,9 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgInstallationsGetResponse200]:
+    ) -> Response[
+        OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-app-installations-for-an-organization"""
 
         from ..models import OrgsOrgInstallationsGetResponse200
@@ -2348,7 +2406,7 @@ class OrgsClient:
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-pending-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -2388,7 +2446,7 @@ class OrgsClient:
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-pending-organization-invitations"""
 
         from ..models import BasicError, OrganizationInvitation
@@ -2422,7 +2480,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     @overload
     def create_invitation(
@@ -2437,7 +2495,7 @@ class OrgsClient:
             Literal["admin", "direct_member", "billing_manager", "reinstate"]
         ] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     def create_invitation(
         self,
@@ -2446,7 +2504,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationInvitation]:
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
         """See also: https://docs.github.com/rest/orgs/members#create-an-organization-invitation"""
 
         from ..models import (
@@ -2488,7 +2546,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     @overload
     async def async_create_invitation(
@@ -2503,7 +2561,7 @@ class OrgsClient:
             Literal["admin", "direct_member", "billing_manager", "reinstate"]
         ] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[OrganizationInvitation]: ...
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
     async def async_create_invitation(
         self,
@@ -2512,7 +2570,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrganizationInvitation]:
+    ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
         """See also: https://docs.github.com/rest/orgs/members#create-an-organization-invitation"""
 
         from ..models import (
@@ -2605,7 +2663,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-invitation-teams"""
 
         from ..models import Team, BasicError
@@ -2638,7 +2696,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-invitation-teams"""
 
         from ..models import Team, BasicError
@@ -2672,7 +2730,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-members"""
 
         from ..models import SimpleUser, ValidationError
@@ -2708,7 +2766,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-members"""
 
         from ..models import SimpleUser, ValidationError
@@ -2829,7 +2887,7 @@ class OrgsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-organization-membership-for-a-user"""
 
         from ..models import BasicError, OrgMembership
@@ -2855,7 +2913,7 @@ class OrgsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-organization-membership-for-a-user"""
 
         from ..models import BasicError, OrgMembership
@@ -2883,7 +2941,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     def set_membership_for_user(
@@ -2894,7 +2952,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     def set_membership_for_user(
         self,
@@ -2904,7 +2962,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user"""
 
         from ..models import (
@@ -2947,7 +3005,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     async def async_set_membership_for_user(
@@ -2958,7 +3016,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     async def async_set_membership_for_user(
         self,
@@ -2968,7 +3026,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user"""
 
         from ..models import (
@@ -3058,7 +3116,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgOrganizationRolesGetResponse200]:
+    ) -> Response[
+        OrgsOrgOrganizationRolesGetResponse200,
+        OrgsOrgOrganizationRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#get-all-organization-roles-for-an-organization"""
 
         from ..models import (
@@ -3087,7 +3148,10 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgsOrgOrganizationRolesGetResponse200]:
+    ) -> Response[
+        OrgsOrgOrganizationRolesGetResponse200,
+        OrgsOrgOrganizationRolesGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#get-all-organization-roles-for-an-organization"""
 
         from ..models import (
@@ -3357,7 +3421,7 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#get-an-organization-role"""
 
         from ..models import BasicError, ValidationError, OrganizationRole
@@ -3383,7 +3447,7 @@ class OrgsClient:
         role_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrganizationRole]:
+    ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#get-an-organization-role"""
 
         from ..models import BasicError, ValidationError, OrganizationRole
@@ -3411,7 +3475,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamRoleAssignment]]:
+    ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
         from ..models import TeamRoleAssignment
@@ -3442,7 +3506,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamRoleAssignment]]:
+    ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
         from ..models import TeamRoleAssignment
@@ -3473,7 +3537,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserRoleAssignment]]:
+    ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
         from ..models import UserRoleAssignment
@@ -3504,7 +3568,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[UserRoleAssignment]]:
+    ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
         from ..models import UserRoleAssignment
@@ -3535,7 +3599,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
         from ..models import SimpleUser
@@ -3566,7 +3630,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
         from ..models import SimpleUser
@@ -3597,7 +3661,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     @overload
     def convert_member_to_outside_collaborator(
@@ -3608,7 +3675,10 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         async_: Missing[bool] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     def convert_member_to_outside_collaborator(
         self,
@@ -3618,7 +3688,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]:
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator"""
 
         from ..models import (
@@ -3661,7 +3734,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     @overload
     async def async_convert_member_to_outside_collaborator(
@@ -3672,7 +3748,10 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         async_: Missing[bool] = UNSET,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]: ...
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]: ...
 
     async def async_convert_member_to_outside_collaborator(
         self,
@@ -3682,7 +3761,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgsOrgOutsideCollaboratorsUsernamePutResponse202]:
+    ) -> Response[
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
+        OrgsOrgOutsideCollaboratorsUsernamePutResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#convert-an-organization-member-to-outside-collaborator"""
 
         from ..models import (
@@ -3779,7 +3861,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrantRequest]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrantRequest],
+        list[OrganizationProgrammaticAccessGrantRequestType],
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -3832,7 +3917,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrantRequest]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrantRequest],
+        list[OrganizationProgrammaticAccessGrantRequestType],
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -3878,7 +3966,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     def review_pat_grant_requests_in_bulk(
@@ -3890,7 +3981,10 @@ class OrgsClient:
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     def review_pat_grant_requests_in_bulk(
         self,
@@ -3899,7 +3993,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#review-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -3945,7 +4042,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     async def async_review_pat_grant_requests_in_bulk(
@@ -3957,7 +4057,10 @@ class OrgsClient:
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     async def async_review_pat_grant_requests_in_bulk(
         self,
@@ -3966,7 +4069,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#review-requests-to-access-organization-resources-with-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -4151,7 +4257,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
         from ..models import BasicError, MinimalRepository
@@ -4188,7 +4294,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
         from ..models import BasicError, MinimalRepository
@@ -4231,7 +4337,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrant]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrant],
+        list[OrganizationProgrammaticAccessGrantType],
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-fine-grained-personal-access-tokens-with-access-to-organization-resources"""
 
         from ..models import (
@@ -4284,7 +4393,10 @@ class OrgsClient:
         last_used_after: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationProgrammaticAccessGrant]]:
+    ) -> Response[
+        list[OrganizationProgrammaticAccessGrant],
+        list[OrganizationProgrammaticAccessGrantType],
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-fine-grained-personal-access-tokens-with-access-to-organization-resources"""
 
         from ..models import (
@@ -4330,7 +4442,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     def update_pat_accesses(
@@ -4341,7 +4456,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     def update_pat_accesses(
         self,
@@ -4350,7 +4468,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#update-the-access-to-organization-resources-via-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -4394,7 +4515,10 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     @overload
     async def async_update_pat_accesses(
@@ -4405,7 +4529,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]: ...
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]: ...
 
     async def async_update_pat_accesses(
         self,
@@ -4414,7 +4541,10 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#update-the-access-to-organization-resources-via-fine-grained-personal-access-tokens"""
 
         from ..models import (
@@ -4587,7 +4717,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
         from ..models import BasicError, MinimalRepository
@@ -4622,7 +4752,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
         from ..models import BasicError, MinimalRepository
@@ -4654,7 +4784,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -4679,7 +4809,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -4706,7 +4836,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     @overload
     def create_or_update_custom_properties(
@@ -4716,7 +4846,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         properties: list[CustomPropertyType],
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     def create_or_update_custom_properties(
         self,
@@ -4725,7 +4855,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#create-or-update-custom-properties-for-an-organization"""
 
         from ..models import (
@@ -4766,7 +4896,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     @overload
     async def async_create_or_update_custom_properties(
@@ -4776,7 +4906,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         properties: list[CustomPropertyType],
-    ) -> Response[list[CustomProperty]]: ...
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
     async def async_create_or_update_custom_properties(
         self,
@@ -4785,7 +4915,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[CustomProperty]]:
+    ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#create-or-update-custom-properties-for-an-organization"""
 
         from ..models import (
@@ -4825,7 +4955,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -4851,7 +4981,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
         from ..models import BasicError, CustomProperty
@@ -4879,7 +5009,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     @overload
     def create_or_update_custom_property(
@@ -4894,7 +5024,7 @@ class OrgsClient:
         default_value: Missing[Union[str, list[str], None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         allowed_values: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     def create_or_update_custom_property(
         self,
@@ -4904,7 +5034,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#create-or-update-a-custom-property-for-an-organization"""
 
         from ..models import (
@@ -4948,7 +5078,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     @overload
     async def async_create_or_update_custom_property(
@@ -4963,7 +5093,7 @@ class OrgsClient:
         default_value: Missing[Union[str, list[str], None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         allowed_values: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[CustomProperty]: ...
+    ) -> Response[CustomProperty, CustomPropertyType]: ...
 
     async def async_create_or_update_custom_property(
         self,
@@ -4973,7 +5103,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaCustomPropertyNamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CustomProperty]:
+    ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#create-or-update-a-custom-property-for-an-organization"""
 
         from ..models import (
@@ -5067,7 +5197,9 @@ class OrgsClient:
         repository_query: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgRepoCustomPropertyValues]]:
+    ) -> Response[
+        list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
+    ]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#list-custom-property-values-for-organization-repositories"""
 
         from ..models import BasicError, OrgRepoCustomPropertyValues
@@ -5102,7 +5234,9 @@ class OrgsClient:
         repository_query: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgRepoCustomPropertyValues]]:
+    ) -> Response[
+        list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
+    ]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#list-custom-property-values-for-organization-repositories"""
 
         from ..models import BasicError, OrgRepoCustomPropertyValues
@@ -5258,7 +5392,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-public-organization-members"""
 
         from ..models import SimpleUser
@@ -5287,7 +5421,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-public-organization-members"""
 
         from ..models import SimpleUser
@@ -5440,7 +5574,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamSimple]]:
+    ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/security-managers#list-security-manager-teams"""
 
         from ..models import TeamSimple
@@ -5461,7 +5595,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamSimple]]:
+    ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/security-managers#list-security-manager-teams"""
 
         from ..models import TeamSimple
@@ -5724,7 +5858,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgMembership]]:
+    ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership, ValidationError
@@ -5759,7 +5893,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrgMembership]]:
+    ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership, ValidationError
@@ -5792,7 +5926,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership
@@ -5817,7 +5951,7 @@ class OrgsClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import BasicError, OrgMembership
@@ -5844,7 +5978,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     def update_membership_for_authenticated_user(
@@ -5854,7 +5988,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         state: Literal["active"],
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     def update_membership_for_authenticated_user(
         self,
@@ -5863,7 +5997,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#update-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import (
@@ -5906,7 +6040,7 @@ class OrgsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     @overload
     async def async_update_membership_for_authenticated_user(
@@ -5916,7 +6050,7 @@ class OrgsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         state: Literal["active"],
-    ) -> Response[OrgMembership]: ...
+    ) -> Response[OrgMembership, OrgMembershipType]: ...
 
     async def async_update_membership_for_authenticated_user(
         self,
@@ -5925,7 +6059,7 @@ class OrgsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[OrgMembership]:
+    ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#update-an-organization-membership-for-the-authenticated-user"""
 
         from ..models import (
@@ -5967,7 +6101,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
         from ..models import BasicError, OrganizationSimple
@@ -5999,7 +6133,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
         from ..models import BasicError, OrganizationSimple
@@ -6032,7 +6166,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-a-user"""
 
         from ..models import OrganizationSimple
@@ -6061,7 +6195,7 @@ class OrgsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSimple]]:
+    ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-a-user"""
 
         from ..models import OrganizationSimple

--- a/githubkit/versions/v2022_11_28/rest/packages.py
+++ b/githubkit/versions/v2022_11_28/rest/packages.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import Package, PackageVersion
+    from ..types import PackageType, PackageVersionType
 
 
 class PackagesClient:
@@ -46,7 +47,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
         from ..models import Package, BasicError
@@ -71,7 +72,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
         from ..models import Package, BasicError
@@ -102,7 +103,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-an-organization"""
 
         from ..models import Package, BasicError
@@ -141,7 +142,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-an-organization"""
 
         from ..models import Package, BasicError
@@ -178,7 +179,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization"""
 
         from ..models import Package
@@ -203,7 +204,7 @@ class PackagesClient:
         org: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization"""
 
         from ..models import Package
@@ -359,7 +360,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
         from ..models import BasicError, PackageVersion
@@ -399,7 +400,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
         from ..models import BasicError, PackageVersion
@@ -437,7 +438,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization"""
 
         from ..models import PackageVersion
@@ -463,7 +464,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization"""
 
         from ..models import PackageVersion
@@ -603,7 +604,7 @@ class PackagesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
         from ..models import Package
@@ -623,7 +624,7 @@ class PackagesClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
         from ..models import Package
@@ -649,7 +650,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
         from ..models import Package
@@ -684,7 +685,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
         from ..models import Package
@@ -717,7 +718,7 @@ class PackagesClient:
         package_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
         from ..models import Package
@@ -741,7 +742,7 @@ class PackagesClient:
         package_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
         from ..models import Package
@@ -892,7 +893,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
         from ..models import BasicError, PackageVersion
@@ -931,7 +932,7 @@ class PackagesClient:
         state: Missing[Literal["active", "deleted"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
         from ..models import BasicError, PackageVersion
@@ -968,7 +969,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
         from ..models import PackageVersion
@@ -993,7 +994,7 @@ class PackagesClient:
         package_version_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
         from ..models import PackageVersion
@@ -1130,7 +1131,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
         from ..models import Package, BasicError
@@ -1155,7 +1156,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
         from ..models import Package, BasicError
@@ -1186,7 +1187,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-a-user"""
 
         from ..models import Package, BasicError
@@ -1225,7 +1226,7 @@ class PackagesClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Package]]:
+    ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-a-user"""
 
         from ..models import Package, BasicError
@@ -1262,7 +1263,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-a-user"""
 
         from ..models import Package
@@ -1287,7 +1288,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Package]:
+    ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-a-user"""
 
         from ..models import Package
@@ -1440,7 +1441,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
         from ..models import BasicError, PackageVersion
@@ -1470,7 +1471,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PackageVersion]]:
+    ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
         from ..models import BasicError, PackageVersion
@@ -1501,7 +1502,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-a-user"""
 
         from ..models import PackageVersion
@@ -1527,7 +1528,7 @@ class PackagesClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PackageVersion]:
+    ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-a-user"""
 
         from ..models import PackageVersion

--- a/githubkit/versions/v2022_11_28/rest/projects.py
+++ b/githubkit/versions/v2022_11_28/rest/projects.py
@@ -36,9 +36,14 @@ if TYPE_CHECKING:
         ProjectsColumnsCardsCardIdMovesPostResponse201,
     )
     from ..types import (
+        ProjectType,
+        SimpleUserType,
+        ProjectCardType,
+        ProjectColumnType,
         UserProjectsPostBodyType,
         OrgsOrgProjectsPostBodyType,
         ProjectsProjectIdPatchBodyType,
+        ProjectCollaboratorPermissionType,
         ReposOwnerRepoProjectsPostBodyType,
         ProjectsColumnsColumnIdPatchBodyType,
         ProjectsProjectIdColumnsPostBodyType,
@@ -47,7 +52,9 @@ if TYPE_CHECKING:
         ProjectsColumnsCardsCardIdMovesPostBodyType,
         ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
         ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
         ProjectsProjectIdCollaboratorsUsernamePutBodyType,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
     )
 
 
@@ -74,7 +81,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-organization-projects"""
 
         from ..models import Project, ValidationErrorSimple
@@ -108,7 +115,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-organization-projects"""
 
         from ..models import Project, ValidationErrorSimple
@@ -141,7 +148,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def create_for_org(
@@ -152,7 +159,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def create_for_org(
         self,
@@ -161,7 +168,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#create-an-organization-project"""
 
         from ..models import (
@@ -206,7 +213,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_create_for_org(
@@ -217,7 +224,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_create_for_org(
         self,
@@ -226,7 +233,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#create-an-organization-project"""
 
         from ..models import (
@@ -269,7 +276,7 @@ class ProjectsClient:
         card_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#get-a-project-card"""
 
         from ..models import BasicError, ProjectCard
@@ -295,7 +302,7 @@ class ProjectsClient:
         card_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#get-a-project-card"""
 
         from ..models import BasicError, ProjectCard
@@ -373,7 +380,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     def update_card(
@@ -384,7 +391,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     def update_card(
         self,
@@ -393,7 +400,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#update-an-existing-project-card"""
 
         from ..models import (
@@ -437,7 +444,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     async def async_update_card(
@@ -448,7 +455,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     async def async_update_card(
         self,
@@ -457,7 +464,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#update-an-existing-project-card"""
 
         from ..models import (
@@ -501,7 +508,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     def move_card(
@@ -512,7 +522,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     def move_card(
         self,
@@ -521,7 +534,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/projects/cards#move-a-project-card"""
 
         from ..models import (
@@ -567,7 +583,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_move_card(
@@ -578,7 +597,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]: ...
 
     async def async_move_card(
         self,
@@ -587,7 +609,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsCardsCardIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsCardsCardIdMovesPostResponse201,
+        ProjectsColumnsCardsCardIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/projects/cards#move-a-project-card"""
 
         from ..models import (
@@ -631,7 +656,7 @@ class ProjectsClient:
         column_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#get-a-project-column"""
 
         from ..models import BasicError, ProjectColumn
@@ -657,7 +682,7 @@ class ProjectsClient:
         column_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#get-a-project-column"""
 
         from ..models import BasicError, ProjectColumn
@@ -733,7 +758,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     def update_column(
@@ -743,7 +768,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     def update_column(
         self,
@@ -752,7 +777,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#update-an-existing-project-column"""
 
         from ..models import BasicError, ProjectColumn, ProjectsColumnsColumnIdPatchBody
@@ -789,7 +814,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     async def async_update_column(
@@ -799,7 +824,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     async def async_update_column(
         self,
@@ -808,7 +833,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#update-an-existing-project-column"""
 
         from ..models import BasicError, ProjectColumn, ProjectsColumnsColumnIdPatchBody
@@ -846,7 +871,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectCard]]:
+    ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/rest/projects/cards#list-project-cards"""
 
         from ..models import BasicError, ProjectCard
@@ -881,7 +906,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectCard]]:
+    ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/rest/projects/cards#list-project-cards"""
 
         from ..models import BasicError, ProjectCard
@@ -918,7 +943,7 @@ class ProjectsClient:
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
         ],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     def create_card(
@@ -928,7 +953,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         note: Union[str, None],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     def create_card(
@@ -939,7 +964,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         content_id: int,
         content_type: str,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     def create_card(
         self,
@@ -953,7 +978,7 @@ class ProjectsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#create-a-project-card"""
 
         from typing import Union
@@ -1011,7 +1036,7 @@ class ProjectsClient:
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
         ],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     async def async_create_card(
@@ -1021,7 +1046,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         note: Union[str, None],
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     @overload
     async def async_create_card(
@@ -1032,7 +1057,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         content_id: int,
         content_type: str,
-    ) -> Response[ProjectCard]: ...
+    ) -> Response[ProjectCard, ProjectCardType]: ...
 
     async def async_create_card(
         self,
@@ -1046,7 +1071,7 @@ class ProjectsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProjectCard]:
+    ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#create-a-project-card"""
 
         from typing import Union
@@ -1101,7 +1126,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     def move_column(
@@ -1111,7 +1139,10 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         position: str,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     def move_column(
         self,
@@ -1120,7 +1151,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/projects/columns#move-a-project-column"""
 
         from ..models import (
@@ -1163,7 +1197,10 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_move_column(
@@ -1173,7 +1210,10 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         position: str,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]: ...
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]: ...
 
     async def async_move_column(
         self,
@@ -1182,7 +1222,10 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectsColumnsColumnIdMovesPostResponse201]:
+    ) -> Response[
+        ProjectsColumnsColumnIdMovesPostResponse201,
+        ProjectsColumnsColumnIdMovesPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/projects/columns#move-a-project-column"""
 
         from ..models import (
@@ -1223,7 +1266,7 @@ class ProjectsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#get-a-project"""
 
         from ..models import Project, BasicError
@@ -1248,7 +1291,7 @@ class ProjectsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#get-a-project"""
 
         from ..models import Project, BasicError
@@ -1327,7 +1370,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def update(
@@ -1343,7 +1386,7 @@ class ProjectsClient:
             Literal["read", "write", "admin", "none"]
         ] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def update(
         self,
@@ -1352,7 +1395,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#update-a-project"""
 
         from ..models import (
@@ -1397,7 +1440,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_update(
@@ -1413,7 +1456,7 @@ class ProjectsClient:
             Literal["read", "write", "admin", "none"]
         ] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_update(
         self,
@@ -1422,7 +1465,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#update-a-project"""
 
         from ..models import (
@@ -1468,7 +1511,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/projects/collaborators#list-project-collaborators"""
 
         from ..models import BasicError, SimpleUser, ValidationError
@@ -1505,7 +1548,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/projects/collaborators#list-project-collaborators"""
 
         from ..models import BasicError, SimpleUser, ValidationError
@@ -1738,7 +1781,7 @@ class ProjectsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCollaboratorPermission]:
+    ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/rest/projects/collaborators#get-project-permission-for-a-user"""
 
         from ..models import BasicError, ValidationError, ProjectCollaboratorPermission
@@ -1766,7 +1809,7 @@ class ProjectsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProjectCollaboratorPermission]:
+    ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/rest/projects/collaborators#get-project-permission-for-a-user"""
 
         from ..models import BasicError, ValidationError, ProjectCollaboratorPermission
@@ -1795,7 +1838,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectColumn]]:
+    ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/rest/projects/columns#list-project-columns"""
 
         from ..models import BasicError, ProjectColumn
@@ -1828,7 +1871,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ProjectColumn]]:
+    ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/rest/projects/columns#list-project-columns"""
 
         from ..models import BasicError, ProjectColumn
@@ -1861,7 +1904,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     def create_column(
@@ -1871,7 +1914,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     def create_column(
         self,
@@ -1880,7 +1923,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#create-a-project-column"""
 
         from ..models import (
@@ -1923,7 +1966,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     @overload
     async def async_create_column(
@@ -1933,7 +1976,7 @@ class ProjectsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[ProjectColumn]: ...
+    ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
     async def async_create_column(
         self,
@@ -1942,7 +1985,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProjectColumn]:
+    ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#create-a-project-column"""
 
         from ..models import (
@@ -1987,7 +2030,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-repository-projects"""
 
         from ..models import Project, BasicError, ValidationErrorSimple
@@ -2026,7 +2069,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-repository-projects"""
 
         from ..models import Project, BasicError, ValidationErrorSimple
@@ -2064,7 +2107,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def create_for_repo(
@@ -2076,7 +2119,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def create_for_repo(
         self,
@@ -2086,7 +2129,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#create-a-repository-project"""
 
         from ..models import (
@@ -2132,7 +2175,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_create_for_repo(
@@ -2144,7 +2187,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_create_for_repo(
         self,
@@ -2154,7 +2197,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#create-a-repository-project"""
 
         from ..models import (
@@ -2198,7 +2241,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -2208,7 +2251,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     def create_for_authenticated_user(
         self,
@@ -2216,7 +2259,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#create-a-user-project"""
 
         from ..models import (
@@ -2258,7 +2301,7 @@ class ProjectsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserProjectsPostBodyType,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -2268,7 +2311,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
-    ) -> Response[Project]: ...
+    ) -> Response[Project, ProjectType]: ...
 
     async def async_create_for_authenticated_user(
         self,
@@ -2276,7 +2319,7 @@ class ProjectsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Project]:
+    ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#create-a-user-project"""
 
         from ..models import (
@@ -2320,7 +2363,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-user-projects"""
 
         from ..models import Project, ValidationError
@@ -2354,7 +2397,7 @@ class ProjectsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Project]]:
+    ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-user-projects"""
 
         from ..models import Project, ValidationError

--- a/githubkit/versions/v2022_11_28/rest/pulls.py
+++ b/githubkit/versions/v2022_11_28/rest/pulls.py
@@ -40,6 +40,15 @@ if TYPE_CHECKING:
         ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
     )
     from ..types import (
+        CommitType,
+        DiffEntryType,
+        PullRequestType,
+        ReviewCommentType,
+        PullRequestReviewType,
+        PullRequestSimpleType,
+        PullRequestMergeResultType,
+        PullRequestReviewCommentType,
+        PullRequestReviewRequestType,
         ReposOwnerRepoPullsPostBodyType,
         ReposOwnerRepoPullsPullNumberPatchBodyType,
         ReposOwnerRepoPullsPullNumberMergePutBodyType,
@@ -48,6 +57,7 @@ if TYPE_CHECKING:
         ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
         ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType,
         ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
         ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
         ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
         ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
@@ -88,7 +98,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests"""
 
         from ..models import ValidationError, PullRequestSimple
@@ -133,7 +143,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests"""
 
         from ..models import ValidationError, PullRequestSimple
@@ -171,7 +181,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     def create(
@@ -189,7 +199,7 @@ class PullsClient:
         maintainer_can_modify: Missing[bool] = UNSET,
         draft: Missing[bool] = UNSET,
         issue: Missing[int] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     def create(
         self,
@@ -199,7 +209,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#create-a-pull-request"""
 
         from ..models import (
@@ -242,7 +252,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     async def async_create(
@@ -260,7 +270,7 @@ class PullsClient:
         maintainer_can_modify: Missing[bool] = UNSET,
         draft: Missing[bool] = UNSET,
         issue: Missing[int] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     async def async_create(
         self,
@@ -270,7 +280,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#create-a-pull-request"""
 
         from ..models import (
@@ -316,7 +326,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-in-a-repository"""
 
         from ..models import PullRequestReviewComment
@@ -352,7 +362,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-in-a-repository"""
 
         from ..models import PullRequestReviewComment
@@ -384,7 +394,7 @@ class PullsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReviewComment
@@ -410,7 +420,7 @@ class PullsClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReviewComment
@@ -488,7 +498,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     def update_review_comment(
@@ -500,7 +510,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     def update_review_comment(
         self,
@@ -511,7 +521,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#update-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -551,7 +561,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     async def async_update_review_comment(
@@ -563,7 +573,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     async def async_update_review_comment(
         self,
@@ -574,7 +584,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#update-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -612,7 +622,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#get-a-pull-request"""
 
         from ..models import (
@@ -645,7 +655,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#get-a-pull-request"""
 
         from ..models import (
@@ -680,7 +690,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     def update(
@@ -696,7 +706,7 @@ class PullsClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         base: Missing[str] = UNSET,
         maintainer_can_modify: Missing[bool] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     def update(
         self,
@@ -707,7 +717,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#update-a-pull-request"""
 
         from ..models import (
@@ -751,7 +761,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     @overload
     async def async_update(
@@ -767,7 +777,7 @@ class PullsClient:
         state: Missing[Literal["open", "closed"]] = UNSET,
         base: Missing[str] = UNSET,
         maintainer_can_modify: Missing[bool] = UNSET,
-    ) -> Response[PullRequest]: ...
+    ) -> Response[PullRequest, PullRequestType]: ...
 
     async def async_update(
         self,
@@ -778,7 +788,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequest]:
+    ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#update-a-pull-request"""
 
         from ..models import (
@@ -825,7 +835,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
         from ..models import PullRequestReviewComment
@@ -862,7 +872,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReviewComment]]:
+    ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
         from ..models import PullRequestReviewComment
@@ -896,7 +906,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     def create_review_comment(
@@ -917,7 +927,7 @@ class PullsClient:
         start_side: Missing[Literal["LEFT", "RIGHT", "side"]] = UNSET,
         in_reply_to: Missing[int] = UNSET,
         subject_type: Missing[Literal["line", "file"]] = UNSET,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     def create_review_comment(
         self,
@@ -928,7 +938,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#create-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -974,7 +984,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     async def async_create_review_comment(
@@ -995,7 +1005,7 @@ class PullsClient:
         start_side: Missing[Literal["LEFT", "RIGHT", "side"]] = UNSET,
         in_reply_to: Missing[int] = UNSET,
         subject_type: Missing[Literal["line", "file"]] = UNSET,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     async def async_create_review_comment(
         self,
@@ -1006,7 +1016,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#create-a-review-comment-for-a-pull-request"""
 
         from ..models import (
@@ -1053,7 +1063,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     def create_reply_for_review_comment(
@@ -1066,7 +1076,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     def create_reply_for_review_comment(
         self,
@@ -1080,7 +1090,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#create-a-reply-for-a-review-comment"""
 
         from ..models import (
@@ -1125,7 +1135,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     @overload
     async def async_create_reply_for_review_comment(
@@ -1138,7 +1148,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReviewComment]: ...
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
     async def async_create_reply_for_review_comment(
         self,
@@ -1152,7 +1162,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReviewComment]:
+    ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#create-a-reply-for-a-review-comment"""
 
         from ..models import (
@@ -1196,7 +1206,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-commits-on-a-pull-request"""
 
         from ..models import Commit
@@ -1227,7 +1237,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-commits-on-a-pull-request"""
 
         from ..models import Commit
@@ -1258,7 +1268,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DiffEntry]]:
+    ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests-files"""
 
         from ..models import (
@@ -1299,7 +1309,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DiffEntry]]:
+    ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests-files"""
 
         from ..models import (
@@ -1384,7 +1394,7 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     @overload
     def merge(
@@ -1399,7 +1409,7 @@ class PullsClient:
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
         merge_method: Missing[Literal["merge", "squash", "rebase"]] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     def merge(
         self,
@@ -1412,7 +1422,7 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestMergeResult]:
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]:
         """See also: https://docs.github.com/rest/pulls/pulls#merge-a-pull-request"""
 
         from typing import Union
@@ -1467,7 +1477,7 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     @overload
     async def async_merge(
@@ -1482,7 +1492,7 @@ class PullsClient:
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
         merge_method: Missing[Literal["merge", "squash", "rebase"]] = UNSET,
-    ) -> Response[PullRequestMergeResult]: ...
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]: ...
 
     async def async_merge(
         self,
@@ -1495,7 +1505,7 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestMergeResult]:
+    ) -> Response[PullRequestMergeResult, PullRequestMergeResultType]:
         """See also: https://docs.github.com/rest/pulls/pulls#merge-a-pull-request"""
 
         from typing import Union
@@ -1546,7 +1556,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewRequest]:
+    ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
         from ..models import PullRequestReviewRequest
@@ -1569,7 +1579,7 @@ class PullsClient:
         pull_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReviewRequest]:
+    ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
         from ..models import PullRequestReviewRequest
@@ -1599,7 +1609,7 @@ class PullsClient:
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof1Type,
             ]
         ] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     def request_reviewers(
@@ -1612,7 +1622,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     def request_reviewers(
@@ -1625,7 +1635,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     def request_reviewers(
         self,
@@ -1641,7 +1651,7 @@ class PullsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request"""
 
         from typing import Union
@@ -1697,7 +1707,7 @@ class PullsClient:
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof1Type,
             ]
         ] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     async def async_request_reviewers(
@@ -1710,7 +1720,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     async def async_request_reviewers(
@@ -1723,7 +1733,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     async def async_request_reviewers(
         self,
@@ -1739,7 +1749,7 @@ class PullsClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request"""
 
         from typing import Union
@@ -1790,7 +1800,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     def remove_requested_reviewers(
@@ -1803,7 +1813,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     def remove_requested_reviewers(
         self,
@@ -1816,7 +1826,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request"""
 
         from ..models import (
@@ -1860,7 +1870,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     @overload
     async def async_remove_requested_reviewers(
@@ -1873,7 +1883,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
-    ) -> Response[PullRequestSimple]: ...
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
     async def async_remove_requested_reviewers(
         self,
@@ -1886,7 +1896,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestSimple]:
+    ) -> Response[PullRequestSimple, PullRequestSimpleType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#remove-requested-reviewers-from-a-pull-request"""
 
         from ..models import (
@@ -1930,7 +1940,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReview]]:
+    ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
         from ..models import PullRequestReview
@@ -1961,7 +1971,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestReview]]:
+    ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
         from ..models import PullRequestReview
@@ -1992,7 +2002,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def create_review(
@@ -2009,7 +2019,7 @@ class PullsClient:
         comments: Missing[
             list[ReposOwnerRepoPullsPullNumberReviewsPostBodyPropCommentsItemsType]
         ] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def create_review(
         self,
@@ -2020,7 +2030,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#create-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2066,7 +2076,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_create_review(
@@ -2083,7 +2093,7 @@ class PullsClient:
         comments: Missing[
             list[ReposOwnerRepoPullsPullNumberReviewsPostBodyPropCommentsItemsType]
         ] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_create_review(
         self,
@@ -2094,7 +2104,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#create-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2139,7 +2149,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview
@@ -2166,7 +2176,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview
@@ -2195,7 +2205,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def update_review(
@@ -2208,7 +2218,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def update_review(
         self,
@@ -2220,7 +2230,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#update-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2265,7 +2275,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_update_review(
@@ -2278,7 +2288,7 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_update_review(
         self,
@@ -2290,7 +2300,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#update-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2333,7 +2343,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview, ValidationErrorSimple
@@ -2361,7 +2371,7 @@ class PullsClient:
         review_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
         from ..models import BasicError, PullRequestReview, ValidationErrorSimple
@@ -2391,7 +2401,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReviewComment]]:
+    ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
         from ..models import BasicError, ReviewComment
@@ -2426,7 +2436,7 @@ class PullsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReviewComment]]:
+    ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
         from ..models import BasicError, ReviewComment
@@ -2461,7 +2471,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def dismiss_review(
@@ -2475,7 +2485,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def dismiss_review(
         self,
@@ -2489,7 +2499,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#dismiss-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2538,7 +2548,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_dismiss_review(
@@ -2552,7 +2562,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_dismiss_review(
         self,
@@ -2566,7 +2576,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#dismiss-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2615,7 +2625,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     def submit_review(
@@ -2629,7 +2639,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     def submit_review(
         self,
@@ -2643,7 +2653,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#submit-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2691,7 +2701,7 @@ class PullsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     @overload
     async def async_submit_review(
@@ -2705,7 +2715,7 @@ class PullsClient:
         headers: Optional[dict[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
-    ) -> Response[PullRequestReview]: ...
+    ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
     async def async_submit_review(
         self,
@@ -2719,7 +2729,7 @@ class PullsClient:
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[PullRequestReview]:
+    ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#submit-a-review-for-a-pull-request"""
 
         from ..models import (
@@ -2768,7 +2778,10 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     @overload
     def update_branch(
@@ -2780,7 +2793,10 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     def update_branch(
         self,
@@ -2793,7 +2809,10 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/pulls/pulls#update-a-pull-request-branch"""
 
         from typing import Union
@@ -2843,7 +2862,10 @@ class PullsClient:
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     @overload
     async def async_update_branch(
@@ -2855,7 +2877,10 @@ class PullsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]: ...
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]: ...
 
     async def async_update_branch(
         self,
@@ -2868,7 +2893,10 @@ class PullsClient:
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202]:
+    ) -> Response[
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
+        ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/pulls/pulls#update-a-pull-request-branch"""
 
         from typing import Union

--- a/githubkit/versions/v2022_11_28/rest/rate_limit.py
+++ b/githubkit/versions/v2022_11_28/rest/rate_limit.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from githubkit.response import Response
 
     from ..models import RateLimitOverview
+    from ..types import RateLimitOverviewType
 
 
 class RateLimitClient:
@@ -40,7 +41,7 @@ class RateLimitClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RateLimitOverview]:
+    ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 
         from ..models import BasicError, RateLimitOverview
@@ -63,7 +64,7 @@ class RateLimitClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RateLimitOverview]:
+    ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 
         from ..models import BasicError, RateLimitOverview

--- a/githubkit/versions/v2022_11_28/rest/reactions.py
+++ b/githubkit/versions/v2022_11_28/rest/reactions.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
     from ..models import Reaction
     from ..types import (
+        ReactionType,
         ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
         ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
         ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
@@ -70,7 +71,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
         from ..models import Reaction
@@ -108,7 +109,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
         from ..models import Reaction
@@ -141,7 +142,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_comment_in_org(
@@ -156,7 +157,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_comment_in_org(
         self,
@@ -170,7 +171,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment"""
 
         from ..models import (
@@ -212,7 +213,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_comment_in_org(
@@ -227,7 +228,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_comment_in_org(
         self,
@@ -241,7 +242,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment"""
 
         from ..models import (
@@ -331,7 +332,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
         from ..models import Reaction
@@ -368,7 +369,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
         from ..models import Reaction
@@ -400,7 +401,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_in_org(
@@ -414,7 +415,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_in_org(
         self,
@@ -427,7 +428,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion"""
 
         from ..models import (
@@ -467,7 +468,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_in_org(
@@ -481,7 +482,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_in_org(
         self,
@@ -494,7 +495,7 @@ class ReactionsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion"""
 
         from ..models import (
@@ -581,7 +582,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
         from ..models import Reaction, BasicError
@@ -621,7 +622,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
         from ..models import Reaction, BasicError
@@ -656,7 +657,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_commit_comment(
@@ -670,7 +671,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_commit_comment(
         self,
@@ -681,7 +682,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-commit-comment"""
 
         from ..models import (
@@ -725,7 +726,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_commit_comment(
@@ -739,7 +740,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_commit_comment(
         self,
@@ -750,7 +751,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-commit-comment"""
 
         from ..models import (
@@ -841,7 +842,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
         from ..models import Reaction, BasicError
@@ -881,7 +882,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
         from ..models import Reaction, BasicError
@@ -916,7 +917,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_issue_comment(
@@ -930,7 +931,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_issue_comment(
         self,
@@ -943,7 +944,7 @@ class ReactionsClient:
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue-comment"""
 
         from ..models import (
@@ -987,7 +988,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_issue_comment(
@@ -1001,7 +1002,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_issue_comment(
         self,
@@ -1014,7 +1015,7 @@ class ReactionsClient:
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue-comment"""
 
         from ..models import (
@@ -1105,7 +1106,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue"""
 
         from ..models import Reaction, BasicError
@@ -1146,7 +1147,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue"""
 
         from ..models import Reaction, BasicError
@@ -1182,7 +1183,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_issue(
@@ -1196,7 +1197,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_issue(
         self,
@@ -1207,7 +1208,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue"""
 
         from ..models import (
@@ -1251,7 +1252,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_issue(
@@ -1265,7 +1266,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_issue(
         self,
@@ -1276,7 +1277,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue"""
 
         from ..models import (
@@ -1367,7 +1368,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
         from ..models import Reaction, BasicError
@@ -1407,7 +1408,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
         from ..models import Reaction, BasicError
@@ -1442,7 +1443,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_pull_request_review_comment(
@@ -1456,7 +1457,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_pull_request_review_comment(
         self,
@@ -1469,7 +1470,7 @@ class ReactionsClient:
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment"""
 
         from ..models import (
@@ -1513,7 +1514,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_pull_request_review_comment(
@@ -1527,7 +1528,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_pull_request_review_comment(
         self,
@@ -1540,7 +1541,7 @@ class ReactionsClient:
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment"""
 
         from ..models import (
@@ -1633,7 +1634,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-release"""
 
         from ..models import Reaction, BasicError
@@ -1671,7 +1672,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-release"""
 
         from ..models import Reaction, BasicError
@@ -1706,7 +1707,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_release(
@@ -1718,7 +1719,7 @@ class ReactionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_release(
         self,
@@ -1729,7 +1730,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-release"""
 
         from ..models import (
@@ -1773,7 +1774,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_release(
@@ -1785,7 +1786,7 @@ class ReactionsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_release(
         self,
@@ -1796,7 +1797,7 @@ class ReactionsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-release"""
 
         from ..models import (
@@ -1887,7 +1888,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
         from ..models import Reaction
@@ -1924,7 +1925,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
         from ..models import Reaction
@@ -1956,7 +1957,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_comment_legacy(
@@ -1970,7 +1971,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_comment_legacy(
         self,
@@ -1983,7 +1984,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment-legacy"""
 
         from ..models import (
@@ -2024,7 +2025,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_comment_legacy(
@@ -2038,7 +2039,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_comment_legacy(
         self,
@@ -2051,7 +2052,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-comment-legacy"""
 
         from ..models import (
@@ -2096,7 +2097,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
         from ..models import Reaction
@@ -2132,7 +2133,7 @@ class ReactionsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Reaction]]:
+    ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
         from ..models import Reaction
@@ -2163,7 +2164,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     def create_for_team_discussion_legacy(
@@ -2176,7 +2177,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     def create_for_team_discussion_legacy(
         self,
@@ -2188,7 +2189,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-legacy"""
 
         from ..models import (
@@ -2227,7 +2228,7 @@ class ReactionsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     @overload
     async def async_create_for_team_discussion_legacy(
@@ -2240,7 +2241,7 @@ class ReactionsClient:
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
-    ) -> Response[Reaction]: ...
+    ) -> Response[Reaction, ReactionType]: ...
 
     async def async_create_for_team_discussion_legacy(
         self,
@@ -2252,7 +2253,7 @@ class ReactionsClient:
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[Reaction]:
+    ) -> Response[Reaction, ReactionType]:
         """See also: https://docs.github.com/rest/reactions/reactions#create-reaction-for-a-team-discussion-legacy"""
 
         from ..models import (

--- a/githubkit/versions/v2022_11_28/rest/repos.py
+++ b/githubkit/versions/v2022_11_28/rest/repos.py
@@ -125,20 +125,84 @@ if TYPE_CHECKING:
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
     )
     from ..types import (
+        TagType,
+        HookType,
+        PageType,
+        TeamType,
+        TopicType,
+        CommitType,
+        StatusType,
+        ReleaseType,
+        ActivityType,
+        AutolinkType,
+        LanguageType,
+        DeployKeyType,
+        PageBuildType,
+        RuleSuiteType,
+        DeploymentType,
+        FileCommitType,
+        RepositoryType,
+        SimpleUserType,
+        BranchShortType,
+        ContentFileType,
+        ContributorType,
+        EnvironmentType,
+        IntegrationType,
+        ShortBranchType,
+        ViewTrafficType,
+        CloneTrafficType,
+        CollaboratorType,
+        HookDeliveryType,
+        ReleaseAssetType,
+        CommitCommentType,
+        TagProtectionType,
         WebhookConfigType,
+        CommitActivityType,
+        ContentSymlinkType,
+        ContentTrafficType,
+        FullRepositoryType,
+        MergedUpstreamType,
+        PageDeploymentType,
+        PageBuildStatusType,
+        ProtectedBranchType,
+        ReferrerTrafficType,
+        RuleSuitesItemsType,
+        BranchProtectionType,
+        CodeownersErrorsType,
+        CommitComparisonType,
+        CommunityProfileType,
+        ContentSubmoduleType,
+        DeploymentStatusType,
+        HookDeliveryItemType,
+        PagesHealthCheckType,
+        MinimalRepositoryType,
+        PullRequestSimpleType,
+        RepositoryRulesetType,
+        StatusCheckPolicyType,
         UserReposPostBodyType,
+        ParticipationStatsType,
+        ContributorActivityType,
         CustomPropertyValueType,
+        ReleaseNotesContentType,
+        BranchWithProtectionType,
+        CombinedCommitStatusType,
         OrgsOrgReposPostBodyType,
+        RepositoryInvitationType,
         RepositoryRuleUpdateType,
+        ContentDirectoryItemsType,
+        PagesDeploymentStatusType,
         RepositoryRuleOneof15Type,
         RepositoryRuleOneof16Type,
         RepositoryRuleOneof17Type,
         RepositoryRuleOneof18Type,
+        DeploymentBranchPolicyType,
         RepositoryRuleCreationType,
         RepositoryRuleDeletionType,
+        BranchRestrictionPolicyType,
         OrgsOrgRulesetsPostBodyType,
         RepositoryRuleWorkflowsType,
         ReposOwnerRepoPatchBodyType,
+        DeploymentProtectionRuleType,
         RepositoryRuleMergeQueueType,
         RepositoryRulePullRequestType,
         OrgRulesetConditionsOneof0Type,
@@ -146,14 +210,33 @@ if TYPE_CHECKING:
         OrgRulesetConditionsOneof2Type,
         RepositoryRuleCodeScanningType,
         ReposOwnerRepoKeysPostBodyType,
+        CheckAutomatedSecurityFixesType,
         RepositoryRulesetConditionsType,
         ReposOwnerRepoForksPostBodyType,
         ReposOwnerRepoHooksPostBodyType,
         ReposOwnerRepoTopicsPutBodyType,
+        ProtectedBranchAdminEnforcedType,
+        RepositoryRuleDetailedOneof0Type,
+        RepositoryRuleDetailedOneof1Type,
+        RepositoryRuleDetailedOneof2Type,
+        RepositoryRuleDetailedOneof3Type,
+        RepositoryRuleDetailedOneof4Type,
+        RepositoryRuleDetailedOneof5Type,
+        RepositoryRuleDetailedOneof6Type,
+        RepositoryRuleDetailedOneof7Type,
+        RepositoryRuleDetailedOneof8Type,
+        RepositoryRuleDetailedOneof9Type,
         RepositoryRuleNonFastForwardType,
         RepositoryRulesetBypassActorType,
         RepositoryRuleTagNamePatternType,
         ReposOwnerRepoMergesPostBodyType,
+        RepositoryRuleDetailedOneof10Type,
+        RepositoryRuleDetailedOneof11Type,
+        RepositoryRuleDetailedOneof12Type,
+        RepositoryRuleDetailedOneof13Type,
+        RepositoryRuleDetailedOneof14Type,
+        RepositoryRuleDetailedOneof15Type,
+        RepositoryRuleDetailedOneof16Type,
         DeploymentBranchPolicySettingsType,
         ReposOwnerRepoReleasesPostBodyType,
         ReposOwnerRepoRulesetsPostBodyType,
@@ -161,6 +244,8 @@ if TYPE_CHECKING:
         OrgsOrgRulesetsRulesetIdPutBodyType,
         RepositoryRuleBranchNamePatternType,
         ReposOwnerRepoAutolinksPostBodyType,
+        ProtectedBranchPullRequestReviewType,
+        RepositoryCollaboratorPermissionType,
         RepositoryRuleRequiredSignaturesType,
         ReposOwnerRepoDispatchesPostBodyType,
         ReposOwnerRepoPagesPutBodyAnyof0Type,
@@ -192,9 +277,11 @@ if TYPE_CHECKING:
         ReposOwnerRepoPropertiesValuesPatchBodyType,
         OrgsOrgReposPostBodyPropCustomPropertiesType,
         ReposOwnerRepoCommentsCommentIdPatchBodyType,
+        ReposOwnerRepoEnvironmentsGetResponse200Type,
         ReposOwnerRepoHooksHookIdConfigPatchBodyType,
         ReposOwnerRepoReleasesReleaseIdPatchBodyType,
         DeploymentBranchPolicyNamePatternWithTypeType,
+        ReposOwnerRepoAttestationsPostResponse201Type,
         ReposOwnerRepoBranchesBranchRenamePostBodyType,
         ReposOwnerRepoCollaboratorsUsernamePutBodyType,
         ReposOwnerRepoPagesPutBodyPropSourceAnyof1Type,
@@ -212,8 +299,11 @@ if TYPE_CHECKING:
         ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType,
         ReposOwnerRepoContentsPathDeleteBodyPropCommitterType,
         ReposOwnerRepoDispatchesPostBodyPropClientPayloadType,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         ReposOwnerRepoDeploymentsPostBodyPropPayloadOneof0Type,
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
         ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionPutBodyPropRestrictionsType,
         ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
         ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
@@ -231,9 +321,12 @@ if TYPE_CHECKING:
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
         ReposOwnerRepoBranchesBranchProtectionPutBodyPropRequiredPullRequestReviewsType,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyPropChecksItemsType,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
         ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropDismissalRestrictionsType,
         ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropBypassPullRequestAllowancesType,
     )
@@ -266,7 +359,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-organization-repositories"""
 
         from ..models import MinimalRepository
@@ -303,7 +396,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-organization-repositories"""
 
         from ..models import MinimalRepository
@@ -335,7 +428,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_in_org(
@@ -375,7 +468,7 @@ class ReposClient:
         custom_properties: Missing[
             OrgsOrgReposPostBodyPropCustomPropertiesType
         ] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_in_org(
         self,
@@ -384,7 +477,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#create-an-organization-repository"""
 
         from ..models import (
@@ -426,7 +519,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_in_org(
@@ -466,7 +559,7 @@ class ReposClient:
         custom_properties: Missing[
             OrgsOrgReposPostBodyPropCustomPropertiesType
         ] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_in_org(
         self,
@@ -475,7 +568,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#create-an-organization-repository"""
 
         from ..models import (
@@ -518,7 +611,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -553,7 +646,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -587,7 +680,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def create_org_ruleset(
@@ -634,7 +727,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def create_org_ruleset(
         self,
@@ -643,7 +736,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#create-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset, OrgsOrgRulesetsPostBody
@@ -680,7 +773,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_create_org_ruleset(
@@ -727,7 +820,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_create_org_ruleset(
         self,
@@ -736,7 +829,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#create-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset, OrgsOrgRulesetsPostBody
@@ -778,7 +871,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#list-organization-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -821,7 +914,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#list-organization-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -858,7 +951,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -884,7 +977,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -910,7 +1003,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#get-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -936,7 +1029,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#get-an-organization-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -964,7 +1057,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def update_org_ruleset(
@@ -1012,7 +1105,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def update_org_ruleset(
         self,
@@ -1022,7 +1115,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#update-an-organization-repository-ruleset"""
 
         from ..models import (
@@ -1064,7 +1157,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_update_org_ruleset(
@@ -1112,7 +1205,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_update_org_ruleset(
         self,
@@ -1122,7 +1215,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#update-an-organization-repository-ruleset"""
 
         from ..models import (
@@ -1212,7 +1305,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#get-a-repository"""
 
         from ..models import BasicError, FullRepository
@@ -1238,7 +1331,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#get-a-repository"""
 
         from ..models import BasicError, FullRepository
@@ -1316,7 +1409,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def update(
@@ -1357,7 +1450,7 @@ class ReposClient:
         archived: Missing[bool] = UNSET,
         allow_forking: Missing[bool] = UNSET,
         web_commit_signoff_required: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def update(
         self,
@@ -1367,7 +1460,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#update-a-repository"""
 
         from ..models import (
@@ -1411,7 +1504,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_update(
@@ -1452,7 +1545,7 @@ class ReposClient:
         archived: Missing[bool] = UNSET,
         allow_forking: Missing[bool] = UNSET,
         web_commit_signoff_required: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_update(
         self,
@@ -1462,7 +1555,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#update-a-repository"""
 
         from ..models import (
@@ -1523,7 +1616,7 @@ class ReposClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Activity]]:
+    ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-activities"""
 
         from ..models import Activity, ValidationErrorSimple
@@ -1579,7 +1672,7 @@ class ReposClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Activity]]:
+    ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-activities"""
 
         from ..models import Activity, ValidationErrorSimple
@@ -1618,7 +1711,10 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     @overload
     def create_attestation(
@@ -1629,7 +1725,10 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     def create_attestation(
         self,
@@ -1639,7 +1738,10 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/repos#create-an-attestation"""
 
         from ..models import (
@@ -1682,7 +1784,10 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     @overload
     async def async_create_attestation(
@@ -1693,7 +1798,10 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]: ...
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]: ...
 
     async def async_create_attestation(
         self,
@@ -1703,7 +1811,10 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReposOwnerRepoAttestationsPostResponse201]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsPostResponse201,
+        ReposOwnerRepoAttestationsPostResponse201Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/repos#create-an-attestation"""
 
         from ..models import (
@@ -1748,7 +1859,10 @@ class ReposClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/repos#list-attestations"""
 
         from ..models import ReposOwnerRepoAttestationsSubjectDigestGetResponse200
@@ -1781,7 +1895,10 @@ class ReposClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
+        ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/repos#list-attestations"""
 
         from ..models import ReposOwnerRepoAttestationsSubjectDigestGetResponse200
@@ -1810,7 +1927,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Autolink]]:
+    ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
         from ..models import Autolink
@@ -1832,7 +1949,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Autolink]]:
+    ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
         from ..models import Autolink
@@ -1856,7 +1973,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     @overload
     def create_autolink(
@@ -1869,7 +1986,7 @@ class ReposClient:
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     def create_autolink(
         self,
@@ -1879,7 +1996,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository"""
 
         from ..models import Autolink, ValidationError, ReposOwnerRepoAutolinksPostBody
@@ -1916,7 +2033,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     @overload
     async def async_create_autolink(
@@ -1929,7 +2046,7 @@ class ReposClient:
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
-    ) -> Response[Autolink]: ...
+    ) -> Response[Autolink, AutolinkType]: ...
 
     async def async_create_autolink(
         self,
@@ -1939,7 +2056,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository"""
 
         from ..models import Autolink, ValidationError, ReposOwnerRepoAutolinksPostBody
@@ -1975,7 +2092,7 @@ class ReposClient:
         autolink_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
         from ..models import Autolink, BasicError
@@ -2001,7 +2118,7 @@ class ReposClient:
         autolink_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Autolink]:
+    ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
         from ..models import Autolink, BasicError
@@ -2076,7 +2193,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckAutomatedSecurityFixes]:
+    ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
         from ..models import CheckAutomatedSecurityFixes
@@ -2099,7 +2216,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CheckAutomatedSecurityFixes]:
+    ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
         from ..models import CheckAutomatedSecurityFixes
@@ -2201,7 +2318,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ShortBranch]]:
+    ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/rest/branches/branches#list-branches"""
 
         from ..models import BasicError, ShortBranch
@@ -2236,7 +2353,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ShortBranch]]:
+    ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/rest/branches/branches#list-branches"""
 
         from ..models import BasicError, ShortBranch
@@ -2269,7 +2386,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/rest/branches/branches#get-a-branch"""
 
         from ..models import BasicError, BranchWithProtection
@@ -2295,7 +2412,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/rest/branches/branches#get-a-branch"""
 
         from ..models import BasicError, BranchWithProtection
@@ -2321,7 +2438,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchProtection]:
+    ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-branch-protection"""
 
         from ..models import BasicError, BranchProtection
@@ -2347,7 +2464,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchProtection]:
+    ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-branch-protection"""
 
         from ..models import BasicError, BranchProtection
@@ -2375,7 +2492,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     @overload
     def update_branch_protection(
@@ -2405,7 +2522,7 @@ class ReposClient:
         required_conversation_resolution: Missing[bool] = UNSET,
         lock_branch: Missing[bool] = UNSET,
         allow_fork_syncing: Missing[bool] = UNSET,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     def update_branch_protection(
         self,
@@ -2416,7 +2533,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranch]:
+    ) -> Response[ProtectedBranch, ProtectedBranchType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#update-branch-protection"""
 
         from ..models import (
@@ -2463,7 +2580,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     @overload
     async def async_update_branch_protection(
@@ -2493,7 +2610,7 @@ class ReposClient:
         required_conversation_resolution: Missing[bool] = UNSET,
         lock_branch: Missing[bool] = UNSET,
         allow_fork_syncing: Missing[bool] = UNSET,
-    ) -> Response[ProtectedBranch]: ...
+    ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
     async def async_update_branch_protection(
         self,
@@ -2504,7 +2621,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranch]:
+    ) -> Response[ProtectedBranch, ProtectedBranchType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#update-branch-protection"""
 
         from ..models import (
@@ -2599,7 +2716,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2622,7 +2739,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2645,7 +2762,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2668,7 +2785,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-admin-branch-protection"""
 
         from ..models import ProtectedBranchAdminEnforced
@@ -2741,7 +2858,9 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-pull-request-review-protection"""
 
         from ..models import ProtectedBranchPullRequestReview
@@ -2764,7 +2883,9 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-pull-request-review-protection"""
 
         from ..models import ProtectedBranchPullRequestReview
@@ -2841,7 +2962,9 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     @overload
     def update_pull_request_review_protection(
@@ -2862,7 +2985,9 @@ class ReposClient:
         bypass_pull_request_allowances: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropBypassPullRequestAllowancesType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     def update_pull_request_review_protection(
         self,
@@ -2875,7 +3000,9 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/rest/branches/branch-protection#update-pull-request-review-protection"""
 
         from ..models import (
@@ -2922,7 +3049,9 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     @overload
     async def async_update_pull_request_review_protection(
@@ -2943,7 +3072,9 @@ class ReposClient:
         bypass_pull_request_allowances: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropBypassPullRequestAllowancesType
         ] = UNSET,
-    ) -> Response[ProtectedBranchPullRequestReview]: ...
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]: ...
 
     async def async_update_pull_request_review_protection(
         self,
@@ -2956,7 +3087,9 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[ProtectedBranchPullRequestReview]:
+    ) -> Response[
+        ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
+    ]:
         """See also: https://docs.github.com/rest/branches/branch-protection#update-pull-request-review-protection"""
 
         from ..models import (
@@ -2999,7 +3132,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3025,7 +3158,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3051,7 +3184,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#create-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3077,7 +3210,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ProtectedBranchAdminEnforced]:
+    ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#create-commit-signature-protection"""
 
         from ..models import BasicError, ProtectedBranchAdminEnforced
@@ -3153,7 +3286,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection"""
 
         from ..models import BasicError, StatusCheckPolicy
@@ -3181,7 +3314,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection"""
 
         from ..models import BasicError, StatusCheckPolicy
@@ -3257,7 +3390,7 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     @overload
     def update_status_check_protection(
@@ -3275,7 +3408,7 @@ class ReposClient:
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyPropChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     def update_status_check_protection(
         self,
@@ -3288,7 +3421,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#update-status-check-protection"""
 
         from ..models import (
@@ -3339,7 +3472,7 @@ class ReposClient:
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     @overload
     async def async_update_status_check_protection(
@@ -3357,7 +3490,7 @@ class ReposClient:
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyPropChecksItemsType
             ]
         ] = UNSET,
-    ) -> Response[StatusCheckPolicy]: ...
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]: ...
 
     async def async_update_status_check_protection(
         self,
@@ -3370,7 +3503,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[StatusCheckPolicy]:
+    ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#update-status-check-protection"""
 
         from ..models import (
@@ -3417,7 +3550,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-all-status-check-contexts"""
 
         from ..models import BasicError
@@ -3443,7 +3576,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-all-status-check-contexts"""
 
         from ..models import BasicError
@@ -3476,7 +3609,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     def set_status_check_contexts(
@@ -3488,7 +3621,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     def set_status_check_contexts(
         self,
@@ -3504,7 +3637,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-status-check-contexts"""
 
         from typing import Union
@@ -3560,7 +3693,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     async def async_set_status_check_contexts(
@@ -3572,7 +3705,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     async def async_set_status_check_contexts(
         self,
@@ -3588,7 +3721,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-status-check-contexts"""
 
         from typing import Union
@@ -3644,7 +3777,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     def add_status_check_contexts(
@@ -3656,7 +3789,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     def add_status_check_contexts(
         self,
@@ -3672,7 +3805,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-status-check-contexts"""
 
         from typing import Union
@@ -3729,7 +3862,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     async def async_add_status_check_contexts(
@@ -3741,7 +3874,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     async def async_add_status_check_contexts(
         self,
@@ -3757,7 +3890,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-status-check-contexts"""
 
         from typing import Union
@@ -3814,7 +3947,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     def remove_status_check_contexts(
@@ -3826,7 +3959,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     def remove_status_check_contexts(
         self,
@@ -3842,7 +3975,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-status-check-contexts"""
 
         from typing import Union
@@ -3898,7 +4031,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     @overload
     async def async_remove_status_check_contexts(
@@ -3910,7 +4043,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         contexts: list[str],
-    ) -> Response[list[str]]: ...
+    ) -> Response[list[str], list[str]]: ...
 
     async def async_remove_status_check_contexts(
         self,
@@ -3926,7 +4059,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[str]]:
+    ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-status-check-contexts"""
 
         from typing import Union
@@ -3975,7 +4108,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchRestrictionPolicy]:
+    ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-access-restrictions"""
 
         from ..models import BasicError, BranchRestrictionPolicy
@@ -4001,7 +4134,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[BranchRestrictionPolicy]:
+    ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-access-restrictions"""
 
         from ..models import BasicError, BranchRestrictionPolicy
@@ -4067,7 +4200,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
         from typing import Union
@@ -4095,7 +4228,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
         from typing import Union
@@ -4125,7 +4258,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     def set_app_access_restrictions(
@@ -4137,7 +4272,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     def set_app_access_restrictions(
         self,
@@ -4150,7 +4287,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-app-access-restrictions"""
 
         from typing import Union
@@ -4196,7 +4333,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     async def async_set_app_access_restrictions(
@@ -4208,7 +4347,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     async def async_set_app_access_restrictions(
         self,
@@ -4221,7 +4362,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-app-access-restrictions"""
 
         from typing import Union
@@ -4267,7 +4408,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     def add_app_access_restrictions(
@@ -4279,7 +4422,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     def add_app_access_restrictions(
         self,
@@ -4292,7 +4437,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-app-access-restrictions"""
 
         from typing import Union
@@ -4338,7 +4483,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     async def async_add_app_access_restrictions(
@@ -4350,7 +4497,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     async def async_add_app_access_restrictions(
         self,
@@ -4363,7 +4512,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-app-access-restrictions"""
 
         from typing import Union
@@ -4409,7 +4558,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     def remove_app_access_restrictions(
@@ -4421,7 +4572,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     def remove_app_access_restrictions(
         self,
@@ -4434,7 +4587,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-app-access-restrictions"""
 
         from typing import Union
@@ -4480,7 +4633,9 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     @overload
     async def async_remove_app_access_restrictions(
@@ -4492,7 +4647,9 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         apps: list[str],
-    ) -> Response[list[Union[Integration, None]]]: ...
+    ) -> Response[
+        list[Union[Integration, None]], list[Union[IntegrationType, None]]
+    ]: ...
 
     async def async_remove_app_access_restrictions(
         self,
@@ -4505,7 +4662,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Union[Integration, None]]]:
+    ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-app-access-restrictions"""
 
         from typing import Union
@@ -4549,7 +4706,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
         from ..models import Team, BasicError
@@ -4575,7 +4732,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
         from ..models import Team, BasicError
@@ -4608,7 +4765,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     def set_team_access_restrictions(
@@ -4620,7 +4777,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     def set_team_access_restrictions(
         self,
@@ -4636,7 +4793,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-team-access-restrictions"""
 
         from typing import Union
@@ -4691,7 +4848,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     async def async_set_team_access_restrictions(
@@ -4703,7 +4860,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     async def async_set_team_access_restrictions(
         self,
@@ -4719,7 +4876,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-team-access-restrictions"""
 
         from typing import Union
@@ -4774,7 +4931,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     def add_team_access_restrictions(
@@ -4786,7 +4943,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     def add_team_access_restrictions(
         self,
@@ -4802,7 +4959,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-team-access-restrictions"""
 
         from typing import Union
@@ -4857,7 +5014,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     async def async_add_team_access_restrictions(
@@ -4869,7 +5026,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     async def async_add_team_access_restrictions(
         self,
@@ -4885,7 +5042,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-team-access-restrictions"""
 
         from typing import Union
@@ -4940,7 +5097,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     def remove_team_access_restrictions(
@@ -4952,7 +5109,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     def remove_team_access_restrictions(
         self,
@@ -4968,7 +5125,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-team-access-restrictions"""
 
         from typing import Union
@@ -5023,7 +5180,7 @@ class ReposClient:
                 list[str],
             ]
         ] = UNSET,
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     @overload
     async def async_remove_team_access_restrictions(
@@ -5035,7 +5192,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         teams: list[str],
-    ) -> Response[list[Team]]: ...
+    ) -> Response[list[Team], list[TeamType]]: ...
 
     async def async_remove_team_access_restrictions(
         self,
@@ -5051,7 +5208,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-team-access-restrictions"""
 
         from typing import Union
@@ -5099,7 +5256,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
         from ..models import BasicError, SimpleUser
@@ -5125,7 +5282,7 @@ class ReposClient:
         branch: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
         from ..models import BasicError, SimpleUser
@@ -5153,7 +5310,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     def set_user_access_restrictions(
@@ -5165,7 +5322,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     def set_user_access_restrictions(
         self,
@@ -5178,7 +5335,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-user-access-restrictions"""
 
         from ..models import (
@@ -5222,7 +5379,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     async def async_set_user_access_restrictions(
@@ -5234,7 +5391,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     async def async_set_user_access_restrictions(
         self,
@@ -5247,7 +5404,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-user-access-restrictions"""
 
         from ..models import (
@@ -5291,7 +5448,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     def add_user_access_restrictions(
@@ -5303,7 +5460,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     def add_user_access_restrictions(
         self,
@@ -5316,7 +5473,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-user-access-restrictions"""
 
         from ..models import (
@@ -5360,7 +5517,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     async def async_add_user_access_restrictions(
@@ -5372,7 +5529,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     async def async_add_user_access_restrictions(
         self,
@@ -5385,7 +5542,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#add-user-access-restrictions"""
 
         from ..models import (
@@ -5429,7 +5586,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     def remove_user_access_restrictions(
@@ -5441,7 +5598,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     def remove_user_access_restrictions(
         self,
@@ -5454,7 +5611,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-user-access-restrictions"""
 
         from ..models import (
@@ -5498,7 +5655,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     @overload
     async def async_remove_user_access_restrictions(
@@ -5510,7 +5667,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         users: list[str],
-    ) -> Response[list[SimpleUser]]: ...
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
     async def async_remove_user_access_restrictions(
         self,
@@ -5523,7 +5680,7 @@ class ReposClient:
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-user-access-restrictions"""
 
         from ..models import (
@@ -5567,7 +5724,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     @overload
     def rename_branch(
@@ -5579,7 +5736,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         new_name: str,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     def rename_branch(
         self,
@@ -5590,7 +5747,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/rest/branches/branches#rename-a-branch"""
 
         from ..models import (
@@ -5637,7 +5794,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     @overload
     async def async_rename_branch(
@@ -5649,7 +5806,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         new_name: str,
-    ) -> Response[BranchWithProtection]: ...
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
     async def async_rename_branch(
         self,
@@ -5660,7 +5817,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[BranchWithProtection]:
+    ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/rest/branches/branches#rename-a-branch"""
 
         from ..models import (
@@ -5705,7 +5862,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeownersErrors]:
+    ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/rest/repos/repos#list-codeowners-errors"""
 
         from ..models import CodeownersErrors
@@ -5734,7 +5891,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CodeownersErrors]:
+    ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/rest/repos/repos#list-codeowners-errors"""
 
         from ..models import CodeownersErrors
@@ -5768,7 +5925,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Collaborator]]:
+    ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#list-repository-collaborators"""
 
         from ..models import BasicError, Collaborator
@@ -5807,7 +5964,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Collaborator]]:
+    ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#list-repository-collaborators"""
 
         from ..models import BasicError, Collaborator
@@ -5885,7 +6042,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     def add_collaborator(
@@ -5897,7 +6054,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         permission: Missing[str] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     def add_collaborator(
         self,
@@ -5908,7 +6065,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#add-a-repository-collaborator"""
 
         from ..models import (
@@ -5954,7 +6111,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     async def async_add_collaborator(
@@ -5966,7 +6123,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         permission: Missing[str] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     async def async_add_collaborator(
         self,
@@ -5977,7 +6134,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#add-a-repository-collaborator"""
 
         from ..models import (
@@ -6073,7 +6230,9 @@ class ReposClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryCollaboratorPermission]:
+    ) -> Response[
+        RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
+    ]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#get-repository-permissions-for-a-user"""
 
         from ..models import BasicError, RepositoryCollaboratorPermission
@@ -6099,7 +6258,9 @@ class ReposClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryCollaboratorPermission]:
+    ) -> Response[
+        RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
+    ]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#get-repository-permissions-for-a-user"""
 
         from ..models import BasicError, RepositoryCollaboratorPermission
@@ -6126,7 +6287,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments-for-a-repository"""
 
         from ..models import CommitComment
@@ -6156,7 +6317,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments-for-a-repository"""
 
         from ..models import CommitComment
@@ -6185,7 +6346,7 @@ class ReposClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#get-a-commit-comment"""
 
         from ..models import BasicError, CommitComment
@@ -6211,7 +6372,7 @@ class ReposClient:
         comment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#get-a-commit-comment"""
 
         from ..models import BasicError, CommitComment
@@ -6289,7 +6450,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     def update_commit_comment(
@@ -6301,7 +6462,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     def update_commit_comment(
         self,
@@ -6312,7 +6473,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#update-a-commit-comment"""
 
         from ..models import (
@@ -6354,7 +6515,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     async def async_update_commit_comment(
@@ -6366,7 +6527,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     async def async_update_commit_comment(
         self,
@@ -6377,7 +6538,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#update-a-commit-comment"""
 
         from ..models import (
@@ -6424,7 +6585,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-commits"""
 
         from ..models import Commit, BasicError
@@ -6472,7 +6633,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Commit]]:
+    ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-commits"""
 
         from ..models import Commit, BasicError
@@ -6513,7 +6674,7 @@ class ReposClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BranchShort]]:
+    ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-branches-for-head-commit"""
 
         from ..models import BasicError, BranchShort, ValidationError
@@ -6540,7 +6701,7 @@ class ReposClient:
         commit_sha: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[BranchShort]]:
+    ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-branches-for-head-commit"""
 
         from ..models import BasicError, BranchShort, ValidationError
@@ -6569,7 +6730,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments"""
 
         from ..models import CommitComment
@@ -6600,7 +6761,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitComment]]:
+    ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments"""
 
         from ..models import CommitComment
@@ -6631,7 +6792,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     def create_commit_comment(
@@ -6646,7 +6807,7 @@ class ReposClient:
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
         line: Missing[int] = UNSET,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     def create_commit_comment(
         self,
@@ -6657,7 +6818,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#create-a-commit-comment"""
 
         from ..models import (
@@ -6703,7 +6864,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     @overload
     async def async_create_commit_comment(
@@ -6718,7 +6879,7 @@ class ReposClient:
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
         line: Missing[int] = UNSET,
-    ) -> Response[CommitComment]: ...
+    ) -> Response[CommitComment, CommitCommentType]: ...
 
     async def async_create_commit_comment(
         self,
@@ -6729,7 +6890,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[CommitComment]:
+    ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#create-a-commit-comment"""
 
         from ..models import (
@@ -6775,7 +6936,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
         from ..models import BasicError, PullRequestSimple
@@ -6809,7 +6970,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PullRequestSimple]]:
+    ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
         from ..models import BasicError, PullRequestSimple
@@ -6843,7 +7004,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/rest/commits/commits#get-a-commit"""
 
         from ..models import (
@@ -6886,7 +7047,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/rest/commits/commits#get-a-commit"""
 
         from ..models import (
@@ -6929,7 +7090,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedCommitStatus]:
+    ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
         from ..models import BasicError, CombinedCommitStatus
@@ -6963,7 +7124,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CombinedCommitStatus]:
+    ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
         from ..models import BasicError, CombinedCommitStatus
@@ -6997,7 +7158,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Status]]:
+    ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
         from ..models import Status
@@ -7028,7 +7189,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Status]]:
+    ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
         from ..models import Status
@@ -7056,7 +7217,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommunityProfile]:
+    ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/rest/metrics/community#get-community-profile-metrics"""
 
         from ..models import CommunityProfile
@@ -7078,7 +7239,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommunityProfile]:
+    ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/rest/metrics/community#get-community-profile-metrics"""
 
         from ..models import CommunityProfile
@@ -7103,7 +7264,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComparison]:
+    ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/rest/commits/commits#compare-two-commits"""
 
         from ..models import (
@@ -7143,7 +7304,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CommitComparison]:
+    ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/rest/commits/commits#compare-two-commits"""
 
         from ..models import (
@@ -7185,7 +7346,13 @@ class ReposClient:
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
-        ]
+        ],
+        Union[
+            list[ContentDirectoryItemsType],
+            ContentFileType,
+            ContentSymlinkType,
+            ContentSubmoduleType,
+        ],
     ]:
         """See also: https://docs.github.com/rest/repos/contents#get-repository-content"""
 
@@ -7235,7 +7402,13 @@ class ReposClient:
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
-        ]
+        ],
+        Union[
+            list[ContentDirectoryItemsType],
+            ContentFileType,
+            ContentSymlinkType,
+            ContentSubmoduleType,
+        ],
     ]:
         """See also: https://docs.github.com/rest/repos/contents#get-repository-content"""
 
@@ -7283,7 +7456,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     def create_or_update_file_contents(
@@ -7300,7 +7473,7 @@ class ReposClient:
         branch: Missing[str] = UNSET,
         committer: Missing[ReposOwnerRepoContentsPathPutBodyPropCommitterType] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathPutBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     def create_or_update_file_contents(
         self,
@@ -7311,7 +7484,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/rest/repos/contents#create-or-update-file-contents"""
 
         from typing import Union
@@ -7359,7 +7532,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     async def async_create_or_update_file_contents(
@@ -7376,7 +7549,7 @@ class ReposClient:
         branch: Missing[str] = UNSET,
         committer: Missing[ReposOwnerRepoContentsPathPutBodyPropCommitterType] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathPutBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     async def async_create_or_update_file_contents(
         self,
@@ -7387,7 +7560,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/rest/repos/contents#create-or-update-file-contents"""
 
         from typing import Union
@@ -7435,7 +7608,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     def delete_file(
@@ -7453,7 +7626,7 @@ class ReposClient:
             ReposOwnerRepoContentsPathDeleteBodyPropCommitterType
         ] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathDeleteBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     def delete_file(
         self,
@@ -7464,7 +7637,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/rest/repos/contents#delete-a-file"""
 
         from ..models import (
@@ -7511,7 +7684,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     @overload
     async def async_delete_file(
@@ -7529,7 +7702,7 @@ class ReposClient:
             ReposOwnerRepoContentsPathDeleteBodyPropCommitterType
         ] = UNSET,
         author: Missing[ReposOwnerRepoContentsPathDeleteBodyPropAuthorType] = UNSET,
-    ) -> Response[FileCommit]: ...
+    ) -> Response[FileCommit, FileCommitType]: ...
 
     async def async_delete_file(
         self,
@@ -7540,7 +7713,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FileCommit]:
+    ) -> Response[FileCommit, FileCommitType]:
         """See also: https://docs.github.com/rest/repos/contents#delete-a-file"""
 
         from ..models import (
@@ -7587,7 +7760,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Contributor]]:
+    ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-contributors"""
 
         from ..models import BasicError, Contributor
@@ -7623,7 +7796,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Contributor]]:
+    ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-contributors"""
 
         from ..models import BasicError, Contributor
@@ -7662,7 +7835,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/rest/deployments/deployments#list-deployments"""
 
         from ..models import Deployment
@@ -7700,7 +7873,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Deployment]]:
+    ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/rest/deployments/deployments#list-deployments"""
 
         from ..models import Deployment
@@ -7734,7 +7907,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     @overload
     def create_deployment(
@@ -7755,7 +7928,7 @@ class ReposClient:
         description: Missing[Union[str, None]] = UNSET,
         transient_environment: Missing[bool] = UNSET,
         production_environment: Missing[bool] = UNSET,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     def create_deployment(
         self,
@@ -7765,7 +7938,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/rest/deployments/deployments#create-a-deployment"""
 
         from ..models import (
@@ -7806,7 +7979,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     @overload
     async def async_create_deployment(
@@ -7827,7 +8000,7 @@ class ReposClient:
         description: Missing[Union[str, None]] = UNSET,
         transient_environment: Missing[bool] = UNSET,
         production_environment: Missing[bool] = UNSET,
-    ) -> Response[Deployment]: ...
+    ) -> Response[Deployment, DeploymentType]: ...
 
     async def async_create_deployment(
         self,
@@ -7837,7 +8010,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/rest/deployments/deployments#create-a-deployment"""
 
         from ..models import (
@@ -7877,7 +8050,7 @@ class ReposClient:
         deployment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/rest/deployments/deployments#get-a-deployment"""
 
         from ..models import BasicError, Deployment
@@ -7903,7 +8076,7 @@ class ReposClient:
         deployment_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Deployment]:
+    ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/rest/deployments/deployments#get-a-deployment"""
 
         from ..models import BasicError, Deployment
@@ -7983,7 +8156,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeploymentStatus]]:
+    ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/rest/deployments/statuses#list-deployment-statuses"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8017,7 +8190,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeploymentStatus]]:
+    ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/rest/deployments/statuses#list-deployment-statuses"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8051,7 +8224,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     @overload
     def create_deployment_status(
@@ -8077,7 +8250,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         environment_url: Missing[str] = UNSET,
         auto_inactive: Missing[bool] = UNSET,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     def create_deployment_status(
         self,
@@ -8090,7 +8263,7 @@ class ReposClient:
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/rest/deployments/statuses#create-a-deployment-status"""
 
         from ..models import (
@@ -8134,7 +8307,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     @overload
     async def async_create_deployment_status(
@@ -8160,7 +8333,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         environment_url: Missing[str] = UNSET,
         auto_inactive: Missing[bool] = UNSET,
-    ) -> Response[DeploymentStatus]: ...
+    ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
     async def async_create_deployment_status(
         self,
@@ -8173,7 +8346,7 @@ class ReposClient:
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/rest/deployments/statuses#create-a-deployment-status"""
 
         from ..models import (
@@ -8216,7 +8389,7 @@ class ReposClient:
         status_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/rest/deployments/statuses#get-a-deployment-status"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8243,7 +8416,7 @@ class ReposClient:
         status_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentStatus]:
+    ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/rest/deployments/statuses#get-a-deployment-status"""
 
         from ..models import BasicError, DeploymentStatus
@@ -8400,7 +8573,10 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsGetResponse200,
+        ReposOwnerRepoEnvironmentsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/deployments/environments#list-environments"""
 
         from ..models import ReposOwnerRepoEnvironmentsGetResponse200
@@ -8430,7 +8606,10 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoEnvironmentsGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoEnvironmentsGetResponse200,
+        ReposOwnerRepoEnvironmentsGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/deployments/environments#list-environments"""
 
         from ..models import ReposOwnerRepoEnvironmentsGetResponse200
@@ -8459,7 +8638,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/rest/deployments/environments#get-an-environment"""
 
         from ..models import Environment
@@ -8482,7 +8661,7 @@ class ReposClient:
         environment_name: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/rest/deployments/environments#get-an-environment"""
 
         from ..models import Environment
@@ -8509,7 +8688,7 @@ class ReposClient:
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     @overload
     def create_or_update_environment(
@@ -8533,7 +8712,7 @@ class ReposClient:
         deployment_branch_policy: Missing[
             Union[DeploymentBranchPolicySettingsType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     def create_or_update_environment(
         self,
@@ -8546,7 +8725,7 @@ class ReposClient:
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/rest/deployments/environments#create-or-update-an-environment"""
 
         from typing import Union
@@ -8594,7 +8773,7 @@ class ReposClient:
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     @overload
     async def async_create_or_update_environment(
@@ -8618,7 +8797,7 @@ class ReposClient:
         deployment_branch_policy: Missing[
             Union[DeploymentBranchPolicySettingsType, None]
         ] = UNSET,
-    ) -> Response[Environment]: ...
+    ) -> Response[Environment, EnvironmentType]: ...
 
     async def async_create_or_update_environment(
         self,
@@ -8631,7 +8810,7 @@ class ReposClient:
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Environment]:
+    ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/rest/deployments/environments#create-or-update-an-environment"""
 
         from typing import Union
@@ -8718,7 +8897,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#list-deployment-branch-policies"""
 
@@ -8753,7 +8933,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#list-deployment-branch-policies"""
 
@@ -8787,7 +8968,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     def create_deployment_branch_policy(
@@ -8800,7 +8981,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     def create_deployment_branch_policy(
         self,
@@ -8811,7 +8992,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#create-a-deployment-branch-policy"""
 
         from ..models import (
@@ -8850,7 +9031,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     async def async_create_deployment_branch_policy(
@@ -8863,7 +9044,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     async def async_create_deployment_branch_policy(
         self,
@@ -8874,7 +9055,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#create-a-deployment-branch-policy"""
 
         from ..models import (
@@ -8912,7 +9093,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy
@@ -8936,7 +9117,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy
@@ -8962,7 +9143,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     def update_deployment_branch_policy(
@@ -8975,7 +9156,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     def update_deployment_branch_policy(
         self,
@@ -8987,7 +9168,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#update-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy, DeploymentBranchPolicyNamePattern
@@ -9023,7 +9204,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     @overload
     async def async_update_deployment_branch_policy(
@@ -9036,7 +9217,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         name: str,
-    ) -> Response[DeploymentBranchPolicy]: ...
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
     async def async_update_deployment_branch_policy(
         self,
@@ -9048,7 +9229,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentBranchPolicy]:
+    ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#update-a-deployment-branch-policy"""
 
         from ..models import DeploymentBranchPolicy, DeploymentBranchPolicyNamePattern
@@ -9124,7 +9305,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#get-all-deployment-protection-rules-for-an-environment"""
 
@@ -9151,7 +9333,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#get-all-deployment-protection-rules-for-an-environment"""
 
@@ -9179,7 +9362,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     @overload
     def create_deployment_protection_rule(
@@ -9191,7 +9374,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         integration_id: Missing[int] = UNSET,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     def create_deployment_protection_rule(
         self,
@@ -9204,7 +9387,7 @@ class ReposClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#create-a-custom-deployment-protection-rule-on-an-environment"""
 
         from ..models import (
@@ -9245,7 +9428,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     @overload
     async def async_create_deployment_protection_rule(
@@ -9257,7 +9440,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         integration_id: Missing[int] = UNSET,
-    ) -> Response[DeploymentProtectionRule]: ...
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
     async def async_create_deployment_protection_rule(
         self,
@@ -9270,7 +9453,7 @@ class ReposClient:
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#create-a-custom-deployment-protection-rule-on-an-environment"""
 
         from ..models import (
@@ -9312,7 +9495,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#list-custom-deployment-rule-integrations-available-for-an-environment"""
 
@@ -9347,7 +9531,8 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
     ) -> Response[
-        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
+        ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
     ]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#list-custom-deployment-rule-integrations-available-for-an-environment"""
 
@@ -9380,7 +9565,7 @@ class ReposClient:
         protection_rule_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
         from ..models import DeploymentProtectionRule
@@ -9404,7 +9589,7 @@ class ReposClient:
         protection_rule_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeploymentProtectionRule]:
+    ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
         from ..models import DeploymentProtectionRule
@@ -9471,7 +9656,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/forks#list-forks"""
 
         from ..models import BasicError, MinimalRepository
@@ -9506,7 +9691,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/forks#list-forks"""
 
         from ..models import BasicError, MinimalRepository
@@ -9540,7 +9725,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_fork(
@@ -9553,7 +9738,7 @@ class ReposClient:
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_fork(
         self,
@@ -9563,7 +9748,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/forks#create-a-fork"""
 
         from typing import Union
@@ -9610,7 +9795,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_fork(
@@ -9623,7 +9808,7 @@ class ReposClient:
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_fork(
         self,
@@ -9633,7 +9818,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/forks#create-a-fork"""
 
         from typing import Union
@@ -9680,7 +9865,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Hook]]:
+    ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-repository-webhooks"""
 
         from ..models import Hook, BasicError
@@ -9713,7 +9898,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Hook]]:
+    ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-repository-webhooks"""
 
         from ..models import Hook, BasicError
@@ -9746,7 +9931,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     def create_webhook(
@@ -9760,7 +9945,7 @@ class ReposClient:
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     def create_webhook(
         self,
@@ -9770,7 +9955,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#create-a-repository-webhook"""
 
         from typing import Union
@@ -9816,7 +10001,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     async def async_create_webhook(
@@ -9830,7 +10015,7 @@ class ReposClient:
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     async def async_create_webhook(
         self,
@@ -9840,7 +10025,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#create-a-repository-webhook"""
 
         from typing import Union
@@ -9885,7 +10070,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-repository-webhook"""
 
         from ..models import Hook, BasicError
@@ -9911,7 +10096,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-repository-webhook"""
 
         from ..models import Hook, BasicError
@@ -9989,7 +10174,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     def update_webhook(
@@ -10005,7 +10190,7 @@ class ReposClient:
         add_events: Missing[list[str]] = UNSET,
         remove_events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     def update_webhook(
         self,
@@ -10016,7 +10201,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#update-a-repository-webhook"""
 
         from ..models import (
@@ -10060,7 +10245,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     @overload
     async def async_update_webhook(
@@ -10076,7 +10261,7 @@ class ReposClient:
         add_events: Missing[list[str]] = UNSET,
         remove_events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
-    ) -> Response[Hook]: ...
+    ) -> Response[Hook, HookType]: ...
 
     async def async_update_webhook(
         self,
@@ -10087,7 +10272,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Hook]:
+    ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#update-a-repository-webhook"""
 
         from ..models import (
@@ -10129,7 +10314,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig
@@ -10152,7 +10337,7 @@ class ReposClient:
         hook_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig
@@ -10177,7 +10362,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     def update_webhook_config_for_repo(
@@ -10192,7 +10377,7 @@ class ReposClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     def update_webhook_config_for_repo(
         self,
@@ -10203,7 +10388,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/repos/webhooks#update-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig, ReposOwnerRepoHooksHookIdConfigPatchBody
@@ -10238,7 +10423,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     @overload
     async def async_update_webhook_config_for_repo(
@@ -10253,7 +10438,7 @@ class ReposClient:
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
         insecure_ssl: Missing[Union[str, float]] = UNSET,
-    ) -> Response[WebhookConfig]: ...
+    ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
     async def async_update_webhook_config_for_repo(
         self,
@@ -10264,7 +10449,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[WebhookConfig]:
+    ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/repos/webhooks#update-a-webhook-configuration-for-a-repository"""
 
         from ..models import WebhookConfig, ReposOwnerRepoHooksHookIdConfigPatchBody
@@ -10299,7 +10484,7 @@ class ReposClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -10334,7 +10519,7 @@ class ReposClient:
         cursor: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[HookDeliveryItem]]:
+    ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
         from ..models import BasicError, ValidationError, HookDeliveryItem
@@ -10368,7 +10553,7 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -10396,7 +10581,7 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[HookDelivery]:
+    ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
         from ..models import BasicError, HookDelivery, ValidationError
@@ -10424,7 +10609,10 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/webhooks#redeliver-a-delivery-for-a-repository-webhook"""
 
         from ..models import (
@@ -10456,7 +10644,10 @@ class ReposClient:
         delivery_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/webhooks#redeliver-a-delivery-for-a-repository-webhook"""
 
         from ..models import (
@@ -10588,7 +10779,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations"""
 
         from ..models import RepositoryInvitation
@@ -10618,7 +10809,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations"""
 
         from ..models import RepositoryInvitation
@@ -10689,7 +10880,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     def update_invitation(
@@ -10703,7 +10894,7 @@ class ReposClient:
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     def update_invitation(
         self,
@@ -10714,7 +10905,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/rest/collaborators/invitations#update-a-repository-invitation"""
 
         from ..models import (
@@ -10754,7 +10945,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     @overload
     async def async_update_invitation(
@@ -10768,7 +10959,7 @@ class ReposClient:
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
-    ) -> Response[RepositoryInvitation]: ...
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
     async def async_update_invitation(
         self,
@@ -10779,7 +10970,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryInvitation]:
+    ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
         """See also: https://docs.github.com/rest/collaborators/invitations#update-a-repository-invitation"""
 
         from ..models import (
@@ -10818,7 +11009,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeployKey]]:
+    ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
         from ..models import DeployKey
@@ -10848,7 +11039,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[DeployKey]]:
+    ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
         from ..models import DeployKey
@@ -10878,7 +11069,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     @overload
     def create_deploy_key(
@@ -10891,7 +11082,7 @@ class ReposClient:
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     def create_deploy_key(
         self,
@@ -10901,7 +11092,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#create-a-deploy-key"""
 
         from ..models import DeployKey, ValidationError, ReposOwnerRepoKeysPostBody
@@ -10938,7 +11129,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     @overload
     async def async_create_deploy_key(
@@ -10951,7 +11142,7 @@ class ReposClient:
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
-    ) -> Response[DeployKey]: ...
+    ) -> Response[DeployKey, DeployKeyType]: ...
 
     async def async_create_deploy_key(
         self,
@@ -10961,7 +11152,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#create-a-deploy-key"""
 
         from ..models import DeployKey, ValidationError, ReposOwnerRepoKeysPostBody
@@ -10997,7 +11188,7 @@ class ReposClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
         from ..models import DeployKey, BasicError
@@ -11023,7 +11214,7 @@ class ReposClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[DeployKey]:
+    ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
         from ..models import DeployKey, BasicError
@@ -11088,7 +11279,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Language]:
+    ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-languages"""
 
         from ..models import Language
@@ -11110,7 +11301,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Language]:
+    ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-languages"""
 
         from ..models import Language
@@ -11134,7 +11325,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     @overload
     def merge_upstream(
@@ -11145,7 +11336,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         branch: str,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     def merge_upstream(
         self,
@@ -11155,7 +11346,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MergedUpstream]:
+    ) -> Response[MergedUpstream, MergedUpstreamType]:
         """See also: https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository"""
 
         from ..models import MergedUpstream, ReposOwnerRepoMergeUpstreamPostBody
@@ -11190,7 +11381,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     @overload
     async def async_merge_upstream(
@@ -11201,7 +11392,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         branch: str,
-    ) -> Response[MergedUpstream]: ...
+    ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
     async def async_merge_upstream(
         self,
@@ -11211,7 +11402,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MergedUpstream]:
+    ) -> Response[MergedUpstream, MergedUpstreamType]:
         """See also: https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository"""
 
         from ..models import MergedUpstream, ReposOwnerRepoMergeUpstreamPostBody
@@ -11246,7 +11437,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     @overload
     def merge(
@@ -11259,7 +11450,7 @@ class ReposClient:
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     def merge(
         self,
@@ -11269,7 +11460,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/rest/branches/branches#merge-a-branch"""
 
         from ..models import (
@@ -11312,7 +11503,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     @overload
     async def async_merge(
@@ -11325,7 +11516,7 @@ class ReposClient:
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
-    ) -> Response[Commit]: ...
+    ) -> Response[Commit, CommitType]: ...
 
     async def async_merge(
         self,
@@ -11335,7 +11526,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Commit]:
+    ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/rest/branches/branches#merge-a-branch"""
 
         from ..models import (
@@ -11376,7 +11567,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site"""
 
         from ..models import Page, BasicError
@@ -11401,7 +11592,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site"""
 
         from ..models import Page, BasicError
@@ -11781,7 +11972,7 @@ class ReposClient:
             ReposOwnerRepoPagesPostBodyAnyof1Type,
             None,
         ],
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     def create_pages_site(
@@ -11793,7 +11984,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     def create_pages_site(
@@ -11805,7 +11996,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     def create_pages_site(
         self,
@@ -11822,7 +12013,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/rest/pages/pages#create-a-apiname-pages-site"""
 
         from typing import Union
@@ -11881,7 +12072,7 @@ class ReposClient:
             ReposOwnerRepoPagesPostBodyAnyof1Type,
             None,
         ],
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     async def async_create_pages_site(
@@ -11893,7 +12084,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     @overload
     async def async_create_pages_site(
@@ -11905,7 +12096,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
-    ) -> Response[Page]: ...
+    ) -> Response[Page, PageType]: ...
 
     async def async_create_pages_site(
         self,
@@ -11922,7 +12113,7 @@ class ReposClient:
             ]
         ] = UNSET,
         **kwargs,
-    ) -> Response[Page]:
+    ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/rest/pages/pages#create-a-apiname-pages-site"""
 
         from typing import Union
@@ -12028,7 +12219,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PageBuild]]:
+    ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/rest/pages/pages#list-apiname-pages-builds"""
 
         from ..models import PageBuild
@@ -12058,7 +12249,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[PageBuild]]:
+    ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/rest/pages/pages#list-apiname-pages-builds"""
 
         from ..models import PageBuild
@@ -12086,7 +12277,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuildStatus]:
+    ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#request-a-apiname-pages-build"""
 
         from ..models import PageBuildStatus
@@ -12108,7 +12299,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuildStatus]:
+    ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#request-a-apiname-pages-build"""
 
         from ..models import PageBuildStatus
@@ -12130,7 +12321,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-latest-pages-build"""
 
         from ..models import PageBuild
@@ -12152,7 +12343,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-latest-pages-build"""
 
         from ..models import PageBuild
@@ -12175,7 +12366,7 @@ class ReposClient:
         build_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-apiname-pages-build"""
 
         from ..models import PageBuild
@@ -12198,7 +12389,7 @@ class ReposClient:
         build_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PageBuild]:
+    ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-apiname-pages-build"""
 
         from ..models import PageBuild
@@ -12222,7 +12413,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     @overload
     def create_pages_deployment(
@@ -12237,7 +12428,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         pages_build_version: str = "GITHUB_SHA",
         oidc_token: str,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     def create_pages_deployment(
         self,
@@ -12247,7 +12438,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PageDeployment]:
+    ) -> Response[PageDeployment, PageDeploymentType]:
         """See also: https://docs.github.com/rest/pages/pages#create-a-github-pages-deployment"""
 
         from ..models import (
@@ -12291,7 +12482,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     @overload
     async def async_create_pages_deployment(
@@ -12306,7 +12497,7 @@ class ReposClient:
         environment: Missing[str] = UNSET,
         pages_build_version: str = "GITHUB_SHA",
         oidc_token: str,
-    ) -> Response[PageDeployment]: ...
+    ) -> Response[PageDeployment, PageDeploymentType]: ...
 
     async def async_create_pages_deployment(
         self,
@@ -12316,7 +12507,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PageDeployment]:
+    ) -> Response[PageDeployment, PageDeploymentType]:
         """See also: https://docs.github.com/rest/pages/pages#create-a-github-pages-deployment"""
 
         from ..models import (
@@ -12359,7 +12550,7 @@ class ReposClient:
         pages_deployment_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesDeploymentStatus]:
+    ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
         from ..models import BasicError, PagesDeploymentStatus
@@ -12385,7 +12576,7 @@ class ReposClient:
         pages_deployment_id: Union[int, str],
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesDeploymentStatus]:
+    ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
         from ..models import BasicError, PagesDeploymentStatus
@@ -12460,7 +12651,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesHealthCheck]:
+    ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
         from ..models import BasicError, PagesHealthCheck
@@ -12485,7 +12676,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[PagesHealthCheck]:
+    ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
         from ..models import BasicError, PagesHealthCheck
@@ -12510,7 +12701,10 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/repos#check-if-private-vulnerability-reporting-is-enabled-for-a-repository"""
 
         from ..models import (
@@ -12538,7 +12732,10 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200]:
+    ) -> Response[
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
+        ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/repos/repos#check-if-private-vulnerability-reporting-is-enabled-for-a-repository"""
 
         from ..models import (
@@ -12662,7 +12859,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomPropertyValue]]:
+    ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
         from ..models import BasicError, CustomPropertyValue
@@ -12688,7 +12885,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CustomPropertyValue]]:
+    ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
         from ..models import BasicError, CustomPropertyValue
@@ -12841,7 +13038,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -12873,7 +13070,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -12906,7 +13103,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -12939,7 +13136,7 @@ class ReposClient:
         ref: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ContentFile]:
+    ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
         from ..models import BasicError, ContentFile, ValidationError
@@ -12972,7 +13169,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Release]]:
+    ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/rest/releases/releases#list-releases"""
 
         from ..models import Release, BasicError
@@ -13005,7 +13202,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Release]]:
+    ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/rest/releases/releases#list-releases"""
 
         from ..models import Release, BasicError
@@ -13038,7 +13235,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     def create_release(
@@ -13057,7 +13254,7 @@ class ReposClient:
         discussion_category_name: Missing[str] = UNSET,
         generate_release_notes: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     def create_release(
         self,
@@ -13067,7 +13264,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#create-a-release"""
 
         from ..models import (
@@ -13110,7 +13307,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     async def async_create_release(
@@ -13129,7 +13326,7 @@ class ReposClient:
         discussion_category_name: Missing[str] = UNSET,
         generate_release_notes: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     async def async_create_release(
         self,
@@ -13139,7 +13336,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#create-a-release"""
 
         from ..models import (
@@ -13181,7 +13378,7 @@ class ReposClient:
         asset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#get-a-release-asset"""
 
         from ..models import BasicError, ReleaseAsset
@@ -13207,7 +13404,7 @@ class ReposClient:
         asset_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#get-a-release-asset"""
 
         from ..models import BasicError, ReleaseAsset
@@ -13275,7 +13472,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     @overload
     def update_release_asset(
@@ -13289,7 +13486,7 @@ class ReposClient:
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     def update_release_asset(
         self,
@@ -13300,7 +13497,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#update-a-release-asset"""
 
         from ..models import ReleaseAsset, ReposOwnerRepoReleasesAssetsAssetIdPatchBody
@@ -13337,7 +13534,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     @overload
     async def async_update_release_asset(
@@ -13351,7 +13548,7 @@ class ReposClient:
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
-    ) -> Response[ReleaseAsset]: ...
+    ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
     async def async_update_release_asset(
         self,
@@ -13362,7 +13559,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#update-a-release-asset"""
 
         from ..models import ReleaseAsset, ReposOwnerRepoReleasesAssetsAssetIdPatchBody
@@ -13398,7 +13595,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     @overload
     def generate_release_notes(
@@ -13412,7 +13609,7 @@ class ReposClient:
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
         configuration_file_path: Missing[str] = UNSET,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     def generate_release_notes(
         self,
@@ -13422,7 +13619,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseNotesContent]:
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
         """See also: https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release"""
 
         from ..models import (
@@ -13465,7 +13662,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     @overload
     async def async_generate_release_notes(
@@ -13479,7 +13676,7 @@ class ReposClient:
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
         configuration_file_path: Missing[str] = UNSET,
-    ) -> Response[ReleaseNotesContent]: ...
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
     async def async_generate_release_notes(
         self,
@@ -13489,7 +13686,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[ReleaseNotesContent]:
+    ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
         """See also: https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release"""
 
         from ..models import (
@@ -13530,7 +13727,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-the-latest-release"""
 
         from ..models import Release
@@ -13552,7 +13749,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-the-latest-release"""
 
         from ..models import Release
@@ -13575,7 +13772,7 @@ class ReposClient:
         tag: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name"""
 
         from ..models import Release, BasicError
@@ -13601,7 +13798,7 @@ class ReposClient:
         tag: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name"""
 
         from ..models import Release, BasicError
@@ -13627,7 +13824,7 @@ class ReposClient:
         release_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release"""
 
         from ..models import Release
@@ -13651,7 +13848,7 @@ class ReposClient:
         release_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release"""
 
         from ..models import Release
@@ -13717,7 +13914,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     def update_release(
@@ -13736,7 +13933,7 @@ class ReposClient:
         prerelease: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
         discussion_category_name: Missing[str] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     def update_release(
         self,
@@ -13747,7 +13944,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#update-a-release"""
 
         from ..models import (
@@ -13789,7 +13986,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     @overload
     async def async_update_release(
@@ -13808,7 +14005,7 @@ class ReposClient:
         prerelease: Missing[bool] = UNSET,
         make_latest: Missing[Literal["true", "false", "legacy"]] = UNSET,
         discussion_category_name: Missing[str] = UNSET,
-    ) -> Response[Release]: ...
+    ) -> Response[Release, ReleaseType]: ...
 
     async def async_update_release(
         self,
@@ -13819,7 +14016,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Release]:
+    ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#update-a-release"""
 
         from ..models import (
@@ -13861,7 +14058,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReleaseAsset]]:
+    ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/rest/releases/assets#list-release-assets"""
 
         from ..models import ReleaseAsset
@@ -13892,7 +14089,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReleaseAsset]]:
+    ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/rest/releases/assets#list-release-assets"""
 
         from ..models import ReleaseAsset
@@ -13924,7 +14121,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: FileTypes,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#upload-a-release-asset"""
 
         from ..models import ReleaseAsset
@@ -13964,7 +14161,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: FileTypes,
-    ) -> Response[ReleaseAsset]:
+    ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#upload-a-release-asset"""
 
         from ..models import ReleaseAsset
@@ -14024,7 +14221,28 @@ class ReposClient:
                 RepositoryRuleDetailedOneof15,
                 RepositoryRuleDetailedOneof16,
             ]
-        ]
+        ],
+        list[
+            Union[
+                RepositoryRuleDetailedOneof0Type,
+                RepositoryRuleDetailedOneof1Type,
+                RepositoryRuleDetailedOneof2Type,
+                RepositoryRuleDetailedOneof3Type,
+                RepositoryRuleDetailedOneof4Type,
+                RepositoryRuleDetailedOneof5Type,
+                RepositoryRuleDetailedOneof6Type,
+                RepositoryRuleDetailedOneof7Type,
+                RepositoryRuleDetailedOneof8Type,
+                RepositoryRuleDetailedOneof9Type,
+                RepositoryRuleDetailedOneof10Type,
+                RepositoryRuleDetailedOneof11Type,
+                RepositoryRuleDetailedOneof12Type,
+                RepositoryRuleDetailedOneof13Type,
+                RepositoryRuleDetailedOneof14Type,
+                RepositoryRuleDetailedOneof15Type,
+                RepositoryRuleDetailedOneof16Type,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/rest/repos/rules#get-rules-for-a-branch"""
 
@@ -14117,7 +14335,28 @@ class ReposClient:
                 RepositoryRuleDetailedOneof15,
                 RepositoryRuleDetailedOneof16,
             ]
-        ]
+        ],
+        list[
+            Union[
+                RepositoryRuleDetailedOneof0Type,
+                RepositoryRuleDetailedOneof1Type,
+                RepositoryRuleDetailedOneof2Type,
+                RepositoryRuleDetailedOneof3Type,
+                RepositoryRuleDetailedOneof4Type,
+                RepositoryRuleDetailedOneof5Type,
+                RepositoryRuleDetailedOneof6Type,
+                RepositoryRuleDetailedOneof7Type,
+                RepositoryRuleDetailedOneof8Type,
+                RepositoryRuleDetailedOneof9Type,
+                RepositoryRuleDetailedOneof10Type,
+                RepositoryRuleDetailedOneof11Type,
+                RepositoryRuleDetailedOneof12Type,
+                RepositoryRuleDetailedOneof13Type,
+                RepositoryRuleDetailedOneof14Type,
+                RepositoryRuleDetailedOneof15Type,
+                RepositoryRuleDetailedOneof16Type,
+            ]
+        ],
     ]:
         """See also: https://docs.github.com/rest/repos/rules#get-rules-for-a-branch"""
 
@@ -14190,7 +14429,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14228,7 +14467,7 @@ class ReposClient:
         targets: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryRuleset]]:
+    ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14264,7 +14503,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def create_repo_ruleset(
@@ -14306,7 +14545,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def create_repo_ruleset(
         self,
@@ -14316,7 +14555,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#create-a-repository-ruleset"""
 
         from ..models import (
@@ -14358,7 +14597,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_create_repo_ruleset(
@@ -14400,7 +14639,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_create_repo_ruleset(
         self,
@@ -14410,7 +14649,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#create-a-repository-ruleset"""
 
         from ..models import (
@@ -14456,7 +14695,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -14498,7 +14737,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RuleSuitesItems]]:
+    ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites"""
 
         from ..models import BasicError, RuleSuitesItems
@@ -14535,7 +14774,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -14562,7 +14801,7 @@ class ReposClient:
         rule_suite_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RuleSuite]:
+    ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite"""
 
         from ..models import RuleSuite, BasicError
@@ -14590,7 +14829,7 @@ class ReposClient:
         includes_parents: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#get-a-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14623,7 +14862,7 @@ class ReposClient:
         includes_parents: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#get-a-repository-ruleset"""
 
         from ..models import BasicError, RepositoryRuleset
@@ -14657,7 +14896,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     def update_repo_ruleset(
@@ -14700,7 +14939,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     def update_repo_ruleset(
         self,
@@ -14711,7 +14950,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#update-a-repository-ruleset"""
 
         from ..models import (
@@ -14754,7 +14993,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     @overload
     async def async_update_repo_ruleset(
@@ -14797,7 +15036,7 @@ class ReposClient:
                 ]
             ]
         ] = UNSET,
-    ) -> Response[RepositoryRuleset]: ...
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
     async def async_update_repo_ruleset(
         self,
@@ -14808,7 +15047,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryRuleset]:
+    ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#update-a-repository-ruleset"""
 
         from ..models import (
@@ -14900,7 +15139,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-activity"""
 
         url = f"/repos/{owner}/{repo}/stats/code_frequency"
@@ -14921,7 +15160,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-activity"""
 
         url = f"/repos/{owner}/{repo}/stats/code_frequency"
@@ -14942,7 +15181,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitActivity]]:
+    ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
         from ..models import CommitActivity
@@ -14964,7 +15203,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[CommitActivity]]:
+    ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
         from ..models import CommitActivity
@@ -14986,7 +15225,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContributorActivity]]:
+    ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-all-contributor-commit-activity"""
 
         from ..models import ContributorActivity
@@ -15008,7 +15247,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContributorActivity]]:
+    ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-all-contributor-commit-activity"""
 
         from ..models import ContributorActivity
@@ -15030,7 +15269,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ParticipationStats]:
+    ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-count"""
 
         from ..models import BasicError, ParticipationStats
@@ -15055,7 +15294,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ParticipationStats]:
+    ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-count"""
 
         from ..models import BasicError, ParticipationStats
@@ -15080,7 +15319,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
         url = f"/repos/{owner}/{repo}/stats/punch_card"
@@ -15100,7 +15339,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[list[int]]]:
+    ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
         url = f"/repos/{owner}/{repo}/stats/punch_card"
@@ -15123,7 +15362,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     @overload
     def create_commit_status(
@@ -15138,7 +15377,7 @@ class ReposClient:
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     def create_commit_status(
         self,
@@ -15149,7 +15388,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Status]:
+    ) -> Response[Status, StatusType]:
         """See also: https://docs.github.com/rest/commits/statuses#create-a-commit-status"""
 
         from ..models import Status, ReposOwnerRepoStatusesShaPostBody
@@ -15184,7 +15423,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     @overload
     async def async_create_commit_status(
@@ -15199,7 +15438,7 @@ class ReposClient:
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         context: Missing[str] = UNSET,
-    ) -> Response[Status]: ...
+    ) -> Response[Status, StatusType]: ...
 
     async def async_create_commit_status(
         self,
@@ -15210,7 +15449,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Status]:
+    ) -> Response[Status, StatusType]:
         """See also: https://docs.github.com/rest/commits/statuses#create-a-commit-status"""
 
         from ..models import Status, ReposOwnerRepoStatusesShaPostBody
@@ -15244,7 +15483,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Tag]]:
+    ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-tags"""
 
         from ..models import Tag
@@ -15274,7 +15513,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Tag]]:
+    ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-tags"""
 
         from ..models import Tag
@@ -15302,7 +15541,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TagProtection]]:
+    ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
         from ..models import BasicError, TagProtection
@@ -15328,7 +15567,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TagProtection]]:
+    ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
         from ..models import BasicError, TagProtection
@@ -15356,7 +15595,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     @overload
     def create_tag_protection(
@@ -15367,7 +15606,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         pattern: str,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     def create_tag_protection(
         self,
@@ -15377,7 +15616,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TagProtection]:
+    ) -> Response[TagProtection, TagProtectionType]:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---create-a-tag-protection-state-for-a-repository"""
 
         from ..models import (
@@ -15419,7 +15658,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     @overload
     async def async_create_tag_protection(
@@ -15430,7 +15669,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         pattern: str,
-    ) -> Response[TagProtection]: ...
+    ) -> Response[TagProtection, TagProtectionType]: ...
 
     async def async_create_tag_protection(
         self,
@@ -15440,7 +15679,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TagProtection]:
+    ) -> Response[TagProtection, TagProtectionType]:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---create-a-tag-protection-state-for-a-repository"""
 
         from ..models import (
@@ -15574,7 +15813,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-teams"""
 
         from ..models import Team, BasicError
@@ -15607,7 +15846,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-teams"""
 
         from ..models import Team, BasicError
@@ -15640,7 +15879,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/rest/repos/repos#get-all-repository-topics"""
 
         from ..models import Topic, BasicError
@@ -15673,7 +15912,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/rest/repos/repos#get-all-repository-topics"""
 
         from ..models import Topic, BasicError
@@ -15706,7 +15945,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     @overload
     def replace_all_topics(
@@ -15717,7 +15956,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         names: list[str],
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     def replace_all_topics(
         self,
@@ -15727,7 +15966,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/rest/repos/repos#replace-all-repository-topics"""
 
         from ..models import (
@@ -15770,7 +16009,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     @overload
     async def async_replace_all_topics(
@@ -15781,7 +16020,7 @@ class ReposClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         names: list[str],
-    ) -> Response[Topic]: ...
+    ) -> Response[Topic, TopicType]: ...
 
     async def async_replace_all_topics(
         self,
@@ -15791,7 +16030,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Topic]:
+    ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/rest/repos/repos#replace-all-repository-topics"""
 
         from ..models import (
@@ -15833,7 +16072,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CloneTraffic]:
+    ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-repository-clones"""
 
         from ..models import BasicError, CloneTraffic
@@ -15864,7 +16103,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[CloneTraffic]:
+    ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-repository-clones"""
 
         from ..models import BasicError, CloneTraffic
@@ -15894,7 +16133,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContentTraffic]]:
+    ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-paths"""
 
         from ..models import BasicError, ContentTraffic
@@ -15919,7 +16158,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ContentTraffic]]:
+    ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-paths"""
 
         from ..models import BasicError, ContentTraffic
@@ -15944,7 +16183,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReferrerTraffic]]:
+    ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-sources"""
 
         from ..models import BasicError, ReferrerTraffic
@@ -15969,7 +16208,7 @@ class ReposClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[ReferrerTraffic]]:
+    ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-sources"""
 
         from ..models import BasicError, ReferrerTraffic
@@ -15995,7 +16234,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ViewTraffic]:
+    ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-page-views"""
 
         from ..models import BasicError, ViewTraffic
@@ -16026,7 +16265,7 @@ class ReposClient:
         per: Missing[Literal["day", "week"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[ViewTraffic]:
+    ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-page-views"""
 
         from ..models import BasicError, ViewTraffic
@@ -16058,7 +16297,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     @overload
     def transfer(
@@ -16071,7 +16310,7 @@ class ReposClient:
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     def transfer(
         self,
@@ -16081,7 +16320,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MinimalRepository]:
+    ) -> Response[MinimalRepository, MinimalRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#transfer-a-repository"""
 
         from ..models import MinimalRepository, ReposOwnerRepoTransferPostBody
@@ -16115,7 +16354,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     @overload
     async def async_transfer(
@@ -16128,7 +16367,7 @@ class ReposClient:
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
-    ) -> Response[MinimalRepository]: ...
+    ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
     async def async_transfer(
         self,
@@ -16138,7 +16377,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[MinimalRepository]:
+    ) -> Response[MinimalRepository, MinimalRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#transfer-a-repository"""
 
         from ..models import MinimalRepository, ReposOwnerRepoTransferPostBody
@@ -16328,7 +16567,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_using_template(
@@ -16343,7 +16582,7 @@ class ReposClient:
         description: Missing[str] = UNSET,
         include_all_branches: Missing[bool] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_using_template(
         self,
@@ -16353,7 +16592,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#create-a-repository-using-a-template"""
 
         from ..models import (
@@ -16392,7 +16631,7 @@ class ReposClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_using_template(
@@ -16407,7 +16646,7 @@ class ReposClient:
         description: Missing[str] = UNSET,
         include_all_branches: Missing[bool] = UNSET,
         private: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_using_template(
         self,
@@ -16417,7 +16656,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#create-a-repository-using-a-template"""
 
         from ..models import (
@@ -16453,7 +16692,7 @@ class ReposClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-public-repositories"""
 
         from ..models import ValidationError, MinimalRepository
@@ -16482,7 +16721,7 @@ class ReposClient:
         since: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-public-repositories"""
 
         from ..models import ValidationError, MinimalRepository
@@ -16519,7 +16758,7 @@ class ReposClient:
         before: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
         from ..models import BasicError, Repository, ValidationError
@@ -16566,7 +16805,7 @@ class ReposClient:
         before: Missing[datetime] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Repository]]:
+    ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
         from ..models import BasicError, Repository, ValidationError
@@ -16603,7 +16842,7 @@ class ReposClient:
     @overload
     def create_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     def create_for_authenticated_user(
@@ -16638,7 +16877,7 @@ class ReposClient:
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
         has_downloads: Missing[bool] = UNSET,
         is_template: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     def create_for_authenticated_user(
         self,
@@ -16646,7 +16885,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#create-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -16687,7 +16926,7 @@ class ReposClient:
     @overload
     async def async_create_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
     async def async_create_for_authenticated_user(
@@ -16722,7 +16961,7 @@ class ReposClient:
         merge_commit_message: Missing[Literal["PR_BODY", "PR_TITLE", "BLANK"]] = UNSET,
         has_downloads: Missing[bool] = UNSET,
         is_template: Missing[bool] = UNSET,
-    ) -> Response[FullRepository]: ...
+    ) -> Response[FullRepository, FullRepositoryType]: ...
 
     async def async_create_for_authenticated_user(
         self,
@@ -16730,7 +16969,7 @@ class ReposClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#create-a-repository-for-the-authenticated-user"""
 
         from ..models import (
@@ -16774,7 +17013,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
         from ..models import BasicError, RepositoryInvitation
@@ -16807,7 +17046,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryInvitation]]:
+    ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
         from ..models import BasicError, RepositoryInvitation
@@ -16944,7 +17183,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-a-user"""
 
         from ..models import MinimalRepository
@@ -16979,7 +17218,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-a-user"""
 
         from ..models import MinimalRepository

--- a/githubkit/versions/v2022_11_28/rest/search.py
+++ b/githubkit/versions/v2022_11_28/rest/search.py
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
         SearchCommitsGetResponse200,
         SearchRepositoriesGetResponse200,
     )
+    from ..types import (
+        SearchCodeGetResponse200Type,
+        SearchUsersGetResponse200Type,
+        SearchIssuesGetResponse200Type,
+        SearchLabelsGetResponse200Type,
+        SearchTopicsGetResponse200Type,
+        SearchCommitsGetResponse200Type,
+        SearchRepositoriesGetResponse200Type,
+    )
 
 
 class SearchClient:
@@ -58,7 +67,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCodeGetResponse200]:
+    ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-code"""
 
         from ..models import (
@@ -102,7 +111,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCodeGetResponse200]:
+    ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-code"""
 
         from ..models import (
@@ -146,7 +155,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCommitsGetResponse200]:
+    ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-commits"""
 
         from ..models import SearchCommitsGetResponse200
@@ -180,7 +189,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchCommitsGetResponse200]:
+    ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-commits"""
 
         from ..models import SearchCommitsGetResponse200
@@ -228,7 +237,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchIssuesGetResponse200]:
+    ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-issues-and-pull-requests"""
 
         from ..models import (
@@ -286,7 +295,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchIssuesGetResponse200]:
+    ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-issues-and-pull-requests"""
 
         from ..models import (
@@ -331,7 +340,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchLabelsGetResponse200]:
+    ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-labels"""
 
         from ..models import BasicError, ValidationError, SearchLabelsGetResponse200
@@ -372,7 +381,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchLabelsGetResponse200]:
+    ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-labels"""
 
         from ..models import BasicError, ValidationError, SearchLabelsGetResponse200
@@ -414,7 +423,9 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchRepositoriesGetResponse200]:
+    ) -> Response[
+        SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/search/search#search-repositories"""
 
         from ..models import (
@@ -458,7 +469,9 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchRepositoriesGetResponse200]:
+    ) -> Response[
+        SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
+    ]:
         """See also: https://docs.github.com/rest/search/search#search-repositories"""
 
         from ..models import (
@@ -498,7 +511,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchTopicsGetResponse200]:
+    ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-topics"""
 
         from ..models import SearchTopicsGetResponse200
@@ -528,7 +541,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchTopicsGetResponse200]:
+    ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-topics"""
 
         from ..models import SearchTopicsGetResponse200
@@ -560,7 +573,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchUsersGetResponse200]:
+    ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-users"""
 
         from ..models import (
@@ -602,7 +615,7 @@ class SearchClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SearchUsersGetResponse200]:
+    ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-users"""
 
         from ..models import (

--- a/githubkit/versions/v2022_11_28/rest/secret_scanning.py
+++ b/githubkit/versions/v2022_11_28/rest/secret_scanning.py
@@ -33,6 +33,10 @@ if TYPE_CHECKING:
         SecretScanningPushProtectionBypass,
     )
     from ..types import (
+        SecretScanningAlertType,
+        SecretScanningLocationType,
+        OrganizationSecretScanningAlertType,
+        SecretScanningPushProtectionBypassType,
         ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
         ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
     )
@@ -69,7 +73,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -124,7 +130,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-enterprise"""
 
         from ..models import (
@@ -180,7 +188,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -237,7 +247,9 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationSecretScanningAlert]]:
+    ) -> Response[
+        list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
+    ]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-an-organization"""
 
         from ..models import (
@@ -295,7 +307,7 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningAlert]]:
+    ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -351,7 +363,7 @@ class SecretScanningClient:
         is_multi_repo: Missing[bool] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningAlert]]:
+    ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
         from ..models import (
@@ -396,7 +408,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
         from ..models import (
@@ -425,7 +437,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
         from ..models import (
@@ -456,7 +468,7 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     @overload
     def update_alert(
@@ -474,7 +486,7 @@ class SecretScanningClient:
             ]
         ] = UNSET,
         resolution_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     def update_alert(
         self,
@@ -487,7 +499,7 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#update-a-secret-scanning-alert"""
 
         from ..models import (
@@ -531,7 +543,7 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     @overload
     async def async_update_alert(
@@ -549,7 +561,7 @@ class SecretScanningClient:
             ]
         ] = UNSET,
         resolution_comment: Missing[Union[str, None]] = UNSET,
-    ) -> Response[SecretScanningAlert]: ...
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
     async def async_update_alert(
         self,
@@ -562,7 +574,7 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningAlert]:
+    ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#update-a-secret-scanning-alert"""
 
         from ..models import (
@@ -606,7 +618,7 @@ class SecretScanningClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningLocation]]:
+    ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
         from ..models import (
@@ -643,7 +655,7 @@ class SecretScanningClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SecretScanningLocation]]:
+    ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
         from ..models import (
@@ -679,7 +691,9 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     @overload
     def create_push_protection_bypass(
@@ -691,7 +705,9 @@ class SecretScanningClient:
         headers: Optional[dict[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     def create_push_protection_bypass(
         self,
@@ -703,7 +719,9 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningPushProtectionBypass]:
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#create-a-push-protection-bypass"""
 
         from ..models import (
@@ -746,7 +764,9 @@ class SecretScanningClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     @overload
     async def async_create_push_protection_bypass(
@@ -758,7 +778,9 @@ class SecretScanningClient:
         headers: Optional[dict[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
-    ) -> Response[SecretScanningPushProtectionBypass]: ...
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]: ...
 
     async def async_create_push_protection_bypass(
         self,
@@ -770,7 +792,9 @@ class SecretScanningClient:
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[SecretScanningPushProtectionBypass]:
+    ) -> Response[
+        SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
+    ]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#create-a-push-protection-bypass"""
 
         from ..models import (

--- a/githubkit/versions/v2022_11_28/rest/security_advisories.py
+++ b/githubkit/versions/v2022_11_28/rest/security_advisories.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
     )
     from ..types import (
+        FullRepositoryType,
+        GlobalAdvisoryType,
+        RepositoryAdvisoryType,
         RepositoryAdvisoryCreateType,
         RepositoryAdvisoryUpdateType,
         PrivateVulnerabilityReportCreateType,
@@ -40,6 +43,7 @@ if TYPE_CHECKING:
         RepositoryAdvisoryUpdatePropCreditsItemsType,
         RepositoryAdvisoryCreatePropVulnerabilitiesItemsType,
         RepositoryAdvisoryUpdatePropVulnerabilitiesItemsType,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
         PrivateVulnerabilityReportCreatePropVulnerabilitiesItemsType,
     )
 
@@ -101,7 +105,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GlobalAdvisory]]:
+    ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#list-global-security-advisories"""
 
         from ..models import BasicError, GlobalAdvisory, ValidationErrorSimple
@@ -185,7 +189,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GlobalAdvisory]]:
+    ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#list-global-security-advisories"""
 
         from ..models import BasicError, GlobalAdvisory, ValidationErrorSimple
@@ -232,7 +236,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GlobalAdvisory]:
+    ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
         from ..models import BasicError, GlobalAdvisory
@@ -256,7 +260,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GlobalAdvisory]:
+    ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
         from ..models import BasicError, GlobalAdvisory
@@ -286,7 +290,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -327,7 +331,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -369,7 +373,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -411,7 +415,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[RepositoryAdvisory]]:
+    ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -449,7 +453,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     def create_repository_advisory(
@@ -472,7 +476,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     def create_repository_advisory(
         self,
@@ -482,7 +486,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#create-a-repository-security-advisory"""
 
         from ..models import (
@@ -526,7 +530,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     async def async_create_repository_advisory(
@@ -549,7 +553,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     async def async_create_repository_advisory(
         self,
@@ -559,7 +563,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#create-a-repository-security-advisory"""
 
         from ..models import (
@@ -603,7 +607,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     def create_private_vulnerability_report(
@@ -626,7 +630,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     def create_private_vulnerability_report(
         self,
@@ -636,7 +640,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#privately-report-a-security-vulnerability"""
 
         from ..models import (
@@ -680,7 +684,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     async def async_create_private_vulnerability_report(
@@ -703,7 +707,7 @@ class SecurityAdvisoriesClient:
         ] = UNSET,
         cvss_vector_string: Missing[Union[str, None]] = UNSET,
         start_private_fork: Missing[bool] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     async def async_create_private_vulnerability_report(
         self,
@@ -713,7 +717,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#privately-report-a-security-vulnerability"""
 
         from ..models import (
@@ -756,7 +760,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -783,7 +787,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
         from ..models import BasicError, RepositoryAdvisory
@@ -812,7 +816,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     def update_repository_advisory(
@@ -840,7 +844,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["published", "closed", "draft"]] = UNSET,
         collaborating_users: Missing[Union[list[str], None]] = UNSET,
         collaborating_teams: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     def update_repository_advisory(
         self,
@@ -851,7 +855,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#update-a-repository-security-advisory"""
 
         from ..models import (
@@ -896,7 +900,7 @@ class SecurityAdvisoriesClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     @overload
     async def async_update_repository_advisory(
@@ -924,7 +928,7 @@ class SecurityAdvisoriesClient:
         state: Missing[Literal["published", "closed", "draft"]] = UNSET,
         collaborating_users: Missing[Union[list[str], None]] = UNSET,
         collaborating_teams: Missing[Union[list[str], None]] = UNSET,
-    ) -> Response[RepositoryAdvisory]: ...
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
     async def async_update_repository_advisory(
         self,
@@ -935,7 +939,7 @@ class SecurityAdvisoriesClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
-    ) -> Response[RepositoryAdvisory]:
+    ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#update-a-repository-security-advisory"""
 
         from ..models import (
@@ -978,7 +982,10 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#request-a-cve-for-a-repository-security-advisory"""
 
         from ..models import (
@@ -1011,7 +1018,10 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[AppHookDeliveriesDeliveryIdAttemptsPostResponse202]:
+    ) -> Response[
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
+        AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
+    ]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#request-a-cve-for-a-repository-security-advisory"""
 
         from ..models import (
@@ -1044,7 +1054,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 
         from ..models import BasicError, FullRepository, ValidationError
@@ -1073,7 +1083,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[FullRepository]:
+    ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 
         from ..models import BasicError, FullRepository, ValidationError

--- a/githubkit/versions/v2022_11_28/rest/teams.py
+++ b/githubkit/versions/v2022_11_28/rest/teams.py
@@ -39,8 +39,18 @@ if TYPE_CHECKING:
         OrganizationInvitation,
     )
     from ..types import (
+        TeamType,
+        TeamFullType,
+        SimpleUserType,
+        TeamProjectType,
+        TeamDiscussionType,
+        TeamMembershipType,
+        TeamRepositoryType,
+        MinimalRepositoryType,
         OrgsOrgTeamsPostBodyType,
         TeamsTeamIdPatchBodyType,
+        TeamDiscussionCommentType,
+        OrganizationInvitationType,
         OrgsOrgTeamsTeamSlugPatchBodyType,
         TeamsTeamIdDiscussionsPostBodyType,
         TeamsTeamIdReposOwnerRepoPutBodyType,
@@ -81,7 +91,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams"""
 
         from ..models import Team, BasicError
@@ -113,7 +123,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams"""
 
         from ..models import Team, BasicError
@@ -145,7 +155,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     def create(
@@ -164,7 +174,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push"]] = UNSET,
         parent_team_id: Missing[int] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     def create(
         self,
@@ -173,7 +183,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#create-a-team"""
 
         from ..models import TeamFull, BasicError, ValidationError, OrgsOrgTeamsPostBody
@@ -210,7 +220,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     async def async_create(
@@ -229,7 +239,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push"]] = UNSET,
         parent_team_id: Missing[int] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     async def async_create(
         self,
@@ -238,7 +248,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#create-a-team"""
 
         from ..models import TeamFull, BasicError, ValidationError, OrgsOrgTeamsPostBody
@@ -274,7 +284,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-by-name"""
 
         from ..models import TeamFull, BasicError
@@ -299,7 +309,7 @@ class TeamsClient:
         team_slug: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-by-name"""
 
         from ..models import TeamFull, BasicError
@@ -364,7 +374,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     def update_in_org(
@@ -382,7 +392,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     def update_in_org(
         self,
@@ -392,7 +402,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#update-a-team"""
 
         from ..models import (
@@ -436,7 +446,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     async def async_update_in_org(
@@ -454,7 +464,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     async def async_update_in_org(
         self,
@@ -464,7 +474,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#update-a-team"""
 
         from ..models import (
@@ -510,7 +520,7 @@ class TeamsClient:
         pinned: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions"""
 
         from ..models import TeamDiscussion
@@ -544,7 +554,7 @@ class TeamsClient:
         pinned: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions"""
 
         from ..models import TeamDiscussion
@@ -576,7 +586,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def create_discussion_in_org(
@@ -589,7 +599,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def create_discussion_in_org(
         self,
@@ -599,7 +609,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#create-a-discussion"""
 
         from ..models import TeamDiscussion, OrgsOrgTeamsTeamSlugDiscussionsPostBody
@@ -633,7 +643,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_create_discussion_in_org(
@@ -646,7 +656,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_create_discussion_in_org(
         self,
@@ -656,7 +666,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#create-a-discussion"""
 
         from ..models import TeamDiscussion, OrgsOrgTeamsTeamSlugDiscussionsPostBody
@@ -689,7 +699,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion"""
 
         from ..models import TeamDiscussion
@@ -712,7 +722,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion"""
 
         from ..models import TeamDiscussion
@@ -779,7 +789,7 @@ class TeamsClient:
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def update_discussion_in_org(
@@ -792,7 +802,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def update_discussion_in_org(
         self,
@@ -805,7 +815,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#update-a-discussion"""
 
         from ..models import (
@@ -847,7 +857,7 @@ class TeamsClient:
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_update_discussion_in_org(
@@ -860,7 +870,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_update_discussion_in_org(
         self,
@@ -873,7 +883,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#update-a-discussion"""
 
         from ..models import (
@@ -914,7 +924,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments"""
 
         from ..models import TeamDiscussionComment
@@ -947,7 +957,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments"""
 
         from ..models import TeamDiscussionComment
@@ -979,7 +989,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def create_discussion_comment_in_org(
@@ -991,7 +1001,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def create_discussion_comment_in_org(
         self,
@@ -1004,7 +1014,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment"""
 
         from ..models import (
@@ -1044,7 +1054,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_create_discussion_comment_in_org(
@@ -1056,7 +1066,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_create_discussion_comment_in_org(
         self,
@@ -1069,7 +1079,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment"""
 
         from ..models import (
@@ -1108,7 +1118,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment"""
 
         from ..models import TeamDiscussionComment
@@ -1132,7 +1142,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment"""
 
         from ..models import TeamDiscussionComment
@@ -1200,7 +1210,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def update_discussion_comment_in_org(
@@ -1213,7 +1223,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def update_discussion_comment_in_org(
         self,
@@ -1227,7 +1237,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#update-a-discussion-comment"""
 
         from ..models import (
@@ -1269,7 +1279,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_update_discussion_comment_in_org(
@@ -1282,7 +1292,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_update_discussion_comment_in_org(
         self,
@@ -1296,7 +1306,7 @@ class TeamsClient:
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#update-a-discussion-comment"""
 
         from ..models import (
@@ -1336,7 +1346,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations"""
 
         from ..models import OrganizationInvitation
@@ -1366,7 +1376,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations"""
 
         from ..models import OrganizationInvitation
@@ -1397,7 +1407,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members"""
 
         from ..models import SimpleUser
@@ -1429,7 +1439,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members"""
 
         from ..models import SimpleUser
@@ -1459,7 +1469,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user"""
 
         from ..models import TeamMembership
@@ -1483,7 +1493,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user"""
 
         from ..models import TeamMembership
@@ -1509,7 +1519,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     def add_or_update_membership_for_user_in_org(
@@ -1521,7 +1531,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     def add_or_update_membership_for_user_in_org(
         self,
@@ -1532,7 +1542,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user"""
 
         from ..models import (
@@ -1573,7 +1583,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     async def async_add_or_update_membership_for_user_in_org(
@@ -1585,7 +1595,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     async def async_add_or_update_membership_for_user_in_org(
         self,
@@ -1596,7 +1606,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user"""
 
         from ..models import (
@@ -1678,7 +1688,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects"""
 
         from ..models import TeamProject
@@ -1708,7 +1718,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects"""
 
         from ..models import TeamProject
@@ -1737,7 +1747,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project"""
 
         from ..models import TeamProject
@@ -1761,7 +1771,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project"""
 
         from ..models import TeamProject
@@ -1968,7 +1978,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories"""
 
         from ..models import MinimalRepository
@@ -1998,7 +2008,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories"""
 
         from ..models import MinimalRepository
@@ -2028,7 +2038,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository"""
 
         from ..models import TeamRepository
@@ -2053,7 +2063,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository"""
 
         from ..models import TeamRepository
@@ -2240,7 +2250,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams"""
 
         from ..models import Team
@@ -2270,7 +2280,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams"""
 
         from ..models import Team
@@ -2297,7 +2307,7 @@ class TeamsClient:
         team_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-legacy"""
 
         from ..models import TeamFull, BasicError
@@ -2321,7 +2331,7 @@ class TeamsClient:
         team_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-legacy"""
 
         from ..models import TeamFull, BasicError
@@ -2395,7 +2405,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     def update_legacy(
@@ -2412,7 +2422,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     def update_legacy(
         self,
@@ -2421,7 +2431,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#update-a-team-legacy"""
 
         from ..models import TeamFull, BasicError, ValidationError, TeamsTeamIdPatchBody
@@ -2459,7 +2469,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     @overload
     async def async_update_legacy(
@@ -2476,7 +2486,7 @@ class TeamsClient:
         ] = UNSET,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
         parent_team_id: Missing[Union[int, None]] = UNSET,
-    ) -> Response[TeamFull]: ...
+    ) -> Response[TeamFull, TeamFullType]: ...
 
     async def async_update_legacy(
         self,
@@ -2485,7 +2495,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamFull]:
+    ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#update-a-team-legacy"""
 
         from ..models import TeamFull, BasicError, ValidationError, TeamsTeamIdPatchBody
@@ -2524,7 +2534,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions-legacy"""
 
         from ..models import TeamDiscussion
@@ -2555,7 +2565,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussion]]:
+    ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions-legacy"""
 
         from ..models import TeamDiscussion
@@ -2585,7 +2595,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def create_discussion_legacy(
@@ -2597,7 +2607,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def create_discussion_legacy(
         self,
@@ -2606,7 +2616,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#create-a-discussion-legacy"""
 
         from ..models import TeamDiscussion, TeamsTeamIdDiscussionsPostBody
@@ -2639,7 +2649,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_create_discussion_legacy(
@@ -2651,7 +2661,7 @@ class TeamsClient:
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_create_discussion_legacy(
         self,
@@ -2660,7 +2670,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#create-a-discussion-legacy"""
 
         from ..models import TeamDiscussion, TeamsTeamIdDiscussionsPostBody
@@ -2692,7 +2702,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion-legacy"""
 
         from ..models import TeamDiscussion
@@ -2714,7 +2724,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion-legacy"""
 
         from ..models import TeamDiscussion
@@ -2776,7 +2786,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     def update_discussion_legacy(
@@ -2788,7 +2798,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     def update_discussion_legacy(
         self,
@@ -2798,7 +2808,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#update-a-discussion-legacy"""
 
         from ..models import (
@@ -2837,7 +2847,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     @overload
     async def async_update_discussion_legacy(
@@ -2849,7 +2859,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
-    ) -> Response[TeamDiscussion]: ...
+    ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
     async def async_update_discussion_legacy(
         self,
@@ -2859,7 +2869,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussion]:
+    ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#update-a-discussion-legacy"""
 
         from ..models import (
@@ -2899,7 +2909,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -2931,7 +2941,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamDiscussionComment]]:
+    ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -2962,7 +2972,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def create_discussion_comment_legacy(
@@ -2973,7 +2983,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def create_discussion_comment_legacy(
         self,
@@ -2985,7 +2995,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3024,7 +3034,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_create_discussion_comment_legacy(
@@ -3035,7 +3045,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_create_discussion_comment_legacy(
         self,
@@ -3047,7 +3057,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#create-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3085,7 +3095,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -3108,7 +3118,7 @@ class TeamsClient:
         comment_number: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
         from ..models import TeamDiscussionComment
@@ -3173,7 +3183,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     def update_discussion_comment_legacy(
@@ -3185,7 +3195,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     def update_discussion_comment_legacy(
         self,
@@ -3198,7 +3208,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#update-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3239,7 +3249,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     @overload
     async def async_update_discussion_comment_legacy(
@@ -3251,7 +3261,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         body: str,
-    ) -> Response[TeamDiscussionComment]: ...
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
     async def async_update_discussion_comment_legacy(
         self,
@@ -3264,7 +3274,7 @@ class TeamsClient:
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
         **kwargs,
-    ) -> Response[TeamDiscussionComment]:
+    ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#update-a-discussion-comment-legacy"""
 
         from ..models import (
@@ -3303,7 +3313,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations-legacy"""
 
         from ..models import OrganizationInvitation
@@ -3332,7 +3342,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[OrganizationInvitation]]:
+    ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations-legacy"""
 
         from ..models import OrganizationInvitation
@@ -3362,7 +3372,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members-legacy"""
 
         from ..models import BasicError, SimpleUser
@@ -3396,7 +3406,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members-legacy"""
 
         from ..models import BasicError, SimpleUser
@@ -3556,7 +3566,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user-legacy"""
 
         from ..models import BasicError, TeamMembership
@@ -3581,7 +3591,7 @@ class TeamsClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user-legacy"""
 
         from ..models import BasicError, TeamMembership
@@ -3608,7 +3618,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     def add_or_update_membership_for_user_legacy(
@@ -3619,7 +3629,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     def add_or_update_membership_for_user_legacy(
         self,
@@ -3629,7 +3639,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user-legacy"""
 
         from ..models import (
@@ -3670,7 +3680,7 @@ class TeamsClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     @overload
     async def async_add_or_update_membership_for_user_legacy(
@@ -3681,7 +3691,7 @@ class TeamsClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
-    ) -> Response[TeamMembership]: ...
+    ) -> Response[TeamMembership, TeamMembershipType]: ...
 
     async def async_add_or_update_membership_for_user_legacy(
         self,
@@ -3691,7 +3701,7 @@ class TeamsClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
-    ) -> Response[TeamMembership]:
+    ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user-legacy"""
 
         from ..models import (
@@ -3771,7 +3781,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects-legacy"""
 
         from ..models import BasicError, TeamProject
@@ -3803,7 +3813,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamProject]]:
+    ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects-legacy"""
 
         from ..models import BasicError, TeamProject
@@ -3834,7 +3844,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
         from ..models import TeamProject
@@ -3857,7 +3867,7 @@ class TeamsClient:
         project_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamProject]:
+    ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
         from ..models import TeamProject
@@ -4059,7 +4069,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories-legacy"""
 
         from ..models import BasicError, MinimalRepository
@@ -4091,7 +4101,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[MinimalRepository]]:
+    ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories-legacy"""
 
         from ..models import BasicError, MinimalRepository
@@ -4123,7 +4133,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
         from ..models import TeamRepository
@@ -4147,7 +4157,7 @@ class TeamsClient:
         repo: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[TeamRepository]:
+    ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
         from ..models import TeamRepository
@@ -4341,7 +4351,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams-legacy"""
 
         from ..models import Team, BasicError, ValidationError
@@ -4375,7 +4385,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Team]]:
+    ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams-legacy"""
 
         from ..models import Team, BasicError, ValidationError
@@ -4408,7 +4418,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamFull]]:
+    ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams-for-the-authenticated-user"""
 
         from ..models import TeamFull, BasicError
@@ -4440,7 +4450,7 @@ class TeamsClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[TeamFull]]:
+    ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams-for-the-authenticated-user"""
 
         from ..models import TeamFull, BasicError

--- a/githubkit/versions/v2022_11_28/rest/users.py
+++ b/githubkit/versions/v2022_11_28/rest/users.py
@@ -40,6 +40,16 @@ if TYPE_CHECKING:
         UsersUsernameAttestationsSubjectDigestGetResponse200,
     )
     from ..types import (
+        KeyType,
+        EmailType,
+        GpgKeyType,
+        HovercardType,
+        KeySimpleType,
+        PublicUserType,
+        SimpleUserType,
+        PrivateUserType,
+        SocialAccountType,
+        SshSigningKeyType,
         UserPatchBodyType,
         UserKeysPostBodyType,
         UserGpgKeysPostBodyType,
@@ -49,6 +59,7 @@ if TYPE_CHECKING:
         UserSshSigningKeysPostBodyType,
         UserEmailVisibilityPatchBodyType,
         UserSocialAccountsDeleteBodyType,
+        UsersUsernameAttestationsSubjectDigestGetResponse200Type,
     )
 
 
@@ -71,7 +82,9 @@ class UsersClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/rest/users/users#get-the-authenticated-user"""
 
         from typing import Union
@@ -97,7 +110,9 @@ class UsersClient:
         self,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/rest/users/users#get-the-authenticated-user"""
 
         from typing import Union
@@ -125,7 +140,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     @overload
     def update_authenticated(
@@ -141,7 +156,7 @@ class UsersClient:
         location: Missing[str] = UNSET,
         hireable: Missing[bool] = UNSET,
         bio: Missing[str] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     def update_authenticated(
         self,
@@ -149,7 +164,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PrivateUser]:
+    ) -> Response[PrivateUser, PrivateUserType]:
         """See also: https://docs.github.com/rest/users/users#update-the-authenticated-user"""
 
         from ..models import BasicError, PrivateUser, UserPatchBody, ValidationError
@@ -187,7 +202,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     @overload
     async def async_update_authenticated(
@@ -203,7 +218,7 @@ class UsersClient:
         location: Missing[str] = UNSET,
         hireable: Missing[bool] = UNSET,
         bio: Missing[str] = UNSET,
-    ) -> Response[PrivateUser]: ...
+    ) -> Response[PrivateUser, PrivateUserType]: ...
 
     async def async_update_authenticated(
         self,
@@ -211,7 +226,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[PrivateUser]:
+    ) -> Response[PrivateUser, PrivateUserType]:
         """See also: https://docs.github.com/rest/users/users#update-the-authenticated-user"""
 
         from ..models import BasicError, PrivateUser, UserPatchBody, ValidationError
@@ -249,7 +264,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -282,7 +297,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -467,7 +482,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     def set_primary_email_visibility_for_authenticated_user(
@@ -476,7 +491,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         visibility: Literal["public", "private"],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     def set_primary_email_visibility_for_authenticated_user(
         self,
@@ -484,7 +499,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#set-primary-email-visibility-for-the-authenticated-user"""
 
         from ..models import (
@@ -527,7 +542,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     async def async_set_primary_email_visibility_for_authenticated_user(
@@ -536,7 +551,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         visibility: Literal["public", "private"],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_set_primary_email_visibility_for_authenticated_user(
         self,
@@ -544,7 +559,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#set-primary-email-visibility-for-the-authenticated-user"""
 
         from ..models import (
@@ -587,7 +602,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -620,7 +635,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -653,7 +668,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     def add_email_for_authenticated_user(
@@ -662,7 +677,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         emails: list[str],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     def add_email_for_authenticated_user(
         self,
@@ -670,7 +685,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#add-an-email-address-for-the-authenticated-user"""
 
         from typing import Union
@@ -724,7 +739,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     @overload
     async def async_add_email_for_authenticated_user(
@@ -733,7 +748,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         emails: list[str],
-    ) -> Response[list[Email]]: ...
+    ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_add_email_for_authenticated_user(
         self,
@@ -741,7 +756,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#add-an-email-address-for-the-authenticated-user"""
 
         from typing import Union
@@ -925,7 +940,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -957,7 +972,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-the-authenticated-user"""
 
         from ..models import BasicError, SimpleUser
@@ -989,7 +1004,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
         from ..models import BasicError, SimpleUser
@@ -1021,7 +1036,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
         from ..models import BasicError, SimpleUser
@@ -1203,7 +1218,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1236,7 +1251,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1266,7 +1281,7 @@ class UsersClient:
     @overload
     def create_gpg_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
     def create_gpg_key_for_authenticated_user(
@@ -1276,7 +1291,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     def create_gpg_key_for_authenticated_user(
         self,
@@ -1284,7 +1299,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/rest/users/gpg-keys#create-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError, ValidationError, UserGpgKeysPostBody
@@ -1319,7 +1334,7 @@ class UsersClient:
     @overload
     async def async_create_gpg_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
     async def async_create_gpg_key_for_authenticated_user(
@@ -1329,7 +1344,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
-    ) -> Response[GpgKey]: ...
+    ) -> Response[GpgKey, GpgKeyType]: ...
 
     async def async_create_gpg_key_for_authenticated_user(
         self,
@@ -1337,7 +1352,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/rest/users/gpg-keys#create-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError, ValidationError, UserGpgKeysPostBody
@@ -1374,7 +1389,7 @@ class UsersClient:
         gpg_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1400,7 +1415,7 @@ class UsersClient:
         gpg_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[GpgKey]:
+    ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
         from ..models import GpgKey, BasicError
@@ -1479,7 +1494,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Key]]:
+    ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1512,7 +1527,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Key]]:
+    ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1542,7 +1557,7 @@ class UsersClient:
     @overload
     def create_public_ssh_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     @overload
     def create_public_ssh_key_for_authenticated_user(
@@ -1552,7 +1567,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     def create_public_ssh_key_for_authenticated_user(
         self,
@@ -1560,7 +1575,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError, ValidationError, UserKeysPostBody
@@ -1595,7 +1610,7 @@ class UsersClient:
     @overload
     async def async_create_public_ssh_key_for_authenticated_user(
         self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     @overload
     async def async_create_public_ssh_key_for_authenticated_user(
@@ -1605,7 +1620,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[Key]: ...
+    ) -> Response[Key, KeyType]: ...
 
     async def async_create_public_ssh_key_for_authenticated_user(
         self,
@@ -1613,7 +1628,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/rest/users/keys#create-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError, ValidationError, UserKeysPostBody
@@ -1650,7 +1665,7 @@ class UsersClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1676,7 +1691,7 @@ class UsersClient:
         key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Key]:
+    ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
         from ..models import Key, BasicError
@@ -1753,7 +1768,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -1786,7 +1801,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[Email]]:
+    ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
         from ..models import Email, BasicError
@@ -1819,7 +1834,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
         from ..models import BasicError, SocialAccount
@@ -1852,7 +1867,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
         from ..models import BasicError, SocialAccount
@@ -1885,7 +1900,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     @overload
     def add_social_account_for_authenticated_user(
@@ -1894,7 +1909,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         account_urls: list[str],
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     def add_social_account_for_authenticated_user(
         self,
@@ -1902,7 +1917,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#add-social-accounts-for-the-authenticated-user"""
 
         from ..models import (
@@ -1945,7 +1960,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     @overload
     async def async_add_social_account_for_authenticated_user(
@@ -1954,7 +1969,7 @@ class UsersClient:
         data: UnsetType = UNSET,
         headers: Optional[dict[str, str]] = None,
         account_urls: list[str],
-    ) -> Response[list[SocialAccount]]: ...
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     async def async_add_social_account_for_authenticated_user(
         self,
@@ -1962,7 +1977,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#add-social-accounts-for-the-authenticated-user"""
 
         from ..models import (
@@ -2113,7 +2128,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2146,7 +2161,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2179,7 +2194,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     @overload
     def create_ssh_signing_key_for_authenticated_user(
@@ -2189,7 +2204,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     def create_ssh_signing_key_for_authenticated_user(
         self,
@@ -2197,7 +2212,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import (
@@ -2240,7 +2255,7 @@ class UsersClient:
         *,
         headers: Optional[dict[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     @overload
     async def async_create_ssh_signing_key_for_authenticated_user(
@@ -2250,7 +2265,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
-    ) -> Response[SshSigningKey]: ...
+    ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
     async def async_create_ssh_signing_key_for_authenticated_user(
         self,
@@ -2258,7 +2273,7 @@ class UsersClient:
         headers: Optional[dict[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#create-a-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import (
@@ -2300,7 +2315,7 @@ class UsersClient:
         ssh_signing_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2326,7 +2341,7 @@ class UsersClient:
         ssh_signing_key_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[SshSigningKey]:
+    ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
         from ..models import BasicError, SshSigningKey
@@ -2402,7 +2417,9 @@ class UsersClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/rest/users/users#get-a-user-using-their-id"""
 
         from typing import Union
@@ -2428,7 +2445,9 @@ class UsersClient:
         account_id: int,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/rest/users/users#get-a-user-using-their-id"""
 
         from typing import Union
@@ -2455,7 +2474,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/users#list-users"""
 
         from ..models import SimpleUser
@@ -2483,7 +2502,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/users#list-users"""
 
         from ..models import SimpleUser
@@ -2510,7 +2529,9 @@ class UsersClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/rest/users/users#get-a-user"""
 
         from typing import Union
@@ -2536,7 +2557,9 @@ class UsersClient:
         username: str,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Union[PrivateUser, PublicUser]]:
+    ) -> Response[
+        Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
+    ]:
         """See also: https://docs.github.com/rest/users/users#get-a-user"""
 
         from typing import Union
@@ -2566,7 +2589,10 @@ class UsersClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UsersUsernameAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        UsersUsernameAttestationsSubjectDigestGetResponse200,
+        UsersUsernameAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/users/attestations#list-attestations"""
 
         from ..models import (
@@ -2604,7 +2630,10 @@ class UsersClient:
         after: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[UsersUsernameAttestationsSubjectDigestGetResponse200]:
+    ) -> Response[
+        UsersUsernameAttestationsSubjectDigestGetResponse200,
+        UsersUsernameAttestationsSubjectDigestGetResponse200Type,
+    ]:
         """See also: https://docs.github.com/rest/users/attestations#list-attestations"""
 
         from ..models import (
@@ -2640,7 +2669,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-a-user"""
 
         from ..models import SimpleUser
@@ -2669,7 +2698,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-a-user"""
 
         from ..models import SimpleUser
@@ -2698,7 +2727,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-a-user-follows"""
 
         from ..models import SimpleUser
@@ -2727,7 +2756,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SimpleUser]]:
+    ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-a-user-follows"""
 
         from ..models import SimpleUser
@@ -2796,7 +2825,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
         from ..models import GpgKey
@@ -2825,7 +2854,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[GpgKey]]:
+    ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
         from ..models import GpgKey
@@ -2856,7 +2885,7 @@ class UsersClient:
         subject_id: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hovercard]:
+    ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/rest/users/users#get-contextual-information-for-a-user"""
 
         from ..models import Hovercard, BasicError, ValidationError
@@ -2891,7 +2920,7 @@ class UsersClient:
         subject_id: Missing[str] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[Hovercard]:
+    ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/rest/users/users#get-contextual-information-for-a-user"""
 
         from ..models import Hovercard, BasicError, ValidationError
@@ -2924,7 +2953,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[KeySimple]]:
+    ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-keys-for-a-user"""
 
         from ..models import KeySimple
@@ -2953,7 +2982,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[KeySimple]]:
+    ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-keys-for-a-user"""
 
         from ..models import KeySimple
@@ -2982,7 +3011,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-a-user"""
 
         from ..models import SocialAccount
@@ -3011,7 +3040,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SocialAccount]]:
+    ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-a-user"""
 
         from ..models import SocialAccount
@@ -3040,7 +3069,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 
         from ..models import SshSigningKey
@@ -3069,7 +3098,7 @@ class UsersClient:
         page: Missing[int] = UNSET,
         *,
         headers: Optional[dict[str, str]] = None,
-    ) -> Response[list[SshSigningKey]]:
+    ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 
         from ..models import SshSigningKey

--- a/poetry.lock
+++ b/poetry.lock
@@ -1785,4 +1785,4 @@ jwt = ["PyJWT"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "27d75982fab2fa0c107729e55a27d450c485cdd4186ccfdfdc993000628d99d7"
+content-hash = "f30a824f469fc13f61d9cfa3d5aa68ecc8f9ca0726d1fb3c39353124adf2a680"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = ["githubkit/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.9"
 httpx = ">=0.23.0, <1.0.0"
-typing-extensions = "^4.3.0"
+typing-extensions = "^4.6.0"
 hishel = ">=0.0.21, <=0.2.0"
 pydantic = ">=1.9.1, <3.0.0, !=2.5.0, !=2.5.1"
 anyio = { version = ">=3.6.1, <5.0.0", optional = true }


### PR DESCRIPTION
Now, you can inspect the type and fields in `response.json()`

```python
from typing_extensions import reveal_type

from githubkit import GitHub, Response

g = GitHub()

resp = g.rest.repos.get("owner", "repo")

reveal_type(resp.parsed_data)  # FullRepository
reveal_type(resp.json())  # FullRepositoryType
```