### PR TITLE
Fix: typevar with default cause error in `typing-extensions<4.11.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ include = ["githubkit/py.typed"]
 python = "^3.9"
 anyio = ">=3.6.1, <5.0.0"
 httpx = ">=0.23.0, <1.0.0"
-typing-extensions = "^4.6.0"
+typing-extensions = "^4.11.0"
 hishel = ">=0.0.21, <=0.2.0"
 pydantic = ">=1.9.1, <3.0.0, !=2.5.0, !=2.5.1"
 PyJWT = { version = "^2.4.0", extras = ["crypto"], optional = true }


### PR DESCRIPTION
In versions prior to typing-extensions 4.11.0, the following error occurs

```bash
Traceback (most recent call last):
  File "/Users/user/Documents/git/paddle-tools/autoTable/test.py", line 1, in <module>
    from githubkit import GitHub
  File "/Users/user/miniconda3/envs/py312/lib/python3.12/site-packages/githubkit/__init__.py", line 17, in <module>
    from .core import GitHubCore as GitHubCore
  File "/Users/user/miniconda3/envs/py312/lib/python3.12/site-packages/githubkit/core.py", line 44, in <module>
    class GitHubCore(Generic[A]):
  File "/Users/user/miniconda3/envs/py312/lib/python3.12/site-packages/githubkit/core.py", line 342, in GitHubCore
    ) -> Response[T]: ...
         ~~~~~~~~^^^
  File "/Users/user/miniconda3/envs/py312/lib/python3.12/typing.py", line 384, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/user/miniconda3/envs/py312/lib/python3.12/typing.py", line 1066, in _generic_class_getitem
    _check_generic(cls, params, len(cls.__parameters__))
  File "/Users/user/miniconda3/envs/py312/lib/python3.12/typing.py", line 304, in _check_generic
    raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments for {cls};"
TypeError: Too few arguments for <class 'githubkit.response.Response'>; actual 1, expected 2
```

Duplicate code
```python3
from githubkit import GitHub
```

