### PR TITLE
Fix: workflow_run pull_requests id/number types

### DIFF
--- a/githubkit/versions/ghec_v2022_11_28/models/group_0266.py
+++ b/githubkit/versions/ghec_v2022_11_28/models/group_0266.py
@@ -46,6 +46,13 @@ class CodeScanningDefaultSetup(GitHubModel):
             ]
         ]
     ] = Field(default=UNSET, description="Languages to be analyzed.")
+    runner_type: Missing[Union[None, Literal["standard", "labeled"]]] = Field(
+        default=UNSET, description="Runner type to be used."
+    )
+    runner_label: Missing[Union[str, None]] = Field(
+        default=UNSET,
+        description="Runner label to be used if the runner type is labeled.",
+    )
     query_suite: Missing[Literal["default", "extended"]] = Field(
         default=UNSET, description="CodeQL query suite to be used."
     )

--- a/githubkit/versions/ghec_v2022_11_28/models/group_0836.py
+++ b/githubkit/versions/ghec_v2022_11_28/models/group_0836.py
@@ -413,8 +413,8 @@ class WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItems(GitHubMode
     head: WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsPropHead = (
         Field()
     )
-    id: float = Field()
-    number: float = Field()
+    id: int = Field()
+    number: int = Field()
     url: str = Field()
 
 

--- a/githubkit/versions/ghec_v2022_11_28/models/group_0837.py
+++ b/githubkit/versions/ghec_v2022_11_28/models/group_0837.py
@@ -402,8 +402,8 @@ class WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItems(GitHubMod
     head: WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsPropHead = (
         Field()
     )
-    id: float = Field()
-    number: float = Field()
+    id: int = Field()
+    number: int = Field()
     url: str = Field()
 
 

--- a/githubkit/versions/ghec_v2022_11_28/models/group_0838.py
+++ b/githubkit/versions/ghec_v2022_11_28/models/group_0838.py
@@ -410,8 +410,8 @@ class WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItems(GitHubMode
     head: WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsPropHead = (
         Field()
     )
-    id: float = Field()
-    number: float = Field()
+    id: int = Field()
+    number: int = Field()
     url: str = Field()
 
 

--- a/githubkit/versions/ghec_v2022_11_28/types/group_0266.py
+++ b/githubkit/versions/ghec_v2022_11_28/types/group_0266.py
@@ -38,6 +38,8 @@ class CodeScanningDefaultSetupType(TypedDict):
             ]
         ]
     ]
+    runner_type: NotRequired[Union[None, Literal["standard", "labeled"]]]
+    runner_label: NotRequired[Union[str, None]]
     query_suite: NotRequired[Literal["default", "extended"]]
     updated_at: NotRequired[Union[datetime, None]]
     schedule: NotRequired[Union[None, Literal["weekly"]]]

--- a/githubkit/versions/ghec_v2022_11_28/types/group_0836.py
+++ b/githubkit/versions/ghec_v2022_11_28/types/group_0836.py
@@ -368,8 +368,8 @@ class WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsType(TypedD
 
     base: WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsPropBaseType
     head: WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsPropHeadType
-    id: float
-    number: float
+    id: int
+    number: int
     url: str
 
 

--- a/githubkit/versions/ghec_v2022_11_28/types/group_0837.py
+++ b/githubkit/versions/ghec_v2022_11_28/types/group_0837.py
@@ -366,8 +366,8 @@ class WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsType(Typed
 
     base: WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsPropBaseType
     head: WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsPropHeadType
-    id: float
-    number: float
+    id: int
+    number: int
     url: str
 
 

--- a/githubkit/versions/ghec_v2022_11_28/types/group_0838.py
+++ b/githubkit/versions/ghec_v2022_11_28/types/group_0838.py
@@ -368,8 +368,8 @@ class WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsType(TypedD
 
     base: WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsPropBaseType
     head: WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsPropHeadType
-    id: float
-    number: float
+    id: int
+    number: int
     url: str
 
 

--- a/githubkit/versions/v2022_11_28/models/group_0229.py
+++ b/githubkit/versions/v2022_11_28/models/group_0229.py
@@ -46,6 +46,13 @@ class CodeScanningDefaultSetup(GitHubModel):
             ]
         ]
     ] = Field(default=UNSET, description="Languages to be analyzed.")
+    runner_type: Missing[Union[None, Literal["standard", "labeled"]]] = Field(
+        default=UNSET, description="Runner type to be used."
+    )
+    runner_label: Missing[Union[str, None]] = Field(
+        default=UNSET,
+        description="Runner label to be used if the runner type is labeled.",
+    )
     query_suite: Missing[Literal["default", "extended"]] = Field(
         default=UNSET, description="CodeQL query suite to be used."
     )

