### PR TITLE
Feature: add basic throttling logic

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,32 +58,6 @@ If you want to auth as github app, you should install `auth-app` extra dependenc
     pip install githubkit[auth-app]
     ```
 
-If you want to mix sync and async calls in oauth device callback, you should install `auth-oauth-device` extra dependencies:
-
-=== "poetry"
-
-    ```bash
-    poetry add githubkit[auth-oauth-device]
-    ```
-
-=== "pdm"
-
-    ```bash
-    pdm add githubkit[auth-oauth-device]
-    ```
-
-=== "uv"
-
-    ```bash
-    uv add githubkit[auth-oauth-device]
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install githubkit[auth-oauth-device]
-    ```
-
 ## Full Installation
 
 You can install fully featured githubkit with `all` extra dependencies:

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -14,6 +14,7 @@ github = GitHub(
     timeout=None,
     cache_strategy=None,
     http_cache=True,
+    throttler=None,
     auto_retry=True,
     rest_api_validate_body=True,
 )
@@ -35,6 +36,7 @@ config = Config(
     timeout=httpx.Timeout(None),
     cache_strategy=DEFAULT_CACHE_STRATEGY,
     http_cache=True,
+    throttler=None,
     auto_retry=RETRY_DEFAULT,
     rest_api_validate_body=True,
 )
@@ -81,6 +83,14 @@ Available built-in cache strategies:
 ### `http_cache`
 
 The `http_cache` option enables the http caching feature powered by [Hishel](https://hishel.com/) for HTTPX. GitHub API limits the number of requests that you can make within a specific amount of time. This feature is useful to reduce the number of requests to GitHub API and avoid hitting the rate limit.
+
+### `throttler`
+
+The `throttler` option is used to control the request concurrency to avoid hitting the rate limit. You can provide a githubkit built-in throttler or a custom one that implements the `BaseThrottler` interface. By default, githubkit uses the `LocalThrottler` to control the request concurrency.
+
+Available built-in throttlers:
+
+- `LocalThrottler`: Control the request concurrency in the local process / event loop.
 
 ### `auto_retry`
 

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from .config import Config
     from .cache import BaseCacheStrategy
+    from .throttling import BaseThrottler
     from .auth import TokenAuthStrategy, UnauthAuthStrategy
 
 
@@ -75,6 +76,7 @@ class GitHub(GitHubCore[A]):
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
+            throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
         ): ...
@@ -93,6 +95,7 @@ class GitHub(GitHubCore[A]):
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
+            throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
         ): ...
@@ -111,6 +114,7 @@ class GitHub(GitHubCore[A]):
             timeout: Optional[Union[float, httpx.Timeout]] = None,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
+            throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
         ): ...

--- a/githubkit/throttling.py
+++ b/githubkit/throttling.py
@@ -1,0 +1,57 @@
+import abc
+import threading
+from typing import Any, Optional
+from typing_extensions import override
+from collections.abc import Generator, AsyncGenerator
+from contextlib import contextmanager, asynccontextmanager
+
+import anyio
+import httpx
+
+
+class BaseThrottler(abc.ABC):
+    """Throttle the number of concurrent requests to avoid hitting rate limits.
+
+    See also:
+    - https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#avoid-concurrent-requests
+    - https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits
+
+    TODO: Implement the pause between mutative requests.
+    """
+
+    @abc.abstractmethod
+    @contextmanager
+    def acquire(self, request: httpx.Request) -> Generator[None, Any, Any]:
+        raise NotImplementedError
+        yield
+
+    @abc.abstractmethod
+    @asynccontextmanager
+    async def async_acquire(self, request: httpx.Request) -> AsyncGenerator[None, Any]:
+        raise NotImplementedError
+        yield
+
+
+class LocalThrottler(BaseThrottler):
+    def __init__(self, max_concurrency: int) -> None:
+        self.max_concurrency = max_concurrency
+        self.semaphore = threading.Semaphore(max_concurrency)
+        self._async_semaphore: Optional[anyio.Semaphore] = None
+
+    @property
+    def async_semaphore(self) -> anyio.Semaphore:
+        if self._async_semaphore is None:
+            self._async_semaphore = anyio.Semaphore(self.max_concurrency)
+        return self._async_semaphore
+
+    @override
+    @contextmanager
+    def acquire(self, request: httpx.Request) -> Generator[None, Any, Any]:
+        with self.semaphore:
+            yield
+
+    @override
+    @asynccontextmanager
+    async def async_acquire(self, request: httpx.Request) -> AsyncGenerator[None, Any]:
+        async with self.async_semaphore:
+            yield

--- a/poetry.lock
+++ b/poetry.lock
@@ -1805,13 +1805,13 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-all = ["PyJWT", "anyio"]
-auth = ["PyJWT", "anyio"]
+all = ["PyJWT"]
+auth = ["PyJWT"]
 auth-app = ["PyJWT"]
-auth-oauth-device = ["anyio"]
+auth-oauth-device = []
 jwt = ["PyJWT"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b6423573ac36c61240aad2a5793ce3a7fa571717ab0ebce9c5b413a26e61209f"
+content-hash = "128f2a87aaf264f32508ed706af8f9137967e0d9935bab5d20d0cfe35467ab37"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ include = ["githubkit/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
+anyio = ">=3.6.1, <5.0.0"
 httpx = ">=0.23.0, <1.0.0"
 typing-extensions = "^4.6.0"
 hishel = ">=0.0.21, <=0.2.0"
 pydantic = ">=1.9.1, <3.0.0, !=2.5.0, !=2.5.1"
-anyio = { version = ">=3.6.1, <5.0.0", optional = true }
 PyJWT = { version = "^2.4.0", extras = ["crypto"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
@@ -44,9 +44,9 @@ mkdocs-git-revision-date-localized-plugin = "^1.2.9"
 [tool.poetry.extras]
 jwt = ["PyJWT"]
 auth-app = ["PyJWT"]
-auth-oauth-device = ["anyio"]
-auth = ["PyJWT", "anyio"]
-all = ["PyJWT", "anyio"]
+auth-oauth-device = [] # backward compatibility
+auth = ["PyJWT"]
+all = ["PyJWT"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=githubkit --cov-append --cov-report=term-missing"


### PR DESCRIPTION
This pr adds the basic request [concurrency throttling](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits) logic. The [pause between mutative requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#pause-between-mutative-requests) logic is not implemented.

fix #66 