--- a/githubkit/versions/v2022_11_28/models/group_0778.py
+++ b/githubkit/versions/v2022_11_28/models/group_0778.py
@@ -413,8 +413,8 @@ class WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItems(GitHubMode
     head: WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsPropHead = (
         Field()
     )
-    id: float = Field()
-    number: float = Field()
+    id: int = Field()
+    number: int = Field()
     url: str = Field()
 
 

--- a/githubkit/versions/v2022_11_28/models/group_0779.py
+++ b/githubkit/versions/v2022_11_28/models/group_0779.py
@@ -402,8 +402,8 @@ class WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItems(GitHubMod
     head: WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsPropHead = (
         Field()
     )
-    id: float = Field()
-    number: float = Field()
+    id: int = Field()
+    number: int = Field()
     url: str = Field()
 
 

--- a/githubkit/versions/v2022_11_28/models/group_0780.py
+++ b/githubkit/versions/v2022_11_28/models/group_0780.py
@@ -410,8 +410,8 @@ class WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItems(GitHubMode
     head: WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsPropHead = (
         Field()
     )
-    id: float = Field()
-    number: float = Field()
+    id: int = Field()
+    number: int = Field()
     url: str = Field()
 
 

--- a/githubkit/versions/v2022_11_28/types/group_0229.py
+++ b/githubkit/versions/v2022_11_28/types/group_0229.py
@@ -38,6 +38,8 @@ class CodeScanningDefaultSetupType(TypedDict):
             ]
         ]
     ]
+    runner_type: NotRequired[Union[None, Literal["standard", "labeled"]]]
+    runner_label: NotRequired[Union[str, None]]
     query_suite: NotRequired[Literal["default", "extended"]]
     updated_at: NotRequired[Union[datetime, None]]
     schedule: NotRequired[Union[None, Literal["weekly"]]]

--- a/githubkit/versions/v2022_11_28/types/group_0778.py
+++ b/githubkit/versions/v2022_11_28/types/group_0778.py
@@ -368,8 +368,8 @@ class WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsType(TypedD
 
     base: WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsPropBaseType
     head: WebhookWorkflowRunCompletedPropWorkflowRunPropPullRequestsItemsPropHeadType
-    id: float
-    number: float
+    id: int
+    number: int
     url: str
 
 

--- a/githubkit/versions/v2022_11_28/types/group_0779.py
+++ b/githubkit/versions/v2022_11_28/types/group_0779.py
@@ -366,8 +366,8 @@ class WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsType(Typed
 
     base: WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsPropBaseType
     head: WebhookWorkflowRunInProgressPropWorkflowRunPropPullRequestsItemsPropHeadType
-    id: float
-    number: float
+    id: int
+    number: int
     url: str
 
 

--- a/githubkit/versions/v2022_11_28/types/group_0780.py
+++ b/githubkit/versions/v2022_11_28/types/group_0780.py
@@ -368,8 +368,8 @@ class WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsType(TypedD
 
     base: WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsPropBaseType
     head: WebhookWorkflowRunRequestedPropWorkflowRunPropPullRequestsItemsPropHeadType
-    id: float
-    number: float
+    id: int
+    number: int
     url: str
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,6 +472,15 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
   "null",
 ] }
 
+# webhook workflow run workflow-run-*.workflow_run.pull_requests.number and .id should be integers
+# https://github.com/github/rest-api-description/issues/4408
+"/components/schemas/webhook-workflow-run-completed/properties/workflow_run/properties/pull_requests/items/properties/id" = { type = "integer" }
+"/components/schemas/webhook-workflow-run-completed/properties/workflow_run/properties/pull_requests/items/properties/number" = { type = "integer" }
+"/components/schemas/webhook-workflow-run-in-progress/properties/workflow_run/properties/pull_requests/items/properties/id" = { type = "integer" }
+"/components/schemas/webhook-workflow-run-in-progress/properties/workflow_run/properties/pull_requests/items/properties/number" = { type = "integer" }
+"/components/schemas/webhook-workflow-run-requested/properties/workflow_run/properties/pull_requests/items/properties/id" = { type = "integer" }
+"/components/schemas/webhook-workflow-run-requested/properties/workflow_run/properties/pull_requests/items/properties/number" = { type = "integer" }
+
 # webhook repository dispatch action can be any string
 "/webhooks/repository-dispatch-sample.collected/post" = { operationId = "repository-dispatch" }
 # "/components/schemas/webhook-repository-dispatch-sample/properties/action" = { enum = "<unset>" }


### PR DESCRIPTION
The webhook payload for the `workflow_run` event types (completed, in-progress & requested) each define the id and number of pull requests as `number` where they clearly should be `integer` values.

- This issue has been reported to GitHub as github/rest-api-description#4408
- The regenerated models include the latest updates (specifically github/rest-api-description#4404)

