### PR TITLE
Feature: support sequence and mapping input

### DIFF
--- a/codegen/templates/rest/_param.py.jinja
+++ b/codegen/templates/rest/_param.py.jinja
@@ -36,7 +36,7 @@
 {{ query_params(endpoint) }}
 {{ header_params(endpoint) }}
 {{ cookie_params(endpoint) }}
-headers: Optional[dict[str, str]] = None,
+headers: Optional[Mapping[str, str]] = None,
 {{ endpoint.request_body.get_raw_definition() }}
 {% endmacro %}
 
@@ -47,7 +47,7 @@ headers: Optional[dict[str, str]] = None,
 {{ header_params(endpoint) }}
 {{ cookie_params(endpoint) }}
 data: UnsetType = UNSET,
-headers: Optional[dict[str, str]] = None,
+headers: Optional[Mapping[str, str]] = None,
 {{ body_params(model, endpoint.param_names) }}
 {% endmacro %}
 
@@ -57,7 +57,7 @@ headers: Optional[dict[str, str]] = None,
 {{ query_params(endpoint) }}
 {{ header_params(endpoint) }}
 {{ cookie_params(endpoint) }}
-headers: Optional[dict[str, str]] = None,
+headers: Optional[Mapping[str, str]] = None,
 {%- if endpoint.request_body %}
 {{ endpoint.request_body.get_endpoint_definition() }},
 {%- if endpoint.request_body.allowed_models %}

--- a/codegen/templates/rest/client.py.jinja
+++ b/codegen/templates/rest/client.py.jinja
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from weakref import ref
 from typing import TYPE_CHECKING, Literal, Optional, Annotated, overload
 

--- a/codegen/templates/webhooks/_namespace.py.jinja
+++ b/codegen/templates/webhooks/_namespace.py.jinja
@@ -5,6 +5,7 @@
 import hmac
 import json
 import importlib
+from collections.abc import Mapping
 from typing_extensions import TypeAlias
 from typing import TYPE_CHECKING, Any, Union, Literal, overload
 
@@ -81,7 +82,7 @@ class WebhookNamespace:
         return type_validate_json(Event, payload)
 
     @staticmethod
-    def parse_obj_without_name(payload: dict[str, Any]) -> "WebhookEvent":
+    def parse_obj_without_name(payload: Mapping[str, Any]) -> "WebhookEvent":
         """Parse the webhook payload dict without event name.
 
         Note:
@@ -91,7 +92,7 @@ class WebhookNamespace:
             the result may not be the correct type as expected.
 
         Args:
-            payload (dict[str, Any]): webhook payload dict.
+            payload (Mapping[str, Any]): webhook payload dict.
         """
 
         from ._types import WebhookEvent
@@ -101,27 +102,27 @@ class WebhookNamespace:
     {% for name in event_names %}
     @overload
     @staticmethod
-    def parse_obj(name: Literal["{{ name }}"], payload: dict[str, Any]) -> "{{ pascal_case(name) }}Event":
+    def parse_obj(name: Literal["{{ name }}"], payload: Mapping[str, Any]) -> "{{ pascal_case(name) }}Event":
         ...
     {% endfor %}
 
     @overload
     @staticmethod
-    def parse_obj(name: EventNameType, payload: dict[str, Any]) -> "WebhookEvent":
+    def parse_obj(name: EventNameType, payload: Mapping[str, Any]) -> "WebhookEvent":
         ...
 
     @overload
     @staticmethod
-    def parse_obj(name: str, payload: dict[str, Any]) -> "WebhookEvent":
+    def parse_obj(name: str, payload: Mapping[str, Any]) -> "WebhookEvent":
         ...
 
     @staticmethod
-    def parse_obj(name: Union[EventNameType, str], payload: dict[str, Any]) -> "WebhookEvent":
+    def parse_obj(name: Union[EventNameType, str], payload: Mapping[str, Any]) -> "WebhookEvent":
         """Parse the webhook payload dict with event name.
 
         Args:
             name (EventNameType): event name.
-            payload (dict[str, Any]): webhook payload dict.
+            payload (Mapping[str, Any]): webhook payload dict.
         """
 
         if name not in VALID_EVENT_NAMES:

--- a/githubkit/auth/app.py
+++ b/githubkit/auth/app.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, ClassVar, Optional, Union
@@ -35,8 +35,8 @@ class AppAuth(httpx.Auth):
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     installation_id: Union[Unset, int] = UNSET
-    repositories: Union[Unset, list[str]] = UNSET
-    repository_ids: Union[Unset, list[int]] = UNSET
+    repositories: Union[Unset, Sequence[str]] = UNSET
+    repository_ids: Union[Unset, Sequence[int]] = UNSET
     permissions: Union[Unset, "AppPermissionsType"] = UNSET
 
     JWT_CACHE_KEY: ClassVar[LiteralString] = "githubkit:auth:app:{issuer}:jwt"
@@ -277,8 +277,8 @@ class AppAuthStrategy(BaseAuthStrategy):
     def as_installation(
         self,
         installation_id: int,
-        repositories: Union[Unset, list[str]] = UNSET,
-        repository_ids: Union[Unset, list[int]] = UNSET,
+        repositories: Union[Unset, Sequence[str]] = UNSET,
+        repository_ids: Union[Unset, Sequence[int]] = UNSET,
         permissions: Union[Unset, "AppPermissionsType"] = UNSET,
     ) -> "AppInstallationAuthStrategy":
         return AppInstallationAuthStrategy(
@@ -318,8 +318,8 @@ class AppInstallationAuthStrategy(BaseAuthStrategy):
     installation_id: int
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
-    repositories: Union[Unset, list[str]] = UNSET
-    repository_ids: Union[Unset, list[int]] = UNSET
+    repositories: Union[Unset, Sequence[str]] = UNSET
+    repository_ids: Union[Unset, Sequence[int]] = UNSET
     permissions: Union[Unset, "AppPermissionsType"] = UNSET
 
     def __post_init__(self):

--- a/githubkit/auth/oauth.py
+++ b/githubkit/auth/oauth.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator, Coroutine, Generator
+from collections.abc import AsyncGenerator, Coroutine, Generator, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from time import sleep
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 def create_device_code(
-    github: "GitHubCore", client_id: str, scopes: Optional[list[str]] = None
+    github: "GitHubCore", client_id: str, scopes: Optional[Sequence[str]] = None
 ) -> Generator[httpx.Request, httpx.Response, dict[str, Any]]:
     """Create a device code for OAuth."""
     base_url = get_oauth_base_url(github.config.base_url)
@@ -567,7 +567,10 @@ class OAuthAppAuthStrategy(BaseAuthStrategy):
         self, code: str, redirect_uri: Optional[str] = None
     ) -> "OAuthWebAuthStrategy":
         return OAuthWebAuthStrategy(
-            self.client_id, self.client_secret, code, redirect_uri
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            code=code,
+            redirect_uri=redirect_uri,
         )
 
     def get_auth_flow(self, github: "GitHubCore") -> httpx.Auth:

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import dataclass, fields
 from typing import Any, Optional, Union
 from typing_extensions import Self
@@ -42,7 +43,7 @@ def build_base_url(base_url: Optional[Union[str, httpx.URL]]) -> httpx.URL:
 
 
 def build_accept(
-    accept_format: Optional[str] = None, previews: Optional[list[str]] = None
+    accept_format: Optional[str] = None, previews: Optional[Sequence[str]] = None
 ) -> str:
     if accept_format:
         accept_format = (
@@ -99,7 +100,7 @@ def get_config(
     *,
     base_url: Optional[Union[str, httpx.URL]] = None,
     accept_format: Optional[str] = None,
-    previews: Optional[list[str]] = None,
+    previews: Optional[Sequence[str]] = None,
     user_agent: Optional[str] = None,
     follow_redirects: bool = True,
     timeout: Optional[Union[float, httpx.Timeout]] = None,

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
@@ -77,7 +77,7 @@ class GitHubCore(Generic[A]):
         *,
         base_url: Optional[Union[str, httpx.URL]] = None,
         accept_format: Optional[str] = None,
-        previews: Optional[list[str]] = None,
+        previews: Optional[Sequence[str]] = None,
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -96,7 +96,7 @@ class GitHubCore(Generic[A]):
         *,
         base_url: Optional[Union[str, httpx.URL]] = None,
         accept_format: Optional[str] = None,
-        previews: Optional[list[str]] = None,
+        previews: Optional[Sequence[str]] = None,
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -115,7 +115,7 @@ class GitHubCore(Generic[A]):
         *,
         base_url: Optional[Union[str, httpx.URL]] = None,
         accept_format: Optional[str] = None,
-        previews: Optional[list[str]] = None,
+        previews: Optional[Sequence[str]] = None,
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -133,7 +133,7 @@ class GitHubCore(Generic[A]):
         config: Optional[Config] = None,
         base_url: Optional[Union[str, httpx.URL]] = None,
         accept_format: Optional[str] = None,
-        previews: Optional[list[str]] = None,
+        previews: Optional[Sequence[str]] = None,
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -338,7 +338,7 @@ class GitHubCore(Generic[A]):
         self,
         response: httpx.Response,
         response_model: type[T],
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Response[T]: ...
 
     @overload
@@ -346,14 +346,14 @@ class GitHubCore(Generic[A]):
         self,
         response: httpx.Response,
         response_model: UnsetType = UNSET,
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Response[Any]: ...
 
     def _check(
         self,
         response: httpx.Response,
         response_model: Union[type[T], UnsetType] = UNSET,
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Union[Response[T], Response[Any]]:
         if response.is_error:
             error_models = error_models or {}
@@ -443,7 +443,7 @@ class GitHubCore(Generic[A]):
         headers: Optional[HeaderTypes] = None,
         cookies: Optional[CookieTypes] = None,
         response_model: type[T],
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Response[T]: ...
 
     @overload
@@ -460,7 +460,7 @@ class GitHubCore(Generic[A]):
         headers: Optional[HeaderTypes] = None,
         cookies: Optional[CookieTypes] = None,
         response_model: UnsetType = UNSET,
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Response[Any]: ...
 
     def request(
@@ -476,7 +476,7 @@ class GitHubCore(Generic[A]):
         headers: Optional[HeaderTypes] = None,
         cookies: Optional[CookieTypes] = None,
         response_model: Union[type[T], UnsetType] = UNSET,
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Union[Response[T], Response[Any]]:
         """Send a request.
 
@@ -525,7 +525,7 @@ class GitHubCore(Generic[A]):
         headers: Optional[HeaderTypes] = None,
         cookies: Optional[CookieTypes] = None,
         response_model: type[T],
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Response[T]: ...
 
     @overload
@@ -542,7 +542,7 @@ class GitHubCore(Generic[A]):
         headers: Optional[HeaderTypes] = None,
         cookies: Optional[CookieTypes] = None,
         response_model: UnsetType = UNSET,
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Response[Any]: ...
 
     async def arequest(
@@ -558,7 +558,7 @@ class GitHubCore(Generic[A]):
         headers: Optional[HeaderTypes] = None,
         cookies: Optional[CookieTypes] = None,
         response_model: Union[type[T], UnsetType] = UNSET,
-        error_models: Optional[dict[str, type]] = None,
+        error_models: Optional[Mapping[str, type]] = None,
     ) -> Union[Response[T], Response[Any]]:
         """Asynchronously send a request.
 

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -1,4 +1,4 @@
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Iterable
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, overload
 from typing_extensions import ParamSpec
@@ -70,7 +70,7 @@ class GitHub(GitHubCore[A]):
             *,
             base_url: Optional[Union[str, httpx.URL]] = None,
             accept_format: Optional[str] = None,
-            previews: Optional[list[str]] = None,
+            previews: Optional[Iterable[str]] = None,
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -89,7 +89,7 @@ class GitHub(GitHubCore[A]):
             *,
             base_url: Optional[Union[str, httpx.URL]] = None,
             accept_format: Optional[str] = None,
-            previews: Optional[list[str]] = None,
+            previews: Optional[Iterable[str]] = None,
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -108,7 +108,7 @@ class GitHub(GitHubCore[A]):
             *,
             base_url: Optional[Union[str, httpx.URL]] = None,
             accept_format: Optional[str] = None,
-            previews: Optional[list[str]] = None,
+            previews: Optional[Iterable[str]] = None,
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -1,4 +1,4 @@
-from collections.abc import Awaitable, Iterable
+from collections.abc import Awaitable, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, overload
 from typing_extensions import ParamSpec
@@ -70,7 +70,7 @@ class GitHub(GitHubCore[A]):
             *,
             base_url: Optional[Union[str, httpx.URL]] = None,
             accept_format: Optional[str] = None,
-            previews: Optional[Iterable[str]] = None,
+            previews: Optional[Sequence[str]] = None,
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -89,7 +89,7 @@ class GitHub(GitHubCore[A]):
             *,
             base_url: Optional[Union[str, httpx.URL]] = None,
             accept_format: Optional[str] = None,
-            previews: Optional[Iterable[str]] = None,
+            previews: Optional[Sequence[str]] = None,
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -108,7 +108,7 @@ class GitHub(GitHubCore[A]):
             *,
             base_url: Optional[Union[str, httpx.URL]] = None,
             accept_format: Optional[str] = None,
-            previews: Optional[Iterable[str]] = None,
+            previews: Optional[Sequence[str]] = None,
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,

--- a/githubkit/graphql/paginator.py
+++ b/githubkit/graphql/paginator.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
 from typing_extensions import Self
 from weakref import ref
@@ -30,13 +31,13 @@ class Paginator:
         self,
         graphql: "GraphQLNamespace",
         query: str,
-        variables: Optional[dict[str, Any]] = None,
+        variables: Optional[Mapping[str, Any]] = None,
     ) -> None:
         self._graphql_ref = ref(graphql)
         self.query = query
 
         self._has_next_page: bool = True
-        self._current_variables = variables.copy() if variables is not None else {}
+        self._current_variables = dict(variables) if variables is not None else {}
 
     @property
     def _graphql(self) -> "GraphQLNamespace":

--- a/githubkit/typing.py
+++ b/githubkit/typing.py
@@ -1,4 +1,4 @@
-from collections.abc import Hashable
+from collections.abc import Hashable, Mapping, Sequence
 from datetime import timedelta
 from typing import (
     IO,
@@ -27,8 +27,8 @@ URLTypes: TypeAlias = Union[httpx.URL, str]
 PrimitiveData: TypeAlias = Optional[Union[str, int, float, bool]]
 QueryParamTypes: TypeAlias = Union[
     httpx.QueryParams,
-    dict[str, Union[PrimitiveData, list[PrimitiveData]]],
-    list[tuple[str, PrimitiveData]],
+    Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
+    Sequence[tuple[str, PrimitiveData]],
     tuple[tuple[str, PrimitiveData], ...],
     str,
     bytes,
@@ -36,10 +36,10 @@ QueryParamTypes: TypeAlias = Union[
 
 HeaderTypes: TypeAlias = Union[
     httpx.Headers,
-    dict[str, str],
-    dict[bytes, bytes],
-    list[tuple[str, str]],
-    list[tuple[bytes, bytes]],
+    Mapping[str, str],
+    Mapping[bytes, bytes],
+    Sequence[tuple[str, str]],
+    Sequence[tuple[bytes, bytes]],
 ]
 
 CookieTypes: TypeAlias = Union[httpx.Cookies, dict[str, str], list[tuple[str, str]]]
@@ -55,7 +55,9 @@ FileTypes: TypeAlias = Union[
     # (filename, file (or bytes), content_type)
     tuple[Optional[str], FileContent, Optional[str]],
 ]
-RequestFiles: TypeAlias = Union[dict[str, FileTypes], list[tuple[str, FileTypes]]]
+RequestFiles: TypeAlias = Union[
+    Mapping[str, FileTypes], Sequence[tuple[str, FileTypes]]
+]
 
 if PYDANTIC_V2:  # pragma: pydantic-v2
     from pydantic import AfterValidator

--- a/githubkit/versions/ghec_v2022_11_28/rest/actions.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/actions.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -197,7 +198,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-enterprise"""
 
@@ -218,7 +219,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-enterprise"""
 
@@ -240,7 +241,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsOidcCustomIssuerPolicyForEnterpriseType,
     ) -> Response: ...
 
@@ -250,7 +251,7 @@ class ActionsClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         include_enterprise_slug: Missing[bool] = UNSET,
     ) -> Response: ...
 
@@ -258,7 +259,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsOidcCustomIssuerPolicyForEnterpriseType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -293,7 +294,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsOidcCustomIssuerPolicyForEnterpriseType,
     ) -> Response: ...
 
@@ -303,7 +304,7 @@ class ActionsClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         include_enterprise_slug: Missing[bool] = UNSET,
     ) -> Response: ...
 
@@ -311,7 +312,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsOidcCustomIssuerPolicyForEnterpriseType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -345,7 +346,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -368,7 +369,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -392,7 +393,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsSetDefaultWorkflowPermissionsType,
     ) -> Response: ...
 
@@ -402,7 +403,7 @@ class ActionsClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -411,7 +412,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -444,7 +445,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsSetDefaultWorkflowPermissionsType,
     ) -> Response: ...
 
@@ -454,7 +455,7 @@ class ActionsClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -463,7 +464,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -496,7 +497,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
@@ -509,7 +510,7 @@ class ActionsClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -523,7 +524,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
@@ -573,7 +574,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
@@ -586,7 +587,7 @@ class ActionsClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -600,7 +601,7 @@ class ActionsClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
@@ -649,7 +650,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
@@ -670,7 +671,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
@@ -693,7 +694,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
@@ -725,7 +726,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
@@ -755,7 +756,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
@@ -776,7 +777,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
@@ -798,7 +799,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -808,7 +809,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled_repositories: Literal["all", "none", "selected"],
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -817,7 +818,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -850,7 +851,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -860,7 +861,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled_repositories: Literal["all", "none", "selected"],
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -869,7 +870,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -903,7 +904,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsPermissionsRepositoriesGetResponse200,
         OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
@@ -935,7 +936,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsPermissionsRepositoriesGetResponse200,
         OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
@@ -966,7 +967,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -976,7 +977,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -984,7 +985,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1019,7 +1020,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1029,7 +1030,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1037,7 +1038,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1072,7 +1073,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#enable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -1091,7 +1092,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#enable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -1110,7 +1111,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#disable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -1129,7 +1130,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#disable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -1147,7 +1148,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
@@ -1168,7 +1169,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
@@ -1190,7 +1191,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -1200,7 +1201,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -1210,7 +1211,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1243,7 +1244,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -1253,7 +1254,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -1263,7 +1264,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1295,7 +1296,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -1318,7 +1319,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -1342,7 +1343,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
     ) -> Response: ...
 
@@ -1352,7 +1353,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -1361,7 +1362,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1395,7 +1396,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
     ) -> Response: ...
 
@@ -1405,7 +1406,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -1414,7 +1415,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1450,7 +1451,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         visible_to_repository: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsGetResponse200,
         OrgsOrgActionsRunnerGroupsGetResponse200Type,
@@ -1484,7 +1485,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         visible_to_repository: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsGetResponse200,
         OrgsOrgActionsRunnerGroupsGetResponse200Type,
@@ -1516,7 +1517,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1526,7 +1527,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -1540,7 +1541,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1574,7 +1575,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1584,7 +1585,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -1598,7 +1599,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1632,7 +1633,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
@@ -1654,7 +1655,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
@@ -1676,7 +1677,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-organization"""
 
@@ -1695,7 +1696,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-organization"""
 
@@ -1715,7 +1716,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1726,7 +1727,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         allows_public_repositories: Missing[bool] = UNSET,
@@ -1739,7 +1740,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1779,7 +1780,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1790,7 +1791,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         allows_public_repositories: Missing[bool] = UNSET,
@@ -1803,7 +1804,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1844,7 +1845,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
@@ -1879,7 +1880,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
@@ -1913,7 +1914,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1924,7 +1925,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1933,7 +1934,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType
         ] = UNSET,
@@ -1971,7 +1972,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1982,7 +1983,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1991,7 +1992,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType
         ] = UNSET,
@@ -2029,7 +2030,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -2049,7 +2050,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -2069,7 +2070,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -2089,7 +2090,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -2110,7 +2111,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
@@ -2145,7 +2146,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
@@ -2179,7 +2180,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
     ) -> Response: ...
 
@@ -2190,7 +2191,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         runners: list[int],
     ) -> Response: ...
 
@@ -2199,7 +2200,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType
         ] = UNSET,
@@ -2237,7 +2238,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
     ) -> Response: ...
 
@@ -2248,7 +2249,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         runners: list[int],
     ) -> Response: ...
 
@@ -2257,7 +2258,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType
         ] = UNSET,
@@ -2295,7 +2296,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-organization"""
 
@@ -2315,7 +2316,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-organization"""
 
@@ -2335,7 +2336,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-organization"""
 
@@ -2355,7 +2356,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-organization"""
 
@@ -2376,7 +2377,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
     ]:
@@ -2409,7 +2410,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
     ]:
@@ -2439,7 +2440,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
@@ -2460,7 +2461,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
@@ -2482,7 +2483,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
@@ -2495,7 +2496,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -2509,7 +2510,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2557,7 +2558,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
@@ -2570,7 +2571,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -2584,7 +2585,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2631,7 +2632,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
@@ -2652,7 +2653,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
@@ -2673,7 +2674,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
@@ -2694,7 +2695,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
@@ -2716,7 +2717,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
@@ -2738,7 +2739,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
@@ -2760,7 +2761,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization"""
 
@@ -2779,7 +2780,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization"""
 
@@ -2798,7 +2799,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2829,7 +2830,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2861,7 +2862,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2875,7 +2876,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2887,7 +2888,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2936,7 +2937,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2950,7 +2951,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2962,7 +2963,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -3011,7 +3012,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -3025,7 +3026,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -3037,7 +3038,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -3086,7 +3087,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -3100,7 +3101,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -3112,7 +3113,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -3160,7 +3161,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -3191,7 +3192,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -3223,7 +3224,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -3257,7 +3258,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -3291,7 +3292,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
     ]:
@@ -3322,7 +3323,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
     ]:
@@ -3351,7 +3352,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-public-key"""
 
@@ -3372,7 +3373,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-public-key"""
 
@@ -3394,7 +3395,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-secret"""
 
@@ -3416,7 +3417,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-organization-secret"""
 
@@ -3439,7 +3440,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3450,7 +3451,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -3462,7 +3463,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3497,7 +3498,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3508,7 +3509,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -3520,7 +3521,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3554,7 +3555,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#delete-an-organization-secret"""
 
@@ -3573,7 +3574,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#delete-an-organization-secret"""
 
@@ -3594,7 +3595,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3627,7 +3628,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3659,7 +3660,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3670,7 +3671,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3679,7 +3680,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3715,7 +3716,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3726,7 +3727,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3735,7 +3736,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3771,7 +3772,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -3792,7 +3793,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -3813,7 +3814,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -3834,7 +3835,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -3855,7 +3856,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
     ]:
@@ -3886,7 +3887,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
     ]:
@@ -3916,7 +3917,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3926,7 +3927,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
         visibility: Literal["all", "private", "selected"],
@@ -3937,7 +3938,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3971,7 +3972,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3981,7 +3982,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
         visibility: Literal["all", "private", "selected"],
@@ -3992,7 +3993,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -4026,7 +4027,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-organization-variable"""
 
@@ -4048,7 +4049,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-organization-variable"""
 
@@ -4070,7 +4071,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#delete-an-organization-variable"""
 
@@ -4089,7 +4090,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#delete-an-organization-variable"""
 
@@ -4109,7 +4110,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -4120,7 +4121,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
         visibility: Missing[Literal["all", "private", "selected"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -4131,7 +4132,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4165,7 +4166,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -4176,7 +4177,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
         visibility: Missing[Literal["all", "private", "selected"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -4187,7 +4188,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4222,7 +4223,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
@@ -4256,7 +4257,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
@@ -4289,7 +4290,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -4300,7 +4301,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -4309,7 +4310,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4346,7 +4347,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -4357,7 +4358,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -4366,7 +4367,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4403,7 +4404,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#add-selected-repository-to-an-organization-variable"""
 
@@ -4424,7 +4425,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#add-selected-repository-to-an-organization-variable"""
 
@@ -4445,7 +4446,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#remove-selected-repository-from-an-organization-variable"""
 
@@ -4466,7 +4467,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#remove-selected-repository-from-an-organization-variable"""
 
@@ -4489,7 +4490,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsArtifactsGetResponse200,
         ReposOwnerRepoActionsArtifactsGetResponse200Type,
@@ -4524,7 +4525,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsArtifactsGetResponse200,
         ReposOwnerRepoActionsArtifactsGetResponse200Type,
@@ -4557,7 +4558,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#get-an-artifact"""
 
@@ -4580,7 +4581,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#get-an-artifact"""
 
@@ -4603,7 +4604,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#delete-an-artifact"""
 
@@ -4623,7 +4624,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#delete-an-artifact"""
 
@@ -4644,7 +4645,7 @@ class ActionsClient:
         artifact_id: int,
         archive_format: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#download-an-artifact"""
 
@@ -4670,7 +4671,7 @@ class ActionsClient:
         artifact_id: int,
         archive_format: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/artifacts#download-an-artifact"""
 
@@ -4694,7 +4695,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
@@ -4716,7 +4717,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
@@ -4746,7 +4747,7 @@ class ActionsClient:
             Literal["created_at", "last_accessed_at", "size_in_bytes"]
         ] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
@@ -4786,7 +4787,7 @@ class ActionsClient:
             Literal["created_at", "last_accessed_at", "size_in_bytes"]
         ] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
@@ -4820,7 +4821,7 @@ class ActionsClient:
         *,
         key: str,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
@@ -4850,7 +4851,7 @@ class ActionsClient:
         *,
         key: str,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
@@ -4879,7 +4880,7 @@ class ActionsClient:
         repo: str,
         cache_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#delete-a-github-actions-cache-for-a-repository-using-a-cache-id"""
 
@@ -4899,7 +4900,7 @@ class ActionsClient:
         repo: str,
         cache_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/cache#delete-a-github-actions-cache-for-a-repository-using-a-cache-id"""
 
@@ -4919,7 +4920,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
@@ -4942,7 +4943,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
@@ -4965,7 +4966,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run"""
 
@@ -4985,7 +4986,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run"""
 
@@ -5006,7 +5007,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -5020,7 +5021,7 @@ class ActionsClient:
         job_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -5030,7 +5031,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -5079,7 +5080,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -5093,7 +5094,7 @@ class ActionsClient:
         job_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -5103,7 +5104,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -5150,7 +5151,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
@@ -5176,7 +5177,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
@@ -5203,7 +5204,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -5214,7 +5215,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -5224,7 +5225,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -5271,7 +5272,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -5282,7 +5283,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -5292,7 +5293,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -5340,7 +5341,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
@@ -5373,7 +5374,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
@@ -5406,7 +5407,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
@@ -5439,7 +5440,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
@@ -5470,7 +5471,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
@@ -5492,7 +5493,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
@@ -5515,7 +5516,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -5526,7 +5527,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -5536,7 +5537,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5570,7 +5571,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -5581,7 +5582,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -5591,7 +5592,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5624,7 +5625,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
     ]:
@@ -5648,7 +5649,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
     ]:
@@ -5673,7 +5674,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsWorkflowAccessToRepositoryType,
     ) -> Response: ...
 
@@ -5684,7 +5685,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_level: Literal["none", "user", "organization", "enterprise"],
     ) -> Response: ...
 
@@ -5693,7 +5694,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsWorkflowAccessToRepositoryType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5727,7 +5728,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsWorkflowAccessToRepositoryType,
     ) -> Response: ...
 
@@ -5738,7 +5739,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_level: Literal["none", "user", "organization", "enterprise"],
     ) -> Response: ...
 
@@ -5747,7 +5748,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsWorkflowAccessToRepositoryType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5780,7 +5781,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
@@ -5802,7 +5803,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
@@ -5825,7 +5826,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -5836,7 +5837,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -5847,7 +5848,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5881,7 +5882,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -5892,7 +5893,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -5903,7 +5904,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5936,7 +5937,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -5960,7 +5961,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -5985,7 +5986,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsSetDefaultWorkflowPermissionsType,
     ) -> Response: ...
 
@@ -5996,7 +5997,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -6006,7 +6007,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -6041,7 +6042,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsSetDefaultWorkflowPermissionsType,
     ) -> Response: ...
 
@@ -6052,7 +6053,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -6062,7 +6063,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -6099,7 +6100,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunnersGetResponse200,
         ReposOwnerRepoActionsRunnersGetResponse200Type,
@@ -6134,7 +6135,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunnersGetResponse200,
         ReposOwnerRepoActionsRunnersGetResponse200Type,
@@ -6166,7 +6167,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
@@ -6188,7 +6189,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
@@ -6211,7 +6212,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
@@ -6225,7 +6226,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -6240,7 +6241,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
@@ -6291,7 +6292,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGenerateJitconfigPostResponse201,
@@ -6305,7 +6306,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -6320,7 +6321,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
@@ -6370,7 +6371,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
@@ -6392,7 +6393,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
@@ -6414,7 +6415,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
@@ -6436,7 +6437,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
@@ -6459,7 +6460,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
@@ -6482,7 +6483,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
@@ -6505,7 +6506,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-a-repository"""
 
@@ -6525,7 +6526,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-a-repository"""
 
@@ -6545,7 +6546,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -6577,7 +6578,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -6610,7 +6611,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6625,7 +6626,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6638,7 +6639,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6688,7 +6689,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6703,7 +6704,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6716,7 +6717,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6766,7 +6767,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6781,7 +6782,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6794,7 +6795,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6844,7 +6845,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6859,7 +6860,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6872,7 +6873,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6921,7 +6922,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -6953,7 +6954,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -6986,7 +6987,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -7021,7 +7022,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -7081,7 +7082,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsGetResponse200,
         ReposOwnerRepoActionsRunsGetResponse200Type,
@@ -7147,7 +7148,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsGetResponse200,
         ReposOwnerRepoActionsRunsGetResponse200Type,
@@ -7188,7 +7189,7 @@ class ActionsClient:
         run_id: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run"""
 
@@ -7217,7 +7218,7 @@ class ActionsClient:
         run_id: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run"""
 
@@ -7245,7 +7246,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#delete-a-workflow-run"""
 
@@ -7265,7 +7266,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#delete-a-workflow-run"""
 
@@ -7285,7 +7286,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
@@ -7308,7 +7309,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
@@ -7331,7 +7332,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
@@ -7358,7 +7359,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
@@ -7388,7 +7389,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
@@ -7424,7 +7425,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
@@ -7459,7 +7460,7 @@ class ActionsClient:
         attempt_number: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
@@ -7489,7 +7490,7 @@ class ActionsClient:
         attempt_number: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
@@ -7520,7 +7521,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
@@ -7561,7 +7562,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
@@ -7600,7 +7601,7 @@ class ActionsClient:
         run_id: int,
         attempt_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#download-workflow-run-attempt-logs"""
 
@@ -7621,7 +7622,7 @@ class ActionsClient:
         run_id: int,
         attempt_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#download-workflow-run-attempt-logs"""
 
@@ -7641,7 +7642,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#cancel-a-workflow-run"""
 
@@ -7667,7 +7668,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#cancel-a-workflow-run"""
 
@@ -7694,7 +7695,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
         ],
@@ -7708,7 +7709,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         comment: str,
     ) -> Response: ...
@@ -7721,7 +7722,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         state: Literal["approved", "rejected"],
         comment: Missing[str] = UNSET,
@@ -7733,7 +7734,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
@@ -7780,7 +7781,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
         ],
@@ -7794,7 +7795,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         comment: str,
     ) -> Response: ...
@@ -7807,7 +7808,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         state: Literal["approved", "rejected"],
         comment: Missing[str] = UNSET,
@@ -7819,7 +7820,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
@@ -7865,7 +7866,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
@@ -7891,7 +7892,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
@@ -7920,7 +7921,7 @@ class ActionsClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
@@ -7956,7 +7957,7 @@ class ActionsClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
@@ -7989,7 +7990,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#download-workflow-run-logs"""
 
@@ -8009,7 +8010,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#download-workflow-run-logs"""
 
@@ -8029,7 +8030,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#delete-workflow-run-logs"""
 
@@ -8055,7 +8056,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#delete-workflow-run-logs"""
 
@@ -8081,7 +8082,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
@@ -8104,7 +8105,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
@@ -8128,7 +8129,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
     ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
@@ -8140,7 +8141,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
@@ -8152,7 +8153,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
@@ -8195,7 +8196,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
     ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
@@ -8207,7 +8208,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
@@ -8219,7 +8220,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
@@ -8262,7 +8263,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -8276,7 +8277,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8286,7 +8287,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -8328,7 +8329,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -8342,7 +8343,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8352,7 +8353,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -8394,7 +8395,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8408,7 +8409,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8418,7 +8419,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8463,7 +8464,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8477,7 +8478,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8487,7 +8488,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8531,7 +8532,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-workflow-run-usage"""
 
@@ -8554,7 +8555,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflow-runs#get-workflow-run-usage"""
 
@@ -8578,7 +8579,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsSecretsGetResponse200,
         ReposOwnerRepoActionsSecretsGetResponse200Type,
@@ -8611,7 +8612,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsSecretsGetResponse200,
         ReposOwnerRepoActionsSecretsGetResponse200Type,
@@ -8642,7 +8643,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-public-key"""
 
@@ -8664,7 +8665,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-public-key"""
 
@@ -8687,7 +8688,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-secret"""
 
@@ -8710,7 +8711,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-a-repository-secret"""
 
@@ -8734,7 +8735,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8746,7 +8747,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8757,7 +8758,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -8795,7 +8796,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8807,7 +8808,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8818,7 +8819,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -8855,7 +8856,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#delete-a-repository-secret"""
 
@@ -8875,7 +8876,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#delete-a-repository-secret"""
 
@@ -8896,7 +8897,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsVariablesGetResponse200,
         ReposOwnerRepoActionsVariablesGetResponse200Type,
@@ -8929,7 +8930,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsVariablesGetResponse200,
         ReposOwnerRepoActionsVariablesGetResponse200Type,
@@ -8961,7 +8962,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8972,7 +8973,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8982,7 +8983,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -9017,7 +9018,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -9028,7 +9029,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -9038,7 +9039,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -9073,7 +9074,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-a-repository-variable"""
 
@@ -9096,7 +9097,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-a-repository-variable"""
 
@@ -9119,7 +9120,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#delete-a-repository-variable"""
 
@@ -9139,7 +9140,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#delete-a-repository-variable"""
 
@@ -9160,7 +9161,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -9172,7 +9173,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -9182,7 +9183,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -9219,7 +9220,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -9231,7 +9232,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -9241,7 +9242,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -9278,7 +9279,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsGetResponse200,
         ReposOwnerRepoActionsWorkflowsGetResponse200Type,
@@ -9311,7 +9312,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsGetResponse200,
         ReposOwnerRepoActionsWorkflowsGetResponse200Type,
@@ -9343,7 +9344,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-a-workflow"""
 
@@ -9366,7 +9367,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-a-workflow"""
 
@@ -9389,7 +9390,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#disable-a-workflow"""
 
@@ -9409,7 +9410,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#disable-a-workflow"""
 
@@ -9430,7 +9431,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -9442,7 +9443,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         inputs: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType
@@ -9455,7 +9456,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType
         ] = UNSET,
@@ -9494,7 +9495,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -9506,7 +9507,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         inputs: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType
@@ -9519,7 +9520,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType
         ] = UNSET,
@@ -9557,7 +9558,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#enable-a-workflow"""
 
@@ -9577,7 +9578,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#enable-a-workflow"""
 
@@ -9624,7 +9625,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
@@ -9691,7 +9692,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
@@ -9731,7 +9732,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-workflow-usage"""
 
@@ -9754,7 +9755,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/workflows#get-workflow-usage"""
 
@@ -9779,7 +9780,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
@@ -9815,7 +9816,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
@@ -9849,7 +9850,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-public-key"""
 
@@ -9874,7 +9875,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-public-key"""
 
@@ -9900,7 +9901,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-secret"""
 
@@ -9924,7 +9925,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#get-an-environment-secret"""
 
@@ -9949,7 +9950,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -9962,7 +9963,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: str,
         key_id: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -9974,7 +9975,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
@@ -10018,7 +10019,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -10031,7 +10032,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: str,
         key_id: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -10043,7 +10044,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
@@ -10086,7 +10087,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#delete-an-environment-secret"""
 
@@ -10107,7 +10108,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/secrets#delete-an-environment-secret"""
 
@@ -10129,7 +10130,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
@@ -10165,7 +10166,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
@@ -10200,7 +10201,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -10212,7 +10213,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -10223,7 +10224,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
@@ -10266,7 +10267,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -10278,7 +10279,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -10289,7 +10290,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
@@ -10332,7 +10333,7 @@ class ActionsClient:
         environment_name: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-environment-variable"""
 
@@ -10356,7 +10357,7 @@ class ActionsClient:
         environment_name: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#get-an-environment-variable"""
 
@@ -10380,7 +10381,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#delete-an-environment-variable"""
 
@@ -10401,7 +10402,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/variables#delete-an-environment-variable"""
 
@@ -10423,7 +10424,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -10436,7 +10437,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -10447,7 +10448,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType
         ] = UNSET,
@@ -10489,7 +10490,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -10502,7 +10503,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -10513,7 +10514,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType
         ] = UNSET,

--- a/githubkit/versions/ghec_v2022_11_28/rest/activity.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/activity.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -81,7 +82,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events"""
 
@@ -117,7 +118,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events"""
 
@@ -151,7 +152,7 @@ class ActivityClient:
     def get_feeds(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/feeds#get-feeds"""
 
@@ -171,7 +172,7 @@ class ActivityClient:
     async def async_get_feeds(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/feeds#get-feeds"""
 
@@ -195,7 +196,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
@@ -229,7 +230,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
@@ -265,7 +266,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
@@ -306,7 +307,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
@@ -342,7 +343,7 @@ class ActivityClient:
     def mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
@@ -351,7 +352,7 @@ class ActivityClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
@@ -359,7 +360,7 @@ class ActivityClient:
     def mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
@@ -400,7 +401,7 @@ class ActivityClient:
     async def async_mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
@@ -409,7 +410,7 @@ class ActivityClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
@@ -417,7 +418,7 @@ class ActivityClient:
     async def async_mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
@@ -458,7 +459,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread"""
 
@@ -483,7 +484,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread"""
 
@@ -508,7 +509,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-a-thread-as-done"""
 
@@ -526,7 +527,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-a-thread-as-done"""
 
@@ -544,7 +545,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-a-thread-as-read"""
 
@@ -567,7 +568,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#mark-a-thread-as-read"""
 
@@ -590,7 +591,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
@@ -615,7 +616,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
@@ -641,7 +642,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -651,7 +652,7 @@ class ActivityClient:
         thread_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ignored: Missing[bool] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -659,7 +660,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
@@ -703,7 +704,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -713,7 +714,7 @@ class ActivityClient:
         thread_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ignored: Missing[bool] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -721,7 +722,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
@@ -764,7 +765,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#delete-a-thread-subscription"""
 
@@ -788,7 +789,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#delete-a-thread-subscription"""
 
@@ -814,7 +815,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-organization-events"""
 
@@ -843,7 +844,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-organization-events"""
 
@@ -873,7 +874,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-repository-events"""
 
@@ -903,7 +904,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-repository-events"""
 
@@ -937,7 +938,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
@@ -975,7 +976,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
@@ -1008,7 +1009,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1022,7 +1023,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1034,7 +1035,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1075,7 +1076,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1089,7 +1090,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1101,7 +1102,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1143,7 +1144,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[SimpleUser], list[Stargazer]],
         Union[list[SimpleUserType], list[StargazerType]],
@@ -1181,7 +1182,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[SimpleUser], list[Stargazer]],
         Union[list[SimpleUserType], list[StargazerType]],
@@ -1219,7 +1220,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-watchers"""
 
@@ -1249,7 +1250,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-watchers"""
 
@@ -1277,7 +1278,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#get-a-repository-subscription"""
 
@@ -1302,7 +1303,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#get-a-repository-subscription"""
 
@@ -1328,7 +1329,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
@@ -1339,7 +1340,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
@@ -1349,7 +1350,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
@@ -1384,7 +1385,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
@@ -1395,7 +1396,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
@@ -1405,7 +1406,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
@@ -1439,7 +1440,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#delete-a-repository-subscription"""
 
@@ -1458,7 +1459,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#delete-a-repository-subscription"""
 
@@ -1479,7 +1480,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
@@ -1515,7 +1516,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
@@ -1549,7 +1550,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user"""
 
@@ -1575,7 +1576,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user"""
 
@@ -1601,7 +1602,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#star-a-repository-for-the-authenticated-user"""
 
@@ -1627,7 +1628,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#star-a-repository-for-the-authenticated-user"""
 
@@ -1653,7 +1654,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#unstar-a-repository-for-the-authenticated-user"""
 
@@ -1679,7 +1680,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/starring#unstar-a-repository-for-the-authenticated-user"""
 
@@ -1705,7 +1706,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
@@ -1737,7 +1738,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
@@ -1770,7 +1771,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-for-the-authenticated-user"""
 
@@ -1799,7 +1800,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-for-the-authenticated-user"""
 
@@ -1829,7 +1830,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
@@ -1859,7 +1860,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
@@ -1888,7 +1889,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-user"""
 
@@ -1917,7 +1918,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-for-a-user"""
 
@@ -1946,7 +1947,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-received-by-the-authenticated-user"""
 
@@ -1975,7 +1976,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-events-received-by-the-authenticated-user"""
 
@@ -2004,7 +2005,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-received-by-a-user"""
 
@@ -2033,7 +2034,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/events#list-public-events-received-by-a-user"""
 
@@ -2064,7 +2065,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[StarredRepository], list[Repository]],
         Union[list[StarredRepositoryType], list[RepositoryType]],
@@ -2102,7 +2103,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[StarredRepository], list[Repository]],
         Union[list[StarredRepositoryType], list[RepositoryType]],
@@ -2138,7 +2139,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-a-user"""
 
@@ -2167,7 +2168,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/activity/watching#list-repositories-watched-by-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/apps.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/apps.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -91,7 +92,7 @@ class AppsClient:
     def get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-the-authenticated-app"""
 
@@ -113,7 +114,7 @@ class AppsClient:
     async def async_get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-the-authenticated-app"""
 
@@ -136,7 +137,7 @@ class AppsClient:
         self,
         code: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppManifestsCodeConversionsPostResponse201,
         AppManifestsCodeConversionsPostResponse201Type,
@@ -168,7 +169,7 @@ class AppsClient:
         self,
         code: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppManifestsCodeConversionsPostResponse201,
         AppManifestsCodeConversionsPostResponse201Type,
@@ -199,7 +200,7 @@ class AppsClient:
     def get_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
@@ -219,7 +220,7 @@ class AppsClient:
     async def async_get_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
@@ -240,7 +241,7 @@ class AppsClient:
     def update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AppHookConfigPatchBodyType,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -249,7 +250,7 @@ class AppsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -259,7 +260,7 @@ class AppsClient:
     def update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -292,7 +293,7 @@ class AppsClient:
     async def async_update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AppHookConfigPatchBodyType,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -301,7 +302,7 @@ class AppsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -311,7 +312,7 @@ class AppsClient:
     async def async_update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -345,7 +346,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
@@ -377,7 +378,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
@@ -408,7 +409,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
@@ -433,7 +434,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
@@ -458,7 +459,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -490,7 +491,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -523,7 +524,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
     ]:
@@ -556,7 +557,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
     ]:
@@ -591,7 +592,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         outdated: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#list-installations-for-the-authenticated-app"""
 
@@ -623,7 +624,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         outdated: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#list-installations-for-the-authenticated-app"""
 
@@ -652,7 +653,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
@@ -676,7 +677,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
@@ -700,7 +701,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#delete-an-installation-for-the-authenticated-app"""
 
@@ -723,7 +724,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#delete-an-installation-for-the-authenticated-app"""
 
@@ -747,7 +748,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
     ) -> Response[InstallationToken, InstallationTokenType]: ...
 
@@ -757,7 +758,7 @@ class AppsClient:
         installation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
@@ -767,7 +768,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[InstallationToken, InstallationTokenType]:
@@ -814,7 +815,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
     ) -> Response[InstallationToken, InstallationTokenType]: ...
 
@@ -824,7 +825,7 @@ class AppsClient:
         installation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
@@ -834,7 +835,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[InstallationToken, InstallationTokenType]:
@@ -880,7 +881,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#suspend-an-app-installation"""
 
@@ -903,7 +904,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#suspend-an-app-installation"""
 
@@ -926,7 +927,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#unsuspend-an-app-installation"""
 
@@ -949,7 +950,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#unsuspend-an-app-installation"""
 
@@ -973,7 +974,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdGrantDeleteBodyType,
     ) -> Response: ...
 
@@ -983,7 +984,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -991,7 +992,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdGrantDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1027,7 +1028,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdGrantDeleteBodyType,
     ) -> Response: ...
 
@@ -1037,7 +1038,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -1045,7 +1046,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdGrantDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1081,7 +1082,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1091,7 +1092,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1099,7 +1100,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1142,7 +1143,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1152,7 +1153,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1160,7 +1161,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1203,7 +1204,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenDeleteBodyType,
     ) -> Response: ...
 
@@ -1213,7 +1214,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -1221,7 +1222,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1257,7 +1258,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenDeleteBodyType,
     ) -> Response: ...
 
@@ -1267,7 +1268,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -1275,7 +1276,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1311,7 +1312,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1321,7 +1322,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1329,7 +1330,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1370,7 +1371,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1380,7 +1381,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1388,7 +1389,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1429,7 +1430,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1439,7 +1440,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
         target: Missing[str] = UNSET,
         target_id: Missing[int] = UNSET,
@@ -1452,7 +1453,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1497,7 +1498,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1507,7 +1508,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
         target: Missing[str] = UNSET,
         target_id: Missing[int] = UNSET,
@@ -1520,7 +1521,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1564,7 +1565,7 @@ class AppsClient:
         self,
         app_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-app"""
 
@@ -1591,7 +1592,7 @@ class AppsClient:
         self,
         app_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-app"""
 
@@ -1619,7 +1620,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         InstallationRepositoriesGetResponse200,
         InstallationRepositoriesGetResponse200Type,
@@ -1654,7 +1655,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         InstallationRepositoriesGetResponse200,
         InstallationRepositoriesGetResponse200Type,
@@ -1687,7 +1688,7 @@ class AppsClient:
     def revoke_installation_access_token(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#revoke-an-installation-access-token"""
 
@@ -1704,7 +1705,7 @@ class AppsClient:
     async def async_revoke_installation_access_token(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#revoke-an-installation-access-token"""
 
@@ -1722,7 +1723,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
@@ -1747,7 +1748,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
@@ -1773,7 +1774,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans"""
 
@@ -1805,7 +1806,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans"""
 
@@ -1840,7 +1841,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan"""
 
@@ -1878,7 +1879,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan"""
 
@@ -1912,7 +1913,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
@@ -1936,7 +1937,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
@@ -1961,7 +1962,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans-stubbed"""
 
@@ -1992,7 +1993,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-plans-stubbed"""
 
@@ -2026,7 +2027,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
@@ -2062,7 +2063,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
@@ -2094,7 +2095,7 @@ class AppsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
@@ -2115,7 +2116,7 @@ class AppsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
@@ -2137,7 +2138,7 @@ class AppsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
@@ -2162,7 +2163,7 @@ class AppsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
@@ -2187,7 +2188,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
@@ -2219,7 +2220,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
@@ -2252,7 +2253,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserInstallationsInstallationIdRepositoriesGetResponse200,
         UserInstallationsInstallationIdRepositoriesGetResponse200Type,
@@ -2291,7 +2292,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserInstallationsInstallationIdRepositoriesGetResponse200,
         UserInstallationsInstallationIdRepositoriesGetResponse200Type,
@@ -2329,7 +2330,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#add-a-repository-to-an-app-installation"""
 
@@ -2354,7 +2355,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#add-a-repository-to-an-app-installation"""
 
@@ -2379,7 +2380,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#remove-a-repository-from-an-app-installation"""
 
@@ -2404,7 +2405,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/installations#remove-a-repository-from-an-app-installation"""
 
@@ -2429,7 +2430,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
@@ -2461,7 +2462,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
@@ -2493,7 +2494,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
@@ -2524,7 +2525,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
@@ -2554,7 +2555,7 @@ class AppsClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 
@@ -2575,7 +2576,7 @@ class AppsClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/billing.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/billing.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -67,7 +68,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-actions-billing-for-an-enterprise"""
 
@@ -88,7 +89,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-actions-billing-for-an-enterprise"""
 
@@ -111,7 +112,7 @@ class BillingClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
     ]:
@@ -142,7 +143,7 @@ class BillingClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
     ]:
@@ -171,7 +172,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetAllCostCenters, GetAllCostCentersType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-all-cost-centers-for-an-enterprise"""
 
@@ -202,7 +203,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetAllCostCenters, GetAllCostCentersType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-all-cost-centers-for-an-enterprise"""
 
@@ -235,7 +236,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType,
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
@@ -249,7 +250,7 @@ class BillingClient:
         cost_center_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
@@ -261,7 +262,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType
         ] = UNSET,
@@ -316,7 +317,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType,
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
@@ -330,7 +331,7 @@ class BillingClient:
         cost_center_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostResponse200,
@@ -342,7 +343,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourcePostBodyType
         ] = UNSET,
@@ -397,7 +398,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType,
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
@@ -411,7 +412,7 @@ class BillingClient:
         cost_center_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
@@ -423,7 +424,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType
         ] = UNSET,
@@ -477,7 +478,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType,
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
@@ -491,7 +492,7 @@ class BillingClient:
         cost_center_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[
         EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteResponse200,
@@ -503,7 +504,7 @@ class BillingClient:
         enterprise: str,
         cost_center_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseSettingsBillingCostCentersCostCenterIdResourceDeleteBodyType
         ] = UNSET,
@@ -555,7 +556,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-packages-billing-for-an-enterprise"""
 
@@ -576,7 +577,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-github-packages-billing-for-an-enterprise"""
 
@@ -597,7 +598,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-shared-storage-billing-for-an-enterprise"""
 
@@ -618,7 +619,7 @@ class BillingClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-shared-storage-billing-for-an-enterprise"""
 
@@ -644,7 +645,7 @@ class BillingClient:
         day: Missing[int] = UNSET,
         hour: Missing[int] = UNSET,
         cost_center_id: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-billing-usage-report-for-an-enterprise"""
 
@@ -689,7 +690,7 @@ class BillingClient:
         day: Missing[int] = UNSET,
         hour: Missing[int] = UNSET,
         cost_center_id: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/billing#get-billing-usage-report-for-an-enterprise"""
 
@@ -733,7 +734,7 @@ class BillingClient:
         month: Missing[int] = UNSET,
         day: Missing[int] = UNSET,
         hour: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/enhanced-billing#get-billing-usage-report-for-an-organization"""
 
@@ -776,7 +777,7 @@ class BillingClient:
         month: Missing[int] = UNSET,
         day: Missing[int] = UNSET,
         hour: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/enhanced-billing#get-billing-usage-report-for-an-organization"""
 
@@ -815,7 +816,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
@@ -836,7 +837,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
@@ -859,7 +860,7 @@ class BillingClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
     ]:
@@ -890,7 +891,7 @@ class BillingClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AdvancedSecurityActiveCommitters, AdvancedSecurityActiveCommittersType
     ]:
@@ -919,7 +920,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
@@ -940,7 +941,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
@@ -961,7 +962,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
@@ -982,7 +983,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
@@ -1003,7 +1004,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-a-user"""
 
@@ -1024,7 +1025,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-actions-billing-for-a-user"""
 
@@ -1045,7 +1046,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-a-user"""
 
@@ -1066,7 +1067,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-github-packages-billing-for-a-user"""
 
@@ -1087,7 +1088,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-a-user"""
 
@@ -1108,7 +1109,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/billing/billing#get-shared-storage-billing-for-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/checks.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/checks.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -81,7 +82,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
@@ -95,7 +96,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -126,7 +127,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -159,7 +160,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsPostBodyOneof0Type,
@@ -211,7 +212,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
@@ -225,7 +226,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -256,7 +257,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -289,7 +290,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsPostBodyOneof0Type,
@@ -341,7 +342,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#get-a-check-run"""
 
@@ -364,7 +365,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#get-a-check-run"""
 
@@ -388,7 +389,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
@@ -403,7 +404,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -436,7 +437,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -469,7 +470,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
@@ -522,7 +523,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
@@ -537,7 +538,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -570,7 +571,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -603,7 +604,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
@@ -657,7 +658,7 @@ class ChecksClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-run-annotations"""
 
@@ -688,7 +689,7 @@ class ChecksClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#list-check-run-annotations"""
 
@@ -717,7 +718,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#rerequest-a-check-run"""
 
@@ -745,7 +746,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/runs#rerequest-a-check-run"""
 
@@ -773,7 +774,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -784,7 +785,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         head_sha: str,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -793,7 +794,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuite, CheckSuiteType]:
@@ -828,7 +829,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -839,7 +840,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         head_sha: str,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -848,7 +849,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuite, CheckSuiteType]:
@@ -883,7 +884,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
@@ -894,7 +895,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         auto_trigger_checks: Missing[
             list[
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
@@ -907,7 +908,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
@@ -947,7 +948,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
@@ -958,7 +959,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         auto_trigger_checks: Missing[
             list[
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
@@ -971,7 +972,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
@@ -1011,7 +1012,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#get-a-check-suite"""
 
@@ -1034,7 +1035,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#get-a-check-suite"""
 
@@ -1062,7 +1063,7 @@ class ChecksClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
@@ -1104,7 +1105,7 @@ class ChecksClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
@@ -1141,7 +1142,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#rerequest-a-check-suite"""
 
@@ -1164,7 +1165,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/checks/suites#rerequest-a-check-suite"""
 
@@ -1193,7 +1194,7 @@ class ChecksClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         app_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
@@ -1235,7 +1236,7 @@ class ChecksClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         app_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
@@ -1275,7 +1276,7 @@ class ChecksClient:
         check_name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
@@ -1313,7 +1314,7 @@ class ChecksClient:
         check_name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,

--- a/githubkit/versions/ghec_v2022_11_28/rest/classroom.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/classroom.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -58,7 +59,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-an-assignment"""
 
@@ -82,7 +83,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-an-assignment"""
 
@@ -108,7 +109,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
     ]:
@@ -139,7 +140,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
     ]:
@@ -168,7 +169,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-assignment-grades"""
 
@@ -192,7 +193,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-assignment-grades"""
 
@@ -217,7 +218,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-classrooms"""
 
@@ -245,7 +246,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-classrooms"""
 
@@ -272,7 +273,7 @@ class ClassroomClient:
         self,
         classroom_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-a-classroom"""
 
@@ -296,7 +297,7 @@ class ClassroomClient:
         self,
         classroom_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#get-a-classroom"""
 
@@ -322,7 +323,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-assignments-for-a-classroom"""
 
@@ -351,7 +352,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/classroom/classroom#list-assignments-for-a-classroom"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/code_scanning.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/code_scanning.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -98,7 +99,7 @@ class CodeScanningClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         state: Missing[Literal["open", "closed", "dismissed", "fixed"]] = UNSET,
         sort: Missing[Literal["created", "updated"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningOrganizationAlertItems],
         list[CodeScanningOrganizationAlertItemsType],
@@ -152,7 +153,7 @@ class CodeScanningClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         state: Missing[Literal["open", "closed", "dismissed", "fixed"]] = UNSET,
         sort: Missing[Literal["created", "updated"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningOrganizationAlertItems],
         list[CodeScanningOrganizationAlertItemsType],
@@ -209,7 +210,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningOrganizationAlertItems],
         list[CodeScanningOrganizationAlertItemsType],
@@ -267,7 +268,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningOrganizationAlertItems],
         list[CodeScanningOrganizationAlertItemsType],
@@ -328,7 +329,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
@@ -389,7 +390,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
@@ -437,7 +438,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
@@ -469,7 +470,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
@@ -502,7 +503,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
@@ -514,7 +515,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "dismissed"],
         dismissed_reason: Missing[
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
@@ -528,7 +529,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
@@ -576,7 +577,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
@@ -588,7 +589,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "dismissed"],
         dismissed_reason: Missing[
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
@@ -602,7 +603,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
@@ -649,7 +650,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-status-of-an-autofix-for-a-code-scanning-alert"""
 
@@ -682,7 +683,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-status-of-an-autofix-for-a-code-scanning-alert"""
 
@@ -715,7 +716,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#create-an-autofix-for-a-code-scanning-alert"""
 
@@ -748,7 +749,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#create-an-autofix-for-a-code-scanning-alert"""
 
@@ -782,7 +783,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
     ) -> Response[
         CodeScanningAutofixCommitsResponse, CodeScanningAutofixCommitsResponseType
@@ -796,7 +797,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         target_ref: Missing[str] = UNSET,
         message: Missing[str] = UNSET,
     ) -> Response[
@@ -809,7 +810,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
         **kwargs,
     ) -> Response[
@@ -862,7 +863,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
     ) -> Response[
         CodeScanningAutofixCommitsResponse, CodeScanningAutofixCommitsResponseType
@@ -876,7 +877,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         target_ref: Missing[str] = UNSET,
         message: Missing[str] = UNSET,
     ) -> Response[
@@ -889,7 +890,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
         **kwargs,
     ) -> Response[
@@ -945,7 +946,7 @@ class CodeScanningClient:
         per_page: Missing[int] = UNSET,
         ref: Missing[str] = UNSET,
         pr: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
@@ -989,7 +990,7 @@ class CodeScanningClient:
         per_page: Missing[int] = UNSET,
         ref: Missing[str] = UNSET,
         pr: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
@@ -1037,7 +1038,7 @@ class CodeScanningClient:
         sarif_id: Missing[str] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         sort: Missing[Literal["created"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
@@ -1090,7 +1091,7 @@ class CodeScanningClient:
         sarif_id: Missing[str] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         sort: Missing[Literal["created"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
@@ -1135,7 +1136,7 @@ class CodeScanningClient:
         repo: str,
         analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
@@ -1167,7 +1168,7 @@ class CodeScanningClient:
         repo: str,
         analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
@@ -1200,7 +1201,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         confirm_delete: Missing[Union[str, None]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
@@ -1239,7 +1240,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         confirm_delete: Missing[Union[str, None]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
@@ -1276,7 +1277,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
     ]:
@@ -1309,7 +1310,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
     ]:
@@ -1343,7 +1344,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
@@ -1375,7 +1376,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
@@ -1407,7 +1408,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#delete-a-codeql-database"""
 
@@ -1437,7 +1438,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#delete-a-codeql-database"""
 
@@ -1467,7 +1468,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
@@ -1482,7 +1483,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1499,7 +1500,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1516,7 +1517,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1531,7 +1532,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
@@ -1593,7 +1594,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
@@ -1608,7 +1609,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1625,7 +1626,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1642,7 +1643,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1657,7 +1658,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
@@ -1719,7 +1720,7 @@ class CodeScanningClient:
         repo: str,
         codeql_variant_analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
@@ -1750,7 +1751,7 @@ class CodeScanningClient:
         repo: str,
         codeql_variant_analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
@@ -1783,7 +1784,7 @@ class CodeScanningClient:
         repo_owner: str,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
     ]:
@@ -1818,7 +1819,7 @@ class CodeScanningClient:
         repo_owner: str,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
     ]:
@@ -1850,7 +1851,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
@@ -1881,7 +1882,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
@@ -1913,7 +1914,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1924,7 +1925,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Missing[Literal["configured", "not-configured"]] = UNSET,
         runner_type: Missing[Literal["standard", "labeled"]] = UNSET,
         runner_label: Missing[Union[str, None]] = UNSET,
@@ -1951,7 +1952,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1997,7 +1998,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2008,7 +2009,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Missing[Literal["configured", "not-configured"]] = UNSET,
         runner_type: Missing[Literal["standard", "labeled"]] = UNSET,
         runner_label: Missing[Union[str, None]] = UNSET,
@@ -2035,7 +2036,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2081,7 +2082,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
@@ -2092,7 +2093,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_sha: str,
         ref: str,
         sarif: str,
@@ -2107,7 +2108,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
@@ -2152,7 +2153,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
@@ -2163,7 +2164,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_sha: str,
         ref: str,
         sarif: str,
@@ -2178,7 +2179,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
@@ -2223,7 +2224,7 @@ class CodeScanningClient:
         repo: str,
         sarif_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 
@@ -2254,7 +2255,7 @@ class CodeScanningClient:
         repo: str,
         sarif_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/code_security.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/code_security.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -84,7 +85,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-code-security-configurations-for-an-enterprise"""
 
@@ -119,7 +120,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-code-security-configurations-for-an-enterprise"""
 
@@ -152,7 +153,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -162,7 +163,7 @@ class CodeSecurityClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -203,7 +204,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType
         ] = UNSET,
@@ -250,7 +251,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -260,7 +261,7 @@ class CodeSecurityClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -301,7 +302,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType
         ] = UNSET,
@@ -347,7 +348,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -371,7 +372,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -396,7 +397,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#retrieve-a-code-security-configuration-of-an-enterprise"""
 
@@ -424,7 +425,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#retrieve-a-code-security-configuration-of-an-enterprise"""
 
@@ -452,7 +453,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#delete-a-code-security-configuration-for-an-enterprise"""
 
@@ -481,7 +482,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#delete-a-code-security-configuration-for-an-enterprise"""
 
@@ -511,7 +512,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -522,7 +523,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -564,7 +565,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -615,7 +616,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -626,7 +627,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -668,7 +669,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -719,7 +720,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -733,7 +734,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal["all", "all_without_configurations"],
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -745,7 +746,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -797,7 +798,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -811,7 +812,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal["all", "all_without_configurations"],
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -823,7 +824,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -875,7 +876,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -889,7 +890,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -903,7 +904,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -954,7 +955,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -968,7 +969,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -982,7 +983,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -1036,7 +1037,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -1077,7 +1078,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -1117,7 +1118,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
@@ -1154,7 +1155,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
@@ -1188,7 +1189,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1198,7 +1199,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1245,7 +1246,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
@@ -1282,7 +1283,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1292,7 +1293,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1339,7 +1340,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
@@ -1375,7 +1376,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -1403,7 +1404,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -1432,7 +1433,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType,
     ) -> Response: ...
 
@@ -1442,7 +1443,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: Missing[list[int]] = UNSET,
     ) -> Response: ...
 
@@ -1450,7 +1451,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1494,7 +1495,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType,
     ) -> Response: ...
 
@@ -1504,7 +1505,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: Missing[list[int]] = UNSET,
     ) -> Response: ...
 
@@ -1512,7 +1513,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1556,7 +1557,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-a-code-security-configuration"""
 
@@ -1582,7 +1583,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#get-a-code-security-configuration"""
 
@@ -1608,7 +1609,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#delete-a-code-security-configuration"""
 
@@ -1635,7 +1636,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/code-security/configurations#delete-a-code-security-configuration"""
 
@@ -1663,7 +1664,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1674,7 +1675,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1722,7 +1723,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -1764,7 +1765,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1775,7 +1776,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1823,7 +1824,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -1865,7 +1866,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -1879,7 +1880,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal[
             "all",
             "all_without_configurations",
@@ -1898,7 +1899,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -1943,7 +1944,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -1957,7 +1958,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal[
             "all",
             "all_without_configurations",
@@ -1976,7 +1977,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -2021,7 +2022,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -2035,7 +2036,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -2049,7 +2050,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -2099,7 +2100,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -2113,7 +2114,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -2127,7 +2128,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -2180,7 +2181,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -2223,7 +2224,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -2262,7 +2263,7 @@ class CodeSecurityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeSecurityConfigurationForRepository,
         CodeSecurityConfigurationForRepositoryType,
@@ -2291,7 +2292,7 @@ class CodeSecurityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeSecurityConfigurationForRepository,
         CodeSecurityConfigurationForRepositoryType,

--- a/githubkit/versions/ghec_v2022_11_28/rest/codes_of_conduct.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/codes_of_conduct.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class CodesOfConductClient:
     def get_all_codes_of_conduct(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
@@ -60,7 +61,7 @@ class CodesOfConductClient:
     async def async_get_all_codes_of_conduct(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
@@ -81,7 +82,7 @@ class CodesOfConductClient:
         self,
         key: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 
@@ -105,7 +106,7 @@ class CodesOfConductClient:
         self,
         key: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/codespaces.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/codespaces.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -116,7 +117,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
@@ -151,7 +152,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
@@ -185,7 +186,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessPutBodyType,
     ) -> Response: ...
 
@@ -195,7 +196,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal[
             "disabled",
             "selected_members",
@@ -209,7 +210,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -247,7 +248,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessPutBodyType,
     ) -> Response: ...
 
@@ -257,7 +258,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal[
             "disabled",
             "selected_members",
@@ -271,7 +272,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -309,7 +310,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
     ) -> Response: ...
 
@@ -319,7 +320,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -327,7 +328,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -371,7 +372,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
     ) -> Response: ...
 
@@ -381,7 +382,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -389,7 +390,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -433,7 +434,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
     ) -> Response: ...
 
@@ -443,7 +444,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -451,7 +452,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -495,7 +496,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
     ) -> Response: ...
 
@@ -505,7 +506,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -513,7 +514,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -558,7 +559,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsGetResponse200,
         OrgsOrgCodespacesSecretsGetResponse200Type,
@@ -590,7 +591,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsGetResponse200,
         OrgsOrgCodespacesSecretsGetResponse200Type,
@@ -620,7 +621,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
@@ -641,7 +642,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
@@ -663,7 +664,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-secret"""
 
@@ -685,7 +686,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#get-an-organization-secret"""
 
@@ -708,7 +709,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -719,7 +720,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -731,7 +732,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -775,7 +776,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -786,7 +787,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -798,7 +799,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -841,7 +842,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#delete-an-organization-secret"""
 
@@ -865,7 +866,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#delete-an-organization-secret"""
 
@@ -891,7 +892,7 @@ class CodespacesClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -930,7 +931,7 @@ class CodespacesClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -968,7 +969,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -979,7 +980,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -988,7 +989,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -1032,7 +1033,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1043,7 +1044,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1052,7 +1053,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -1096,7 +1097,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -1124,7 +1125,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -1152,7 +1153,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -1180,7 +1181,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organization-secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -1209,7 +1210,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgMembersUsernameCodespacesGetResponse200,
         OrgsOrgMembersUsernameCodespacesGetResponse200Type,
@@ -1248,7 +1249,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgMembersUsernameCodespacesGetResponse200,
         OrgsOrgMembersUsernameCodespacesGetResponse200Type,
@@ -1286,7 +1287,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1321,7 +1322,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1356,7 +1357,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
@@ -1385,7 +1386,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
@@ -1415,7 +1416,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesGetResponse200,
         ReposOwnerRepoCodespacesGetResponse200Type,
@@ -1454,7 +1455,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesGetResponse200,
         ReposOwnerRepoCodespacesGetResponse200Type,
@@ -1492,7 +1493,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -1503,7 +1504,7 @@ class CodespacesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -1524,7 +1525,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -1575,7 +1576,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -1586,7 +1587,7 @@ class CodespacesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -1607,7 +1608,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -1659,7 +1660,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesDevcontainersGetResponse200,
         ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
@@ -1702,7 +1703,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesDevcontainersGetResponse200,
         ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
@@ -1746,7 +1747,7 @@ class CodespacesClient:
         location: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesMachinesGetResponse200,
         ReposOwnerRepoCodespacesMachinesGetResponse200Type,
@@ -1787,7 +1788,7 @@ class CodespacesClient:
         location: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesMachinesGetResponse200,
         ReposOwnerRepoCodespacesMachinesGetResponse200Type,
@@ -1827,7 +1828,7 @@ class CodespacesClient:
         *,
         ref: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesNewGetResponse200,
         ReposOwnerRepoCodespacesNewGetResponse200Type,
@@ -1865,7 +1866,7 @@ class CodespacesClient:
         *,
         ref: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesNewGetResponse200,
         ReposOwnerRepoCodespacesNewGetResponse200Type,
@@ -1903,7 +1904,7 @@ class CodespacesClient:
         *,
         ref: str,
         devcontainer_path: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodespacesPermissionsCheckForDevcontainer,
         CodespacesPermissionsCheckForDevcontainerType,
@@ -1948,7 +1949,7 @@ class CodespacesClient:
         *,
         ref: str,
         devcontainer_path: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodespacesPermissionsCheckForDevcontainer,
         CodespacesPermissionsCheckForDevcontainerType,
@@ -1993,7 +1994,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesSecretsGetResponse200,
         ReposOwnerRepoCodespacesSecretsGetResponse200Type,
@@ -2026,7 +2027,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesSecretsGetResponse200,
         ReposOwnerRepoCodespacesSecretsGetResponse200Type,
@@ -2057,7 +2058,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
@@ -2079,7 +2080,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
@@ -2102,7 +2103,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-secret"""
 
@@ -2125,7 +2126,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#get-a-repository-secret"""
 
@@ -2149,7 +2150,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2161,7 +2162,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -2172,7 +2173,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2213,7 +2214,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2225,7 +2226,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -2236,7 +2237,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2276,7 +2277,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#delete-a-repository-secret"""
 
@@ -2296,7 +2297,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/repository-secrets#delete-a-repository-secret"""
 
@@ -2317,7 +2318,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2329,7 +2330,7 @@ class CodespacesClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         location: Missing[str] = UNSET,
         geo: Missing[
             Literal["EuropeWest", "SoutheastAsia", "UsEast", "UsWest"]
@@ -2350,7 +2351,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
@@ -2403,7 +2404,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2415,7 +2416,7 @@ class CodespacesClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         location: Missing[str] = UNSET,
         geo: Missing[
             Literal["EuropeWest", "SoutheastAsia", "UsEast", "UsWest"]
@@ -2436,7 +2437,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
@@ -2488,7 +2489,7 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
@@ -2524,7 +2525,7 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
@@ -2558,7 +2559,7 @@ class CodespacesClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2567,7 +2568,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_id: int,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
@@ -2589,7 +2590,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pull_request: UserCodespacesPostBodyOneof1PropPullRequestType,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -2604,7 +2605,7 @@ class CodespacesClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
@@ -2655,7 +2656,7 @@ class CodespacesClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2664,7 +2665,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_id: int,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
@@ -2686,7 +2687,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pull_request: UserCodespacesPostBodyOneof1PropPullRequestType,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -2701,7 +2702,7 @@ class CodespacesClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
@@ -2753,7 +2754,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
     ]:
@@ -2783,7 +2784,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
     ]:
@@ -2811,7 +2812,7 @@ class CodespacesClient:
     def get_public_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
@@ -2831,7 +2832,7 @@ class CodespacesClient:
     async def async_get_public_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
@@ -2852,7 +2853,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
@@ -2873,7 +2874,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
@@ -2895,7 +2896,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2905,7 +2906,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
@@ -2915,7 +2916,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2958,7 +2959,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2968,7 +2969,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
@@ -2978,7 +2979,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3020,7 +3021,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#delete-a-secret-for-the-authenticated-user"""
 
@@ -3038,7 +3039,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#delete-a-secret-for-the-authenticated-user"""
 
@@ -3056,7 +3057,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3089,7 +3090,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3123,7 +3124,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3133,7 +3134,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3141,7 +3142,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3185,7 +3186,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3195,7 +3196,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3203,7 +3204,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3247,7 +3248,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#add-a-selected-repository-to-a-user-secret"""
 
@@ -3274,7 +3275,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#add-a-selected-repository-to-a-user-secret"""
 
@@ -3301,7 +3302,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#remove-a-selected-repository-from-a-user-secret"""
 
@@ -3328,7 +3329,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/secrets#remove-a-selected-repository-from-a-user-secret"""
 
@@ -3354,7 +3355,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
@@ -3381,7 +3382,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
@@ -3408,7 +3409,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -3441,7 +3442,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -3475,7 +3476,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -3485,7 +3486,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
@@ -3495,7 +3496,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -3534,7 +3535,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -3544,7 +3545,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
@@ -3554,7 +3555,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -3592,7 +3593,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
@@ -3620,7 +3621,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
@@ -3649,7 +3650,7 @@ class CodespacesClient:
         codespace_name: str,
         export_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
@@ -3674,7 +3675,7 @@ class CodespacesClient:
         codespace_name: str,
         export_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
@@ -3698,7 +3699,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesCodespaceNameMachinesGetResponse200,
         UserCodespacesCodespaceNameMachinesGetResponse200Type,
@@ -3731,7 +3732,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesCodespaceNameMachinesGetResponse200,
         UserCodespacesCodespaceNameMachinesGetResponse200Type,
@@ -3765,7 +3766,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
@@ -3775,7 +3776,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
@@ -3784,7 +3785,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
@@ -3831,7 +3832,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
@@ -3841,7 +3842,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
@@ -3850,7 +3851,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
@@ -3896,7 +3897,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
@@ -3926,7 +3927,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
@@ -3956,7 +3957,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 
@@ -3983,7 +3984,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/copilot.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/copilot.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -75,7 +76,7 @@ class CopilotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
         EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
@@ -116,7 +117,7 @@ class CopilotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseCopilotBillingSeatsGetResponse200,
         EnterprisesEnterpriseCopilotBillingSeatsGetResponse200Type,
@@ -159,7 +160,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise"""
 
@@ -198,7 +199,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise"""
 
@@ -237,7 +238,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-enterprise-members"""
 
@@ -276,7 +277,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-enterprise-members"""
 
@@ -316,7 +317,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise-team"""
 
@@ -356,7 +357,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-enterprise-team"""
 
@@ -396,7 +397,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-an-enterprise-team"""
 
@@ -436,7 +437,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-an-enterprise-team"""
 
@@ -471,7 +472,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
@@ -498,7 +499,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
@@ -527,7 +528,7 @@ class CopilotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCopilotBillingSeatsGetResponse200,
         OrgsOrgCopilotBillingSeatsGetResponse200Type,
@@ -565,7 +566,7 @@ class CopilotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCopilotBillingSeatsGetResponse200,
         OrgsOrgCopilotBillingSeatsGetResponse200Type,
@@ -602,7 +603,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -615,7 +616,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -626,7 +627,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -675,7 +676,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -688,7 +689,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -699,7 +700,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -748,7 +749,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -761,7 +762,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -772,7 +773,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -821,7 +822,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -834,7 +835,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -845,7 +846,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -894,7 +895,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -907,7 +908,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -918,7 +919,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -967,7 +968,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -980,7 +981,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -991,7 +992,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1040,7 +1041,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -1053,7 +1054,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -1064,7 +1065,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1113,7 +1114,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -1126,7 +1127,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -1137,7 +1138,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1189,7 +1190,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
@@ -1228,7 +1229,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
@@ -1267,7 +1268,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
@@ -1306,7 +1307,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
@@ -1342,7 +1343,7 @@ class CopilotClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
@@ -1370,7 +1371,7 @@ class CopilotClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
@@ -1402,7 +1403,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
@@ -1442,7 +1443,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
@@ -1482,7 +1483,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 
@@ -1522,7 +1523,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/dependabot.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/dependabot.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -85,7 +86,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -145,7 +146,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -205,7 +206,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -266,7 +267,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -317,7 +318,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsGetResponse200,
         OrgsOrgDependabotSecretsGetResponse200Type,
@@ -349,7 +350,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsGetResponse200,
         OrgsOrgDependabotSecretsGetResponse200Type,
@@ -379,7 +380,7 @@ class DependabotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-public-key"""
 
@@ -400,7 +401,7 @@ class DependabotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-public-key"""
 
@@ -422,7 +423,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-secret"""
 
@@ -444,7 +445,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-an-organization-secret"""
 
@@ -467,7 +468,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -478,7 +479,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -490,7 +491,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -525,7 +526,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -536,7 +537,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -548,7 +549,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -582,7 +583,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#delete-an-organization-secret"""
 
@@ -601,7 +602,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#delete-an-organization-secret"""
 
@@ -622,7 +623,7 @@ class DependabotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
@@ -657,7 +658,7 @@ class DependabotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
@@ -691,7 +692,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -702,7 +703,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -711,7 +712,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -749,7 +750,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -760,7 +761,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -769,7 +770,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -807,7 +808,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -830,7 +831,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -853,7 +854,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -876,7 +877,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -912,7 +913,7 @@ class DependabotClient:
         after: Missing[str] = UNSET,
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
@@ -972,7 +973,7 @@ class DependabotClient:
         after: Missing[str] = UNSET,
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
@@ -1019,7 +1020,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#get-a-dependabot-alert"""
 
@@ -1046,7 +1047,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/alerts#get-a-dependabot-alert"""
 
@@ -1074,7 +1075,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
     ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
@@ -1086,7 +1087,7 @@ class DependabotClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["dismissed", "open"],
         dismissed_reason: Missing[
             Literal[
@@ -1106,7 +1107,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[DependabotAlert, DependabotAlertType]:
@@ -1156,7 +1157,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
     ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
@@ -1168,7 +1169,7 @@ class DependabotClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["dismissed", "open"],
         dismissed_reason: Missing[
             Literal[
@@ -1188,7 +1189,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[DependabotAlert, DependabotAlertType]:
@@ -1238,7 +1239,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoDependabotSecretsGetResponse200,
         ReposOwnerRepoDependabotSecretsGetResponse200Type,
@@ -1271,7 +1272,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoDependabotSecretsGetResponse200,
         ReposOwnerRepoDependabotSecretsGetResponse200Type,
@@ -1302,7 +1303,7 @@ class DependabotClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-public-key"""
 
@@ -1324,7 +1325,7 @@ class DependabotClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-public-key"""
 
@@ -1347,7 +1348,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-secret"""
 
@@ -1370,7 +1371,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#get-a-repository-secret"""
 
@@ -1394,7 +1395,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1406,7 +1407,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -1417,7 +1418,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1458,7 +1459,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1470,7 +1471,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -1481,7 +1482,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1521,7 +1522,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#delete-a-repository-secret"""
 
@@ -1541,7 +1542,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependabot/secrets#delete-a-repository-secret"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/dependency_graph.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/dependency_graph.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -65,7 +66,7 @@ class DependencyGraphClient:
         basehead: str,
         *,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
@@ -98,7 +99,7 @@ class DependencyGraphClient:
         basehead: str,
         *,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
@@ -129,7 +130,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
@@ -155,7 +156,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
@@ -182,7 +183,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: SnapshotType,
     ) -> Response[
         ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
@@ -196,7 +197,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         version: int,
         job: SnapshotPropJobType,
         sha: str,
@@ -215,7 +216,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -256,7 +257,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: SnapshotType,
     ) -> Response[
         ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
@@ -270,7 +271,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         version: int,
         job: SnapshotPropJobType,
         sha: str,
@@ -289,7 +290,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
     ) -> Response[

--- a/githubkit/versions/ghec_v2022_11_28/rest/emojis.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/emojis.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class EmojisClient:
     def get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/emojis/emojis#get-emojis"""
 
@@ -60,7 +61,7 @@ class EmojisClient:
     async def async_get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/emojis/emojis#get-emojis"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/enterprise_admin.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/enterprise_admin.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -133,7 +134,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsEnterprisePermissions, ActionsEnterprisePermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-enterprise"""
 
@@ -154,7 +155,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsEnterprisePermissions, ActionsEnterprisePermissionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-github-actions-permissions-for-an-enterprise"""
 
@@ -176,7 +177,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -186,7 +187,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled_organizations: Literal["all", "none", "selected"],
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -195,7 +196,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -230,7 +231,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -240,7 +241,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled_organizations: Literal["all", "none", "selected"],
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -249,7 +250,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -285,7 +286,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200,
         EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200Type,
@@ -319,7 +320,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200,
         EnterprisesEnterpriseActionsPermissionsOrganizationsGetResponse200Type,
@@ -352,7 +353,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsPermissionsOrganizationsPutBodyType,
     ) -> Response: ...
 
@@ -362,7 +363,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_organization_ids: list[int],
     ) -> Response: ...
 
@@ -370,7 +371,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsPermissionsOrganizationsPutBodyType
         ] = UNSET,
@@ -407,7 +408,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsPermissionsOrganizationsPutBodyType,
     ) -> Response: ...
 
@@ -417,7 +418,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_organization_ids: list[int],
     ) -> Response: ...
 
@@ -425,7 +426,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsPermissionsOrganizationsPutBodyType
         ] = UNSET,
@@ -462,7 +463,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#enable-a-selected-organization-for-github-actions-in-an-enterprise"""
 
@@ -481,7 +482,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#enable-a-selected-organization-for-github-actions-in-an-enterprise"""
 
@@ -500,7 +501,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#disable-a-selected-organization-for-github-actions-in-an-enterprise"""
 
@@ -519,7 +520,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#disable-a-selected-organization-for-github-actions-in-an-enterprise"""
 
@@ -537,7 +538,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-enterprise"""
 
@@ -558,7 +559,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-enterprise"""
 
@@ -580,7 +581,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: SelectedActionsType,
     ) -> Response: ...
 
@@ -590,7 +591,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -600,7 +601,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -633,7 +634,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: SelectedActionsType,
     ) -> Response: ...
 
@@ -643,7 +644,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -653,7 +654,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -688,7 +689,7 @@ class EnterpriseAdminClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         visible_to_organization: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnerGroupsGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsGetResponse200Type,
@@ -722,7 +723,7 @@ class EnterpriseAdminClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         visible_to_organization: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnerGroupsGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsGetResponse200Type,
@@ -754,7 +755,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsPostBodyType,
     ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
@@ -764,7 +765,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all"]] = UNSET,
         selected_organization_ids: Missing[list[int]] = UNSET,
@@ -778,7 +779,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
@@ -817,7 +818,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsPostBodyType,
     ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]: ...
 
@@ -827,7 +828,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all"]] = UNSET,
         selected_organization_ids: Missing[list[int]] = UNSET,
@@ -841,7 +842,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
@@ -880,7 +881,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-enterprise"""
 
@@ -902,7 +903,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RunnerGroupsEnterprise, RunnerGroupsEnterpriseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-enterprise"""
 
@@ -924,7 +925,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-enterprise"""
 
@@ -943,7 +944,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-enterprise"""
 
@@ -963,7 +964,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
@@ -976,7 +977,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         visibility: Missing[Literal["selected", "all"]] = UNSET,
         allows_public_repositories: Missing[bool] = UNSET,
@@ -989,7 +990,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
@@ -1031,7 +1032,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
@@ -1044,7 +1045,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         visibility: Missing[Literal["selected", "all"]] = UNSET,
         allows_public_repositories: Missing[bool] = UNSET,
@@ -1057,7 +1058,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdPatchBodyType
         ] = UNSET,
@@ -1100,7 +1101,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200Type,
@@ -1135,7 +1136,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsGetResponse200Type,
@@ -1169,7 +1170,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsPutBodyType,
     ) -> Response: ...
 
@@ -1180,7 +1181,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_organization_ids: list[int],
     ) -> Response: ...
 
@@ -1189,7 +1190,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsPutBodyType
         ] = UNSET,
@@ -1230,7 +1231,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsPutBodyType,
     ) -> Response: ...
 
@@ -1241,7 +1242,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_organization_ids: list[int],
     ) -> Response: ...
 
@@ -1250,7 +1251,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdOrganizationsPutBodyType
         ] = UNSET,
@@ -1291,7 +1292,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-organization-access-to-a-self-hosted-runner-group-in-an-enterprise"""
 
@@ -1311,7 +1312,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-organization-access-to-a-self-hosted-runner-group-in-an-enterprise"""
 
@@ -1331,7 +1332,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-organization-access-to-a-self-hosted-runner-group-in-an-enterprise"""
 
@@ -1351,7 +1352,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         org_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-organization-access-to-a-self-hosted-runner-group-in-an-enterprise"""
 
@@ -1372,7 +1373,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
@@ -1409,7 +1410,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
@@ -1445,7 +1446,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
     ) -> Response: ...
 
@@ -1456,7 +1457,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         runners: list[int],
     ) -> Response: ...
 
@@ -1465,7 +1466,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType
         ] = UNSET,
@@ -1508,7 +1509,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
     ) -> Response: ...
 
@@ -1519,7 +1520,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         runners: list[int],
     ) -> Response: ...
 
@@ -1528,7 +1529,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType
         ] = UNSET,
@@ -1571,7 +1572,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-enterprise"""
 
@@ -1591,7 +1592,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-enterprise"""
 
@@ -1611,7 +1612,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-enterprise"""
 
@@ -1631,7 +1632,7 @@ class EnterpriseAdminClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-enterprise"""
 
@@ -1652,7 +1653,7 @@ class EnterpriseAdminClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGetResponse200,
         EnterprisesEnterpriseActionsRunnersGetResponse200Type,
@@ -1686,7 +1687,7 @@ class EnterpriseAdminClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersGetResponse200,
         EnterprisesEnterpriseActionsRunnersGetResponse200Type,
@@ -1717,7 +1718,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-enterprise"""
 
@@ -1738,7 +1739,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#list-runner-applications-for-an-enterprise"""
 
@@ -1759,7 +1760,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-enterprise"""
 
@@ -1780,7 +1781,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-registration-token-for-an-enterprise"""
 
@@ -1801,7 +1802,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-enterprise"""
 
@@ -1822,7 +1823,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#create-a-remove-token-for-an-enterprise"""
 
@@ -1844,7 +1845,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-enterprise"""
 
@@ -1866,7 +1867,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-enterprise"""
 
@@ -1888,7 +1889,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-enterprise"""
 
@@ -1907,7 +1908,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-enterprise"""
 
@@ -1926,7 +1927,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -1957,7 +1958,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -1989,7 +1990,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2003,7 +2004,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2015,7 +2016,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType
         ] = UNSET,
@@ -2066,7 +2067,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2080,7 +2081,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2092,7 +2093,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPutBodyType
         ] = UNSET,
@@ -2143,7 +2144,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2157,7 +2158,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2169,7 +2170,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType
         ] = UNSET,
@@ -2220,7 +2221,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2234,7 +2235,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2246,7 +2247,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseActionsRunnersRunnerIdLabelsPostBodyType
         ] = UNSET,
@@ -2296,7 +2297,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -2329,7 +2330,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -2363,7 +2364,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2397,7 +2398,7 @@ class EnterpriseAdminClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200,
         EnterprisesEnterpriseActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2429,7 +2430,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#get-announcement-banner-for-enterprise"""
 
@@ -2450,7 +2451,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#get-announcement-banner-for-enterprise"""
 
@@ -2471,7 +2472,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#remove-announcement-banner-from-enterprise"""
 
@@ -2489,7 +2490,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/enterprises#remove-announcement-banner-from-enterprise"""
 
@@ -2508,7 +2509,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AnnouncementType,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
@@ -2518,7 +2519,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
@@ -2527,7 +2528,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
@@ -2561,7 +2562,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AnnouncementType,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
@@ -2571,7 +2572,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
@@ -2580,7 +2581,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
@@ -2620,7 +2621,7 @@ class EnterpriseAdminClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-for-an-enterprise"""
 
@@ -2659,7 +2660,7 @@ class EnterpriseAdminClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-for-an-enterprise"""
 
@@ -2691,7 +2692,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuditLogStreamKey, AuditLogStreamKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-stream-key-for-encrypting-secrets"""
 
@@ -2712,7 +2713,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuditLogStreamKey, AuditLogStreamKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#get-the-audit-log-stream-key-for-encrypting-secrets"""
 
@@ -2733,7 +2734,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[GetAuditLogStreamConfigsItems], list[GetAuditLogStreamConfigsItemsType]
     ]:
@@ -2756,7 +2757,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[GetAuditLogStreamConfigsItems], list[GetAuditLogStreamConfigsItemsType]
     ]:
@@ -2780,7 +2781,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseAuditLogStreamsPostBodyType,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]: ...
 
@@ -2790,7 +2791,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         stream_type: Literal[
             "Azure Blob Storage",
@@ -2816,7 +2817,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseAuditLogStreamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]:
@@ -2855,7 +2856,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseAuditLogStreamsPostBodyType,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]: ...
 
@@ -2865,7 +2866,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         stream_type: Literal[
             "Azure Blob Storage",
@@ -2891,7 +2892,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseAuditLogStreamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]:
@@ -2930,7 +2931,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#list-one-audit-log-streaming-configuration-via-a-stream-id"""
 
@@ -2952,7 +2953,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#list-one-audit-log-streaming-configuration-via-a-stream-id"""
 
@@ -2975,7 +2976,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseAuditLogStreamsStreamIdPutBodyType,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]: ...
 
@@ -2986,7 +2987,7 @@ class EnterpriseAdminClient:
         stream_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         stream_type: Literal[
             "Azure Blob Storage",
@@ -3013,7 +3014,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseAuditLogStreamsStreamIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]:
@@ -3057,7 +3058,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseAuditLogStreamsStreamIdPutBodyType,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]: ...
 
@@ -3068,7 +3069,7 @@ class EnterpriseAdminClient:
         stream_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         stream_type: Literal[
             "Azure Blob Storage",
@@ -3095,7 +3096,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseAuditLogStreamsStreamIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[GetAuditLogStreamConfig, GetAuditLogStreamConfigType]:
@@ -3138,7 +3139,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#delete-an-audit-log-streaming-configuration-for-an-enterprise"""
 
@@ -3157,7 +3158,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         stream_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/audit-log#delete-an-audit-log-streaming-configuration-for-an-enterprise"""
 
@@ -3175,7 +3176,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterpriseSecurityAnalysisSettings, EnterpriseSecurityAnalysisSettingsType
     ]:
@@ -3201,7 +3202,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         EnterpriseSecurityAnalysisSettings, EnterpriseSecurityAnalysisSettingsType
     ]:
@@ -3228,7 +3229,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityAndAnalysisPatchBodyType
         ] = UNSET,
@@ -3240,7 +3241,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         advanced_security_enabled_for_new_repositories: Missing[bool] = UNSET,
         advanced_security_enabled_new_user_namespace_repos: Missing[bool] = UNSET,
         dependabot_alerts_enabled_for_new_repositories: Missing[bool] = UNSET,
@@ -3258,7 +3259,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityAndAnalysisPatchBodyType
         ] = UNSET,
@@ -3301,7 +3302,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityAndAnalysisPatchBodyType
         ] = UNSET,
@@ -3313,7 +3314,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         advanced_security_enabled_for_new_repositories: Missing[bool] = UNSET,
         advanced_security_enabled_new_user_namespace_repos: Missing[bool] = UNSET,
         dependabot_alerts_enabled_for_new_repositories: Missing[bool] = UNSET,
@@ -3331,7 +3332,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityAndAnalysisPatchBodyType
         ] = UNSET,
@@ -3375,7 +3376,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetConsumedLicenses, GetConsumedLicensesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#list-enterprise-consumed-licenses"""
 
@@ -3404,7 +3405,7 @@ class EnterpriseAdminClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetConsumedLicenses, GetConsumedLicensesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#list-enterprise-consumed-licenses"""
 
@@ -3431,7 +3432,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetLicenseSyncStatus, GetLicenseSyncStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#get-a-license-sync-status"""
 
@@ -3452,7 +3453,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GetLicenseSyncStatus, GetLicenseSyncStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/license#get-a-license-sync-status"""
 
@@ -3473,7 +3474,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#get-custom-properties-for-an-enterprise"""
 
@@ -3498,7 +3499,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#get-custom-properties-for-an-enterprise"""
 
@@ -3524,7 +3525,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterprisePropertiesSchemaPatchBodyType,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -3534,7 +3535,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyType],
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -3542,7 +3543,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterprisePropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
@@ -3586,7 +3587,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterprisePropertiesSchemaPatchBodyType,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -3596,7 +3597,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyType],
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -3604,7 +3605,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterprisePropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
@@ -3648,7 +3649,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#get-a-custom-property-for-an-enterprise"""
 
@@ -3674,7 +3675,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#get-a-custom-property-for-an-enterprise"""
 
@@ -3701,7 +3702,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CustomPropertySetPayloadType,
     ) -> Response[CustomProperty, CustomPropertyType]: ...
 
@@ -3712,7 +3713,7 @@ class EnterpriseAdminClient:
         custom_property_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value_type: Literal["string", "single_select", "multi_select", "true_false"],
         required: Missing[bool] = UNSET,
         default_value: Missing[Union[str, list[str], None]] = UNSET,
@@ -3725,7 +3726,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CustomPropertySetPayloadType] = UNSET,
         **kwargs,
     ) -> Response[CustomProperty, CustomPropertyType]:
@@ -3764,7 +3765,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CustomPropertySetPayloadType,
     ) -> Response[CustomProperty, CustomPropertyType]: ...
 
@@ -3775,7 +3776,7 @@ class EnterpriseAdminClient:
         custom_property_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value_type: Literal["string", "single_select", "multi_select", "true_false"],
         required: Missing[bool] = UNSET,
         default_value: Missing[Union[str, list[str], None]] = UNSET,
@@ -3788,7 +3789,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CustomPropertySetPayloadType] = UNSET,
         **kwargs,
     ) -> Response[CustomProperty, CustomPropertyType]:
@@ -3826,7 +3827,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#remove-a-custom-property-for-an-enterprise"""
 
@@ -3851,7 +3852,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/custom-properties#remove-a-custom-property-for-an-enterprise"""
 
@@ -3884,7 +3885,7 @@ class EnterpriseAdminClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#enable-or-disable-a-security-feature"""
 
@@ -3916,7 +3917,7 @@ class EnterpriseAdminClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/code-security-and-analysis#enable-or-disable-a-security-feature"""
 
@@ -3943,7 +3944,7 @@ class EnterpriseAdminClient:
         excluded_attributes: Missing[str] = UNSET,
         start_index: Missing[int] = UNSET,
         count: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseGroupList, ScimEnterpriseGroupListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise"""
 
@@ -3981,7 +3982,7 @@ class EnterpriseAdminClient:
         excluded_attributes: Missing[str] = UNSET,
         start_index: Missing[int] = UNSET,
         count: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseGroupList, ScimEnterpriseGroupListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-provisioned-scim-groups-for-an-enterprise"""
 
@@ -4016,7 +4017,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GroupType,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
@@ -4026,7 +4027,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:Group"]],
         external_id: str,
         display_name: str,
@@ -4037,7 +4038,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
@@ -4076,7 +4077,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GroupType,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
@@ -4086,7 +4087,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:Group"]],
         external_id: str,
         display_name: str,
@@ -4097,7 +4098,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
@@ -4137,7 +4138,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         excluded_attributes: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group"""
 
@@ -4171,7 +4172,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         excluded_attributes: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-group"""
 
@@ -4205,7 +4206,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GroupType,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
@@ -4216,7 +4217,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:Group"]],
         external_id: str,
         display_name: str,
@@ -4228,7 +4229,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
@@ -4269,7 +4270,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GroupType,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]: ...
 
@@ -4280,7 +4281,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:Group"]],
         external_id: str,
         display_name: str,
@@ -4292,7 +4293,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GroupType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseGroupResponse, ScimEnterpriseGroupResponseType]:
@@ -4332,7 +4333,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#delete-a-scim-group-from-an-enterprise"""
 
@@ -4359,7 +4360,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#delete-a-scim-group-from-an-enterprise"""
 
@@ -4387,7 +4388,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PatchSchemaType,
     ) -> Response: ...
 
@@ -4398,7 +4399,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         operations: list[PatchSchemaPropOperationsItemsType],
         schemas: list[Literal["urn:ietf:params:scim:api:messages:2.0:PatchOp"]],
     ) -> Response: ...
@@ -4408,7 +4409,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PatchSchemaType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4448,7 +4449,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PatchSchemaType,
     ) -> Response: ...
 
@@ -4459,7 +4460,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         operations: list[PatchSchemaPropOperationsItemsType],
         schemas: list[Literal["urn:ietf:params:scim:api:messages:2.0:PatchOp"]],
     ) -> Response: ...
@@ -4469,7 +4470,7 @@ class EnterpriseAdminClient:
         scim_group_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PatchSchemaType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4510,7 +4511,7 @@ class EnterpriseAdminClient:
         filter_: Missing[str] = UNSET,
         start_index: Missing[int] = UNSET,
         count: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseUserList, ScimEnterpriseUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise"""
 
@@ -4546,7 +4547,7 @@ class EnterpriseAdminClient:
         filter_: Missing[str] = UNSET,
         start_index: Missing[int] = UNSET,
         count: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseUserList, ScimEnterpriseUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#list-scim-provisioned-identities-for-an-enterprise"""
 
@@ -4580,7 +4581,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserType,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
@@ -4590,7 +4591,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:User"]],
         external_id: str,
         active: bool,
@@ -4605,7 +4606,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
@@ -4644,7 +4645,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserType,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
@@ -4654,7 +4655,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:User"]],
         external_id: str,
         active: bool,
@@ -4669,7 +4670,7 @@ class EnterpriseAdminClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
@@ -4708,7 +4709,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user"""
 
@@ -4736,7 +4737,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#get-scim-provisioning-information-for-an-enterprise-user"""
 
@@ -4765,7 +4766,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserType,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
@@ -4776,7 +4777,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:User"]],
         external_id: str,
         active: bool,
@@ -4792,7 +4793,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
@@ -4833,7 +4834,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserType,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
@@ -4844,7 +4845,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: list[Literal["urn:ietf:params:scim:schemas:core:2.0:User"]],
         external_id: str,
         active: bool,
@@ -4860,7 +4861,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
@@ -4900,7 +4901,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#delete-a-scim-user-from-an-enterprise"""
 
@@ -4927,7 +4928,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/scim#delete-a-scim-user-from-an-enterprise"""
 
@@ -4955,7 +4956,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PatchSchemaType,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
@@ -4966,7 +4967,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         operations: list[PatchSchemaPropOperationsItemsType],
         schemas: list[Literal["urn:ietf:params:scim:api:messages:2.0:PatchOp"]],
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
@@ -4976,7 +4977,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PatchSchemaType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:
@@ -5022,7 +5023,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PatchSchemaType,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
 
@@ -5033,7 +5034,7 @@ class EnterpriseAdminClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         operations: list[PatchSchemaPropOperationsItemsType],
         schemas: list[Literal["urn:ietf:params:scim:api:messages:2.0:PatchOp"]],
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]: ...
@@ -5043,7 +5044,7 @@ class EnterpriseAdminClient:
         scim_user_id: str,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PatchSchemaType] = UNSET,
         **kwargs,
     ) -> Response[ScimEnterpriseUserResponse, ScimEnterpriseUserResponseType]:

--- a/githubkit/versions/ghec_v2022_11_28/rest/gists.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/gists.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -63,7 +64,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-the-authenticated-user"""
 
@@ -96,7 +97,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-the-authenticated-user"""
 
@@ -125,7 +126,7 @@ class GistsClient:
 
     @overload
     def create(
-        self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: GistsPostBodyType
     ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
@@ -133,7 +134,7 @@ class GistsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
@@ -142,7 +143,7 @@ class GistsClient:
     def create(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -178,7 +179,7 @@ class GistsClient:
 
     @overload
     async def async_create(
-        self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: GistsPostBodyType
     ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
@@ -186,7 +187,7 @@ class GistsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
@@ -195,7 +196,7 @@ class GistsClient:
     async def async_create(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -235,7 +236,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-public-gists"""
 
@@ -269,7 +270,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-public-gists"""
 
@@ -303,7 +304,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-starred-gists"""
 
@@ -337,7 +338,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-starred-gists"""
 
@@ -369,7 +370,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist"""
 
@@ -394,7 +395,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist"""
 
@@ -419,7 +420,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#delete-a-gist"""
 
@@ -443,7 +444,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#delete-a-gist"""
 
@@ -468,7 +469,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
     ) -> Response[GistSimple, GistSimpleType]: ...
 
@@ -478,7 +479,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
     ) -> Response[GistSimple, GistSimpleType]: ...
@@ -487,7 +488,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -532,7 +533,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
     ) -> Response[GistSimple, GistSimpleType]: ...
 
@@ -542,7 +543,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
     ) -> Response[GistSimple, GistSimpleType]: ...
@@ -551,7 +552,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -597,7 +598,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#list-gist-comments"""
 
@@ -630,7 +631,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#list-gist-comments"""
 
@@ -662,7 +663,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -672,7 +673,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -680,7 +681,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -718,7 +719,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -728,7 +729,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -736,7 +737,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -774,7 +775,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#get-a-gist-comment"""
 
@@ -800,7 +801,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#get-a-gist-comment"""
 
@@ -826,7 +827,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#delete-a-gist-comment"""
 
@@ -851,7 +852,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/comments#delete-a-gist-comment"""
 
@@ -877,7 +878,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -888,7 +889,7 @@ class GistsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -897,7 +898,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -939,7 +940,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -950,7 +951,7 @@ class GistsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -959,7 +960,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -1001,7 +1002,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-commits"""
 
@@ -1034,7 +1035,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-commits"""
 
@@ -1067,7 +1068,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-forks"""
 
@@ -1100,7 +1101,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gist-forks"""
 
@@ -1131,7 +1132,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#fork-a-gist"""
 
@@ -1157,7 +1158,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#fork-a-gist"""
 
@@ -1183,7 +1184,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#check-if-a-gist-is-starred"""
 
@@ -1207,7 +1208,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#check-if-a-gist-is-starred"""
 
@@ -1231,7 +1232,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#star-a-gist"""
 
@@ -1255,7 +1256,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#star-a-gist"""
 
@@ -1279,7 +1280,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#unstar-a-gist"""
 
@@ -1303,7 +1304,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#unstar-a-gist"""
 
@@ -1328,7 +1329,7 @@ class GistsClient:
         gist_id: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist-revision"""
 
@@ -1355,7 +1356,7 @@ class GistsClient:
         gist_id: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#get-a-gist-revision"""
 
@@ -1384,7 +1385,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-a-user"""
 
@@ -1418,7 +1419,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gists/gists#list-gists-for-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/git.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/git.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -68,7 +69,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
     ) -> Response[ShortBlob, ShortBlobType]: ...
 
@@ -79,7 +80,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
     ) -> Response[ShortBlob, ShortBlobType]: ...
@@ -89,7 +90,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ShortBlob, ShortBlobType]:
@@ -138,7 +139,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
     ) -> Response[ShortBlob, ShortBlobType]: ...
 
@@ -149,7 +150,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
     ) -> Response[ShortBlob, ShortBlobType]: ...
@@ -159,7 +160,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ShortBlob, ShortBlobType]:
@@ -208,7 +209,7 @@ class GitClient:
         repo: str,
         file_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/blobs#get-a-blob"""
 
@@ -237,7 +238,7 @@ class GitClient:
         repo: str,
         file_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/blobs#get-a-blob"""
 
@@ -266,7 +267,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
     ) -> Response[GitCommit, GitCommitType]: ...
 
@@ -277,7 +278,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         tree: str,
         parents: Missing[list[str]] = UNSET,
@@ -291,7 +292,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitCommit, GitCommitType]:
@@ -336,7 +337,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
     ) -> Response[GitCommit, GitCommitType]: ...
 
@@ -347,7 +348,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         tree: str,
         parents: Missing[list[str]] = UNSET,
@@ -361,7 +362,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitCommit, GitCommitType]:
@@ -406,7 +407,7 @@ class GitClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/commits#get-a-commit-object"""
 
@@ -433,7 +434,7 @@ class GitClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/commits#get-a-commit-object"""
 
@@ -460,7 +461,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#list-matching-references"""
 
@@ -486,7 +487,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#list-matching-references"""
 
@@ -512,7 +513,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#get-a-reference"""
 
@@ -539,7 +540,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#get-a-reference"""
 
@@ -566,7 +567,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -577,7 +578,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         sha: str,
     ) -> Response[GitRef, GitRefType]: ...
@@ -587,7 +588,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -631,7 +632,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -642,7 +643,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         sha: str,
     ) -> Response[GitRef, GitRefType]: ...
@@ -652,7 +653,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -696,7 +697,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#delete-a-reference"""
 
@@ -722,7 +723,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/refs#delete-a-reference"""
 
@@ -749,7 +750,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -761,7 +762,7 @@ class GitClient:
         ref: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
     ) -> Response[GitRef, GitRefType]: ...
@@ -772,7 +773,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -817,7 +818,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -829,7 +830,7 @@ class GitClient:
         ref: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
     ) -> Response[GitRef, GitRefType]: ...
@@ -840,7 +841,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -884,7 +885,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
     ) -> Response[GitTag, GitTagType]: ...
 
@@ -895,7 +896,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag: str,
         message: str,
         object_: str,
@@ -908,7 +909,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTag, GitTagType]:
@@ -952,7 +953,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
     ) -> Response[GitTag, GitTagType]: ...
 
@@ -963,7 +964,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag: str,
         message: str,
         object_: str,
@@ -976,7 +977,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTag, GitTagType]:
@@ -1020,7 +1021,7 @@ class GitClient:
         repo: str,
         tag_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/tags#get-a-tag"""
 
@@ -1047,7 +1048,7 @@ class GitClient:
         repo: str,
         tag_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/tags#get-a-tag"""
 
@@ -1074,7 +1075,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
     ) -> Response[GitTree, GitTreeType]: ...
 
@@ -1085,7 +1086,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
     ) -> Response[GitTree, GitTreeType]: ...
@@ -1095,7 +1096,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTree, GitTreeType]:
@@ -1141,7 +1142,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
     ) -> Response[GitTree, GitTreeType]: ...
 
@@ -1152,7 +1153,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
     ) -> Response[GitTree, GitTreeType]: ...
@@ -1162,7 +1163,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTree, GitTreeType]:
@@ -1209,7 +1210,7 @@ class GitClient:
         tree_sha: str,
         *,
         recursive: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/trees#get-a-tree"""
 
@@ -1243,7 +1244,7 @@ class GitClient:
         tree_sha: str,
         *,
         recursive: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/git/trees#get-a-tree"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/gitignore.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/gitignore.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class GitignoreClient:
     def get_all_templates(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-all-gitignore-templates"""
 
@@ -58,7 +59,7 @@ class GitignoreClient:
     async def async_get_all_templates(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-all-gitignore-templates"""
 
@@ -77,7 +78,7 @@ class GitignoreClient:
         self,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-a-gitignore-template"""
 
@@ -98,7 +99,7 @@ class GitignoreClient:
         self,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/gitignore/gitignore#get-a-gitignore-template"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/interactions.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/interactions.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -60,7 +61,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -94,7 +95,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -129,7 +130,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -139,7 +140,7 @@ class InteractionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -150,7 +151,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -187,7 +188,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -197,7 +198,7 @@ class InteractionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -208,7 +209,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -244,7 +245,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/orgs#remove-interaction-restrictions-for-an-organization"""
 
@@ -262,7 +263,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/orgs#remove-interaction-restrictions-for-an-organization"""
 
@@ -281,7 +282,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             InteractionLimitResponse,
@@ -320,7 +321,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             InteractionLimitResponse,
@@ -360,7 +361,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -371,7 +372,7 @@ class InteractionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -383,7 +384,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -419,7 +420,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -430,7 +431,7 @@ class InteractionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -442,7 +443,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -477,7 +478,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/repos#remove-interaction-restrictions-for-a-repository"""
 
@@ -497,7 +498,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/repos#remove-interaction-restrictions-for-a-repository"""
 
@@ -515,7 +516,7 @@ class InteractionsClient:
     def get_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -547,7 +548,7 @@ class InteractionsClient:
     async def async_get_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -578,7 +579,7 @@ class InteractionsClient:
 
     @overload
     def set_restrictions_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: InteractionLimitType
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
@@ -586,7 +587,7 @@ class InteractionsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -596,7 +597,7 @@ class InteractionsClient:
     def set_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -630,7 +631,7 @@ class InteractionsClient:
 
     @overload
     async def async_set_restrictions_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: InteractionLimitType
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
@@ -638,7 +639,7 @@ class InteractionsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -648,7 +649,7 @@ class InteractionsClient:
     async def async_set_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -683,7 +684,7 @@ class InteractionsClient:
     def remove_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/user#remove-interaction-restrictions-from-your-public-repositories"""
 
@@ -700,7 +701,7 @@ class InteractionsClient:
     async def async_remove_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/interactions/user#remove-interaction-restrictions-from-your-public-repositories"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/issues.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/issues.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Literal, Optional, overload
 from weakref import ref
 
@@ -149,7 +150,7 @@ class IssuesClient:
         pulls: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
@@ -203,7 +204,7 @@ class IssuesClient:
         pulls: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
@@ -254,7 +255,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
@@ -300,7 +301,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
@@ -339,7 +340,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#list-assignees"""
 
@@ -372,7 +373,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#list-assignees"""
 
@@ -404,7 +405,7 @@ class IssuesClient:
         repo: str,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#check-if-a-user-can-be-assigned"""
 
@@ -429,7 +430,7 @@ class IssuesClient:
         repo: str,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#check-if-a-user-can-be-assigned"""
 
@@ -464,7 +465,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-repository-issues"""
 
@@ -516,7 +517,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-repository-issues"""
 
@@ -558,7 +559,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -569,7 +570,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Union[str, int],
         body: Missing[str] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -585,7 +586,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -634,7 +635,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -645,7 +646,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Union[str, int],
         body: Missing[str] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -661,7 +662,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -714,7 +715,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments-for-a-repository"""
 
@@ -754,7 +755,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments-for-a-repository"""
 
@@ -790,7 +791,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#get-an-issue-comment"""
 
@@ -816,7 +817,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#get-an-issue-comment"""
 
@@ -842,7 +843,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#delete-an-issue-comment"""
 
@@ -862,7 +863,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#delete-an-issue-comment"""
 
@@ -883,7 +884,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -895,7 +896,7 @@ class IssuesClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -905,7 +906,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -950,7 +951,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -962,7 +963,7 @@ class IssuesClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -972,7 +973,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -1017,7 +1018,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#list-issue-events-for-a-repository"""
 
@@ -1050,7 +1051,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#list-issue-events-for-a-repository"""
 
@@ -1082,7 +1083,7 @@ class IssuesClient:
         repo: str,
         event_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#get-an-issue-event"""
 
@@ -1110,7 +1111,7 @@ class IssuesClient:
         repo: str,
         event_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/events#get-an-issue-event"""
 
@@ -1138,7 +1139,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#get-an-issue"""
 
@@ -1165,7 +1166,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#get-an-issue"""
 
@@ -1193,7 +1194,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1205,7 +1206,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[Union[str, int, None]] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -1231,7 +1232,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1280,7 +1281,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1292,7 +1293,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[Union[str, int, None]] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -1318,7 +1319,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1367,7 +1368,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1379,7 +1380,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1389,7 +1390,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1427,7 +1428,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1439,7 +1440,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1449,7 +1450,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1487,7 +1488,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1499,7 +1500,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1509,7 +1510,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1547,7 +1548,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1559,7 +1560,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1569,7 +1570,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1607,7 +1608,7 @@ class IssuesClient:
         issue_number: int,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#check-if-a-user-can-be-assigned-to-a-issue"""
 
@@ -1633,7 +1634,7 @@ class IssuesClient:
         issue_number: int,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/assignees#check-if-a-user-can-be-assigned-to-a-issue"""
 
@@ -1661,7 +1662,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments"""
 
@@ -1698,7 +1699,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/comments#list-issue-comments"""
 
@@ -1733,7 +1734,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1745,7 +1746,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1755,7 +1756,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -1804,7 +1805,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1816,7 +1817,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1826,7 +1827,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -1876,7 +1877,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -1986,7 +1987,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -2096,7 +2097,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-an-issue"""
 
@@ -2131,7 +2132,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-an-issue"""
 
@@ -2165,7 +2166,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2185,7 +2186,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2197,7 +2198,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2209,7 +2210,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2281,7 +2282,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2301,7 +2302,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2313,7 +2314,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2325,7 +2326,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2397,7 +2398,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2417,7 +2418,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2429,7 +2430,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2441,7 +2442,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2513,7 +2514,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2533,7 +2534,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2545,7 +2546,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2557,7 +2558,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2628,7 +2629,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#remove-all-labels-from-an-issue"""
 
@@ -2654,7 +2655,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#remove-all-labels-from-an-issue"""
 
@@ -2681,7 +2682,7 @@ class IssuesClient:
         issue_number: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#remove-a-label-from-an-issue"""
 
@@ -2709,7 +2710,7 @@ class IssuesClient:
         issue_number: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#remove-a-label-from-an-issue"""
 
@@ -2737,7 +2738,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2751,7 +2752,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_reason: Missing[
             Literal["off-topic", "too heated", "resolved", "spam"]
         ] = UNSET,
@@ -2763,7 +2764,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2814,7 +2815,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2828,7 +2829,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_reason: Missing[
             Literal["off-topic", "too heated", "resolved", "spam"]
         ] = UNSET,
@@ -2840,7 +2841,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2890,7 +2891,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#unlock-an-issue"""
 
@@ -2916,7 +2917,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#unlock-an-issue"""
 
@@ -2943,7 +2944,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -2955,7 +2956,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
     ) -> Response[Issue, IssueType]: ...
 
@@ -2965,7 +2966,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3011,7 +3012,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3023,7 +3024,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3033,7 +3034,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3080,7 +3081,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/sub-issues#list-sub-issues"""
 
@@ -3115,7 +3116,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/sub-issues#list-sub-issues"""
 
@@ -3149,7 +3150,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3161,7 +3162,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         replace_parent: Missing[bool] = UNSET,
     ) -> Response[Issue, IssueType]: ...
@@ -3172,7 +3173,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3221,7 +3222,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3233,7 +3234,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         replace_parent: Missing[bool] = UNSET,
     ) -> Response[Issue, IssueType]: ...
@@ -3244,7 +3245,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3293,7 +3294,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3305,7 +3306,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         after_id: Missing[int] = UNSET,
         before_id: Missing[int] = UNSET,
@@ -3317,7 +3318,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType
         ] = UNSET,
@@ -3369,7 +3370,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3381,7 +3382,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         after_id: Missing[int] = UNSET,
         before_id: Missing[int] = UNSET,
@@ -3393,7 +3394,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType
         ] = UNSET,
@@ -3446,7 +3447,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -3585,7 +3586,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -3723,7 +3724,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-a-repository"""
 
@@ -3756,7 +3757,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-a-repository"""
 
@@ -3788,7 +3789,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
     ) -> Response[Label, LabelType]: ...
 
@@ -3799,7 +3800,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -3810,7 +3811,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -3854,7 +3855,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
     ) -> Response[Label, LabelType]: ...
 
@@ -3865,7 +3866,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -3876,7 +3877,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -3920,7 +3921,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#get-a-label"""
 
@@ -3946,7 +3947,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#get-a-label"""
 
@@ -3972,7 +3973,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#delete-a-label"""
 
@@ -3992,7 +3993,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#delete-a-label"""
 
@@ -4013,7 +4014,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
     ) -> Response[Label, LabelType]: ...
 
@@ -4025,7 +4026,7 @@ class IssuesClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -4037,7 +4038,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -4073,7 +4074,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
     ) -> Response[Label, LabelType]: ...
 
@@ -4085,7 +4086,7 @@ class IssuesClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -4097,7 +4098,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -4136,7 +4137,7 @@ class IssuesClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#list-milestones"""
 
@@ -4175,7 +4176,7 @@ class IssuesClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#list-milestones"""
 
@@ -4210,7 +4211,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4221,7 +4222,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4233,7 +4234,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4277,7 +4278,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4288,7 +4289,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4300,7 +4301,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4344,7 +4345,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#get-a-milestone"""
 
@@ -4370,7 +4371,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#get-a-milestone"""
 
@@ -4396,7 +4397,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#delete-a-milestone"""
 
@@ -4421,7 +4422,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/milestones#delete-a-milestone"""
 
@@ -4447,7 +4448,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4459,7 +4460,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4472,7 +4473,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4510,7 +4511,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4522,7 +4523,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4535,7 +4536,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4574,7 +4575,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
@@ -4605,7 +4606,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
@@ -4641,7 +4642,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 
@@ -4686,7 +4687,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/licenses.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/licenses.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -46,7 +47,7 @@ class LicensesClient:
         featured: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-all-commonly-used-licenses"""
 
@@ -76,7 +77,7 @@ class LicensesClient:
         featured: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-all-commonly-used-licenses"""
 
@@ -104,7 +105,7 @@ class LicensesClient:
         self,
         license_: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-a-license"""
 
@@ -129,7 +130,7 @@ class LicensesClient:
         self,
         license_: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-a-license"""
 
@@ -156,7 +157,7 @@ class LicensesClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-the-license-for-a-repository"""
 
@@ -187,7 +188,7 @@ class LicensesClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/licenses/licenses#get-the-license-for-a-repository"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/markdown.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/markdown.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -46,7 +47,7 @@ class MarkdownClient:
 
     @overload
     def render(
-        self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: MarkdownPostBodyType
     ) -> Response[str, str]: ...
 
     @overload
@@ -54,7 +55,7 @@ class MarkdownClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
@@ -63,7 +64,7 @@ class MarkdownClient:
     def render(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[str, str]:
@@ -94,7 +95,7 @@ class MarkdownClient:
 
     @overload
     async def async_render(
-        self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: MarkdownPostBodyType
     ) -> Response[str, str]: ...
 
     @overload
@@ -102,7 +103,7 @@ class MarkdownClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
@@ -111,7 +112,7 @@ class MarkdownClient:
     async def async_render(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[str, str]:
@@ -143,7 +144,7 @@ class MarkdownClient:
     def render_raw(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: str,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""
@@ -169,7 +170,7 @@ class MarkdownClient:
     async def async_render_raw(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: str,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""

--- a/githubkit/versions/ghec_v2022_11_28/rest/meta.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/meta.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -45,7 +46,7 @@ class MetaClient:
     def root(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#github-api-root"""
 
@@ -65,7 +66,7 @@ class MetaClient:
     async def async_root(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#github-api-root"""
 
@@ -85,7 +86,7 @@ class MetaClient:
     def get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-apiname-meta-information"""
 
@@ -105,7 +106,7 @@ class MetaClient:
     async def async_get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-apiname-meta-information"""
 
@@ -126,7 +127,7 @@ class MetaClient:
         self,
         *,
         s: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-octocat"""
 
@@ -150,7 +151,7 @@ class MetaClient:
         self,
         *,
         s: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-octocat"""
 
@@ -173,7 +174,7 @@ class MetaClient:
     def get_all_versions(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-all-api-versions"""
 
@@ -198,7 +199,7 @@ class MetaClient:
     async def async_get_all_versions(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-all-api-versions"""
 
@@ -223,7 +224,7 @@ class MetaClient:
     def get_zen(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-the-zen-of-github"""
 
@@ -241,7 +242,7 @@ class MetaClient:
     async def async_get_zen(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/meta/meta#get-the-zen-of-github"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/migrations.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/migrations.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -70,7 +71,7 @@ class MigrationsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-organization-migrations"""
 
@@ -101,7 +102,7 @@ class MigrationsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-organization-migrations"""
 
@@ -130,7 +131,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -140,7 +141,7 @@ class MigrationsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: list[str],
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
@@ -156,7 +157,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -199,7 +200,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -209,7 +210,7 @@ class MigrationsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: list[str],
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
@@ -225,7 +226,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -269,7 +270,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#get-an-organization-migration-status"""
 
@@ -300,7 +301,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#get-an-organization-migration-status"""
 
@@ -330,7 +331,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#download-an-organization-migration-archive"""
 
@@ -354,7 +355,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#download-an-organization-migration-archive"""
 
@@ -378,7 +379,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#delete-an-organization-migration-archive"""
 
@@ -402,7 +403,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#delete-an-organization-migration-archive"""
 
@@ -427,7 +428,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#unlock-an-organization-repository"""
 
@@ -452,7 +453,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#unlock-an-organization-repository"""
 
@@ -478,7 +479,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
@@ -511,7 +512,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
@@ -542,7 +543,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-an-import-status"""
 
@@ -568,7 +569,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-an-import-status"""
 
@@ -595,7 +596,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -606,7 +607,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_url: str,
         vcs: Missing[Literal["subversion", "git", "mercurial", "tfvc"]] = UNSET,
         vcs_username: Missing[str] = UNSET,
@@ -619,7 +620,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -664,7 +665,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -675,7 +676,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_url: str,
         vcs: Missing[Literal["subversion", "git", "mercurial", "tfvc"]] = UNSET,
         vcs_username: Missing[str] = UNSET,
@@ -688,7 +689,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -732,7 +733,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#cancel-an-import"""
 
@@ -756,7 +757,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#cancel-an-import"""
 
@@ -781,7 +782,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
     ) -> Response[Import, ImportType]: ...
 
@@ -792,7 +793,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
@@ -804,7 +805,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -846,7 +847,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
     ) -> Response[Import, ImportType]: ...
 
@@ -857,7 +858,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
@@ -869,7 +870,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -911,7 +912,7 @@ class MigrationsClient:
         repo: str,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-commit-authors"""
 
@@ -943,7 +944,7 @@ class MigrationsClient:
         repo: str,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-commit-authors"""
 
@@ -976,7 +977,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
@@ -988,7 +989,7 @@ class MigrationsClient:
         author_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
@@ -999,7 +1000,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PorterAuthor, PorterAuthorType]:
@@ -1047,7 +1048,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
@@ -1059,7 +1060,7 @@ class MigrationsClient:
         author_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
@@ -1070,7 +1071,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PorterAuthor, PorterAuthorType]:
@@ -1116,7 +1117,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-large-files"""
 
@@ -1141,7 +1142,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/source-imports#get-large-files"""
 
@@ -1167,7 +1168,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -1178,7 +1179,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
     ) -> Response[Import, ImportType]: ...
 
@@ -1187,7 +1188,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -1231,7 +1232,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -1242,7 +1243,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
     ) -> Response[Import, ImportType]: ...
 
@@ -1251,7 +1252,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -1294,7 +1295,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-user-migrations"""
 
@@ -1326,7 +1327,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-user-migrations"""
 
@@ -1357,7 +1358,7 @@ class MigrationsClient:
     def start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -1366,7 +1367,7 @@ class MigrationsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
         exclude_git_data: Missing[bool] = UNSET,
@@ -1381,7 +1382,7 @@ class MigrationsClient:
     def start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -1424,7 +1425,7 @@ class MigrationsClient:
     async def async_start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -1433,7 +1434,7 @@ class MigrationsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
         exclude_git_data: Missing[bool] = UNSET,
@@ -1448,7 +1449,7 @@ class MigrationsClient:
     async def async_start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -1492,7 +1493,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[str]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#get-a-user-migration-status"""
 
@@ -1524,7 +1525,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[str]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#get-a-user-migration-status"""
 
@@ -1555,7 +1556,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#download-a-user-migration-archive"""
 
@@ -1579,7 +1580,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#download-a-user-migration-archive"""
 
@@ -1603,7 +1604,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#delete-a-user-migration-archive"""
 
@@ -1628,7 +1629,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#delete-a-user-migration-archive"""
 
@@ -1654,7 +1655,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#unlock-a-user-repository"""
 
@@ -1680,7 +1681,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#unlock-a-user-repository"""
 
@@ -1707,7 +1708,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-repositories-for-a-user-migration"""
 
@@ -1739,7 +1740,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/migrations/users#list-repositories-for-a-user-migration"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/oidc.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/oidc.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -45,7 +46,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
@@ -66,7 +67,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
@@ -88,7 +89,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OidcCustomSubType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -98,7 +99,7 @@ class OidcClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         include_claim_keys: list[str],
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -106,7 +107,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -144,7 +145,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OidcCustomSubType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -154,7 +155,7 @@ class OidcClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         include_claim_keys: list[str],
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -162,7 +163,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:

--- a/githubkit/versions/ghec_v2022_11_28/rest/orgs.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/orgs.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -153,7 +154,7 @@ class OrgsClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations"""
 
@@ -181,7 +182,7 @@ class OrgsClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations"""
 
@@ -208,7 +209,7 @@ class OrgsClient:
         self,
         organization_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrganizationsOrganizationIdCustomRolesGetResponse200,
         OrganizationsOrganizationIdCustomRolesGetResponse200Type,
@@ -232,7 +233,7 @@ class OrgsClient:
         self,
         organization_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrganizationsOrganizationIdCustomRolesGetResponse200,
         OrganizationsOrganizationIdCustomRolesGetResponse200Type,
@@ -256,7 +257,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-an-organization"""
 
@@ -280,7 +281,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-an-organization"""
 
@@ -304,7 +305,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -335,7 +336,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -367,7 +368,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
     ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
@@ -377,7 +378,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         billing_email: Missing[str] = UNSET,
         company: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
@@ -421,7 +422,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationFull, OrganizationFullType]:
@@ -467,7 +468,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
     ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
@@ -477,7 +478,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         billing_email: Missing[str] = UNSET,
         company: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
@@ -521,7 +522,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationFull, OrganizationFullType]:
@@ -566,7 +567,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#get-announcement-banner-for-organization"""
 
@@ -587,7 +588,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#get-announcement-banner-for-organization"""
 
@@ -608,7 +609,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#remove-announcement-banner-from-organization"""
 
@@ -626,7 +627,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/announcement-banners/organizations#remove-announcement-banner-from-organization"""
 
@@ -645,7 +646,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AnnouncementType,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
@@ -655,7 +656,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
@@ -664,7 +665,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
@@ -698,7 +699,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AnnouncementType,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
 
@@ -708,7 +709,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         announcement: Union[str, None],
         expires_at: Missing[Union[datetime, None]] = UNSET,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]: ...
@@ -717,7 +718,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AnnouncementType] = UNSET,
         **kwargs,
     ) -> Response[AnnouncementBanner, AnnouncementBannerType]:
@@ -754,7 +755,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgAttestationsSubjectDigestGetResponse200,
         OrgsOrgAttestationsSubjectDigestGetResponse200Type,
@@ -789,7 +790,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgAttestationsSubjectDigestGetResponse200,
         OrgsOrgAttestationsSubjectDigestGetResponse200Type,
@@ -826,7 +827,7 @@ class OrgsClient:
         before: Missing[str] = UNSET,
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-the-audit-log-for-an-organization"""
 
@@ -863,7 +864,7 @@ class OrgsClient:
         before: Missing[str] = UNSET,
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[AuditLogEvent], list[AuditLogEventType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#get-the-audit-log-for-an-organization"""
 
@@ -896,7 +897,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
@@ -925,7 +926,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
@@ -953,7 +954,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization"""
 
@@ -977,7 +978,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization"""
 
@@ -1001,7 +1002,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#block-a-user-from-an-organization"""
 
@@ -1025,7 +1026,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#block-a-user-from-an-organization"""
 
@@ -1049,7 +1050,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#unblock-a-user-from-an-organization"""
 
@@ -1068,7 +1069,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/blocking#unblock-a-user-from-an-organization"""
 
@@ -1095,7 +1096,7 @@ class OrgsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PushRuleBypassRequest], list[PushRuleBypassRequestType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/bypass-requests#list-push-rule-bypass-requests-within-an-organization"""
 
@@ -1140,7 +1141,7 @@ class OrgsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PushRuleBypassRequest], list[PushRuleBypassRequestType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/bypass-requests#list-push-rule-bypass-requests-within-an-organization"""
 
@@ -1179,7 +1180,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         login: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CredentialAuthorization], list[CredentialAuthorizationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization"""
 
@@ -1210,7 +1211,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         login: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CredentialAuthorization], list[CredentialAuthorizationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-saml-sso-authorizations-for-an-organization"""
 
@@ -1239,7 +1240,7 @@ class OrgsClient:
         org: str,
         credential_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#remove-a-saml-sso-authorization-for-an-organization"""
 
@@ -1263,7 +1264,7 @@ class OrgsClient:
         org: str,
         credential_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#remove-a-saml-sso-authorization-for-an-organization"""
 
@@ -1286,7 +1287,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCustomRepositoryRolesGetResponse200,
         OrgsOrgCustomRepositoryRolesGetResponse200Type,
@@ -1310,7 +1311,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCustomRepositoryRolesGetResponse200,
         OrgsOrgCustomRepositoryRolesGetResponse200Type,
@@ -1335,7 +1336,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1347,7 +1348,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
@@ -1360,7 +1361,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1407,7 +1408,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1419,7 +1420,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
@@ -1432,7 +1433,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1479,7 +1480,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
     ]:
@@ -1506,7 +1507,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
     ]:
@@ -1533,7 +1534,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#delete-a-custom-repository-role"""
 
@@ -1552,7 +1553,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#delete-a-custom-repository-role"""
 
@@ -1572,7 +1573,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1585,7 +1586,7 @@ class OrgsClient:
         role_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
@@ -1599,7 +1600,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1647,7 +1648,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1660,7 +1661,7 @@ class OrgsClient:
         role_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
@@ -1674,7 +1675,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1721,7 +1722,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1733,7 +1734,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
@@ -1746,7 +1747,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1793,7 +1794,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleCreateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1805,7 +1806,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Literal["read", "triage", "write", "maintain"],
@@ -1818,7 +1819,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleCreateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1865,7 +1866,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
     ]:
@@ -1892,7 +1893,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
     ]:
@@ -1919,7 +1920,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---delete-a-custom-role"""
 
@@ -1938,7 +1939,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-roles#closing-down---delete-a-custom-role"""
 
@@ -1958,7 +1959,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -1971,7 +1972,7 @@ class OrgsClient:
         role_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
@@ -1985,7 +1986,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2033,7 +2034,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomRepositoryRoleUpdateSchemaType,
     ) -> Response[
         OrganizationCustomRepositoryRole, OrganizationCustomRepositoryRoleType
@@ -2046,7 +2047,7 @@ class OrgsClient:
         role_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
         base_role: Missing[Literal["read", "triage", "write", "maintain"]] = UNSET,
@@ -2060,7 +2061,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomRepositoryRoleUpdateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2108,7 +2109,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-failed-organization-invitations"""
 
@@ -2140,7 +2141,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-failed-organization-invitations"""
 
@@ -2170,7 +2171,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
     ]:
@@ -2193,7 +2194,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
     ]:
@@ -2218,7 +2219,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-organization-webhooks"""
 
@@ -2250,7 +2251,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-organization-webhooks"""
 
@@ -2281,7 +2282,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -2291,7 +2292,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
@@ -2302,7 +2303,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -2340,7 +2341,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -2350,7 +2351,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
@@ -2361,7 +2362,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -2399,7 +2400,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-an-organization-webhook"""
 
@@ -2424,7 +2425,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-an-organization-webhook"""
 
@@ -2449,7 +2450,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#delete-an-organization-webhook"""
 
@@ -2473,7 +2474,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#delete-an-organization-webhook"""
 
@@ -2498,7 +2499,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -2509,7 +2510,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[OrgsOrgHooksHookIdPatchBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
@@ -2521,7 +2522,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -2565,7 +2566,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -2576,7 +2577,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[OrgsOrgHooksHookIdPatchBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
@@ -2588,7 +2589,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -2631,7 +2632,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
@@ -2653,7 +2654,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
@@ -2676,7 +2677,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -2687,7 +2688,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -2699,7 +2700,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -2734,7 +2735,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -2745,7 +2746,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -2757,7 +2758,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -2793,7 +2794,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
@@ -2827,7 +2828,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
@@ -2860,7 +2861,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
@@ -2887,7 +2888,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
@@ -2914,7 +2915,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -2948,7 +2949,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -2981,7 +2982,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#ping-an-organization-webhook"""
 
@@ -3005,7 +3006,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/webhooks#ping-an-organization-webhook"""
 
@@ -3054,7 +3055,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         api_route_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
     ]:
@@ -3114,7 +3115,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         api_route_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
     ]:
@@ -3165,7 +3166,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         subject_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
     ]:
@@ -3216,7 +3217,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         subject_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
     ]:
@@ -3252,7 +3253,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats"""
 
@@ -3281,7 +3282,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats"""
 
@@ -3311,7 +3312,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-user"""
 
@@ -3341,7 +3342,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-user"""
 
@@ -3378,7 +3379,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-actor"""
 
@@ -3415,7 +3416,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-summary-stats-by-actor"""
 
@@ -3445,7 +3446,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats"""
 
@@ -3476,7 +3477,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats"""
 
@@ -3508,7 +3509,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-user"""
 
@@ -3540,7 +3541,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-user"""
 
@@ -3579,7 +3580,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-actor"""
 
@@ -3618,7 +3619,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-time-stats-by-actor"""
 
@@ -3664,7 +3665,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         actor_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-user-stats"""
 
@@ -3714,7 +3715,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         actor_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/api-insights#get-user-stats"""
 
@@ -3748,7 +3749,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
     ]:
@@ -3779,7 +3780,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
     ]:
@@ -3816,7 +3817,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-pending-organization-invitations"""
 
@@ -3856,7 +3857,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-pending-organization-invitations"""
 
@@ -3889,7 +3890,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
@@ -3899,7 +3900,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         invitee_id: Missing[int] = UNSET,
         email: Missing[str] = UNSET,
         role: Missing[
@@ -3912,7 +3913,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
@@ -3955,7 +3956,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
@@ -3965,7 +3966,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         invitee_id: Missing[int] = UNSET,
         email: Missing[str] = UNSET,
         role: Missing[
@@ -3978,7 +3979,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
@@ -4021,7 +4022,7 @@ class OrgsClient:
         org: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#cancel-an-organization-invitation"""
 
@@ -4046,7 +4047,7 @@ class OrgsClient:
         org: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#cancel-an-organization-invitation"""
 
@@ -4073,7 +4074,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-invitation-teams"""
 
@@ -4106,7 +4107,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-invitation-teams"""
 
@@ -4140,7 +4141,7 @@ class OrgsClient:
         role: Missing[Literal["all", "admin", "member"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-members"""
 
@@ -4176,7 +4177,7 @@ class OrgsClient:
         role: Missing[Literal["all", "admin", "member"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-members"""
 
@@ -4209,7 +4210,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#check-organization-membership-for-a-user"""
 
@@ -4229,7 +4230,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#check-organization-membership-for-a-user"""
 
@@ -4249,7 +4250,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#remove-an-organization-member"""
 
@@ -4273,7 +4274,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#remove-an-organization-member"""
 
@@ -4297,7 +4298,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-organization-membership-for-a-user"""
 
@@ -4323,7 +4324,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-organization-membership-for-a-user"""
 
@@ -4350,7 +4351,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -4361,7 +4362,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -4370,7 +4371,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -4414,7 +4415,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -4425,7 +4426,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -4434,7 +4435,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -4477,7 +4478,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#remove-organization-membership-for-a-user"""
 
@@ -4502,7 +4503,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#remove-organization-membership-for-a-user"""
 
@@ -4526,7 +4527,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationFineGrainedPermission],
         list[OrganizationFineGrainedPermissionType],
@@ -4558,7 +4559,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationFineGrainedPermission],
         list[OrganizationFineGrainedPermissionType],
@@ -4590,7 +4591,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgOrganizationRolesGetResponse200,
         OrgsOrgOrganizationRolesGetResponse200Type,
@@ -4622,7 +4623,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgOrganizationRolesGetResponse200,
         OrgsOrgOrganizationRolesGetResponse200Type,
@@ -4655,7 +4656,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomOrganizationRoleCreateSchemaType,
     ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
@@ -4665,7 +4666,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         permissions: list[str],
@@ -4678,7 +4679,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleCreateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
@@ -4724,7 +4725,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomOrganizationRoleCreateSchemaType,
     ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
@@ -4734,7 +4735,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         permissions: list[str],
@@ -4747,7 +4748,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleCreateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
@@ -4793,7 +4794,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-all-organization-roles-for-a-team"""
 
@@ -4812,7 +4813,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-all-organization-roles-for-a-team"""
 
@@ -4832,7 +4833,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#assign-an-organization-role-to-a-team"""
 
@@ -4853,7 +4854,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#assign-an-organization-role-to-a-team"""
 
@@ -4874,7 +4875,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-an-organization-role-from-a-team"""
 
@@ -4894,7 +4895,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-an-organization-role-from-a-team"""
 
@@ -4913,7 +4914,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-all-organization-roles-for-a-user"""
 
@@ -4932,7 +4933,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-all-organization-roles-for-a-user"""
 
@@ -4952,7 +4953,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#assign-an-organization-role-to-a-user"""
 
@@ -4973,7 +4974,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#assign-an-organization-role-to-a-user"""
 
@@ -4994,7 +4995,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-an-organization-role-from-a-user"""
 
@@ -5014,7 +5015,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#remove-an-organization-role-from-a-user"""
 
@@ -5033,7 +5034,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#get-an-organization-role"""
 
@@ -5059,7 +5060,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#get-an-organization-role"""
 
@@ -5085,7 +5086,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#delete-a-custom-organization-role"""
 
@@ -5104,7 +5105,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#delete-a-custom-organization-role"""
 
@@ -5124,7 +5125,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomOrganizationRoleUpdateSchemaType,
     ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
@@ -5135,7 +5136,7 @@ class OrgsClient:
         role_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         permissions: Missing[list[str]] = UNSET,
@@ -5149,7 +5150,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleUpdateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
@@ -5196,7 +5197,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrganizationCustomOrganizationRoleUpdateSchemaType,
     ) -> Response[OrganizationRole, OrganizationRoleType]: ...
 
@@ -5207,7 +5208,7 @@ class OrgsClient:
         role_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         permissions: Missing[list[str]] = UNSET,
@@ -5221,7 +5222,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrganizationCustomOrganizationRoleUpdateSchemaType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
@@ -5269,7 +5270,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
@@ -5300,7 +5301,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
@@ -5331,7 +5332,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
@@ -5362,7 +5363,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
@@ -5393,7 +5394,7 @@ class OrgsClient:
         filter_: Missing[Literal["2fa_disabled", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
@@ -5424,7 +5425,7 @@ class OrgsClient:
         filter_: Missing[Literal["2fa_disabled", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
@@ -5454,7 +5455,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -5468,7 +5469,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         async_: Missing[bool] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -5480,7 +5481,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -5527,7 +5528,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -5541,7 +5542,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         async_: Missing[bool] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -5553,7 +5554,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -5599,7 +5600,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization"""
 
@@ -5623,7 +5624,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization"""
 
@@ -5655,7 +5656,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrantRequest],
         list[OrganizationProgrammaticAccessGrantRequestType],
@@ -5711,7 +5712,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrantRequest],
         list[OrganizationProgrammaticAccessGrantRequestType],
@@ -5759,7 +5760,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -5772,7 +5773,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
@@ -5785,7 +5786,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -5835,7 +5836,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -5848,7 +5849,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
@@ -5861,7 +5862,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -5912,7 +5913,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
     ) -> Response: ...
 
@@ -5923,7 +5924,7 @@ class OrgsClient:
         pat_request_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
     ) -> Response: ...
@@ -5933,7 +5934,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType
         ] = UNSET,
@@ -5981,7 +5982,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
     ) -> Response: ...
 
@@ -5992,7 +5993,7 @@ class OrgsClient:
         pat_request_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
     ) -> Response: ...
@@ -6002,7 +6003,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType
         ] = UNSET,
@@ -6051,7 +6052,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
@@ -6088,7 +6089,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
@@ -6131,7 +6132,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrant],
         list[OrganizationProgrammaticAccessGrantType],
@@ -6187,7 +6188,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrant],
         list[OrganizationProgrammaticAccessGrantType],
@@ -6235,7 +6236,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -6248,7 +6249,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
     ) -> Response[
@@ -6260,7 +6261,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6308,7 +6309,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -6321,7 +6322,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
     ) -> Response[
@@ -6333,7 +6334,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6382,7 +6383,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPatIdPostBodyType,
     ) -> Response: ...
 
@@ -6393,7 +6394,7 @@ class OrgsClient:
         pat_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
     ) -> Response: ...
 
@@ -6402,7 +6403,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPatIdPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -6446,7 +6447,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPatIdPostBodyType,
     ) -> Response: ...
 
@@ -6457,7 +6458,7 @@ class OrgsClient:
         pat_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
     ) -> Response: ...
 
@@ -6466,7 +6467,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPatIdPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -6511,7 +6512,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
@@ -6546,7 +6547,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
@@ -6578,7 +6579,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
@@ -6603,7 +6604,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
@@ -6629,7 +6630,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -6639,7 +6640,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyType],
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -6647,7 +6648,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
@@ -6689,7 +6690,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -6699,7 +6700,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyType],
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -6707,7 +6708,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
@@ -6749,7 +6750,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
@@ -6775,7 +6776,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
@@ -6802,7 +6803,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CustomPropertySetPayloadType,
     ) -> Response[CustomProperty, CustomPropertyType]: ...
 
@@ -6813,7 +6814,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value_type: Literal["string", "single_select", "multi_select", "true_false"],
         required: Missing[bool] = UNSET,
         default_value: Missing[Union[str, list[str], None]] = UNSET,
@@ -6826,7 +6827,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CustomPropertySetPayloadType] = UNSET,
         **kwargs,
     ) -> Response[CustomProperty, CustomPropertyType]:
@@ -6865,7 +6866,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CustomPropertySetPayloadType,
     ) -> Response[CustomProperty, CustomPropertyType]: ...
 
@@ -6876,7 +6877,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value_type: Literal["string", "single_select", "multi_select", "true_false"],
         required: Missing[bool] = UNSET,
         default_value: Missing[Union[str, list[str], None]] = UNSET,
@@ -6889,7 +6890,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CustomPropertySetPayloadType] = UNSET,
         **kwargs,
     ) -> Response[CustomProperty, CustomPropertyType]:
@@ -6927,7 +6928,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#remove-a-custom-property-for-an-organization"""
 
@@ -6952,7 +6953,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/custom-properties#remove-a-custom-property-for-an-organization"""
 
@@ -6979,7 +6980,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_query: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
     ]:
@@ -7016,7 +7017,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_query: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
     ]:
@@ -7051,7 +7052,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -7061,7 +7062,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_names: list[str],
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
@@ -7070,7 +7071,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -7112,7 +7113,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -7122,7 +7123,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_names: list[str],
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
@@ -7131,7 +7132,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -7174,7 +7175,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-public-organization-members"""
 
@@ -7203,7 +7204,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-public-organization-members"""
 
@@ -7231,7 +7232,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#check-public-organization-membership-for-a-user"""
 
@@ -7251,7 +7252,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#check-public-organization-membership-for-a-user"""
 
@@ -7271,7 +7272,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#set-public-organization-membership-for-the-authenticated-user"""
 
@@ -7295,7 +7296,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#set-public-organization-membership-for-the-authenticated-user"""
 
@@ -7319,7 +7320,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#remove-public-organization-membership-for-the-authenticated-user"""
 
@@ -7338,7 +7339,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#remove-public-organization-membership-for-the-authenticated-user"""
 
@@ -7356,7 +7357,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
     ]:
@@ -7379,7 +7380,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[RepositoryFineGrainedPermission], list[RepositoryFineGrainedPermissionType]
     ]:
@@ -7402,7 +7403,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#list-security-manager-teams"""
 
@@ -7423,7 +7424,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#list-security-manager-teams"""
 
@@ -7445,7 +7446,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#add-a-security-manager-team"""
 
@@ -7464,7 +7465,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#add-a-security-manager-team"""
 
@@ -7483,7 +7484,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#remove-a-security-manager-team"""
 
@@ -7502,7 +7503,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/security-managers#remove-a-security-manager-team"""
 
@@ -7531,7 +7532,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
     ) -> Response: ...
 
@@ -7551,7 +7552,7 @@ class OrgsClient:
         enablement: Literal["enable_all", "disable_all"],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         query_suite: Missing[Literal["default", "extended"]] = UNSET,
     ) -> Response: ...
 
@@ -7569,7 +7570,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -7613,7 +7614,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
     ) -> Response: ...
 
@@ -7633,7 +7634,7 @@ class OrgsClient:
         enablement: Literal["enable_all", "disable_all"],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         query_suite: Missing[Literal["default", "extended"]] = UNSET,
     ) -> Response: ...
 
@@ -7651,7 +7652,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -7686,7 +7687,7 @@ class OrgsClient:
         state: Missing[Literal["active", "pending"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
@@ -7721,7 +7722,7 @@ class OrgsClient:
         state: Missing[Literal["active", "pending"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
@@ -7754,7 +7755,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
@@ -7779,7 +7780,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
@@ -7805,7 +7806,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -7815,7 +7816,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["active"],
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -7823,7 +7824,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -7867,7 +7868,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -7877,7 +7878,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["active"],
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -7885,7 +7886,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -7929,7 +7930,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
@@ -7961,7 +7962,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
@@ -7994,7 +7995,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-a-user"""
 
@@ -8023,7 +8024,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/orgs#list-organizations-for-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/packages.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/packages.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional
 from weakref import ref
 
@@ -46,7 +47,7 @@ class PackagesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
@@ -71,7 +72,7 @@ class PackagesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
@@ -102,7 +103,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-an-organization"""
 
@@ -141,7 +142,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-an-organization"""
 
@@ -178,7 +179,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-an-organization"""
 
@@ -203,7 +204,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-an-organization"""
 
@@ -228,7 +229,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-for-an-organization"""
 
@@ -257,7 +258,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-for-an-organization"""
 
@@ -287,7 +288,7 @@ class PackagesClient:
         org: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-for-an-organization"""
 
@@ -322,7 +323,7 @@ class PackagesClient:
         org: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-for-an-organization"""
 
@@ -359,7 +360,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
@@ -399,7 +400,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
@@ -437,7 +438,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-an-organization"""
 
@@ -463,7 +464,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-an-organization"""
 
@@ -489,7 +490,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-package-version-for-an-organization"""
 
@@ -519,7 +520,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-package-version-for-an-organization"""
 
@@ -549,7 +550,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-package-version-for-an-organization"""
 
@@ -579,7 +580,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-package-version-for-an-organization"""
 
@@ -603,7 +604,7 @@ class PackagesClient:
     def list_docker_migration_conflicting_packages_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
@@ -623,7 +624,7 @@ class PackagesClient:
     async def async_list_docker_migration_conflicting_packages_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
@@ -649,7 +650,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
@@ -684,7 +685,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
@@ -717,7 +718,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
@@ -741,7 +742,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
@@ -765,7 +766,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-for-the-authenticated-user"""
 
@@ -793,7 +794,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-for-the-authenticated-user"""
 
@@ -822,7 +823,7 @@ class PackagesClient:
         package_name: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-for-the-authenticated-user"""
 
@@ -856,7 +857,7 @@ class PackagesClient:
         package_name: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-for-the-authenticated-user"""
 
@@ -892,7 +893,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
@@ -931,7 +932,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
@@ -968,7 +969,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
@@ -993,7 +994,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
@@ -1018,7 +1019,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-version-for-the-authenticated-user"""
 
@@ -1047,7 +1048,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-version-for-the-authenticated-user"""
 
@@ -1076,7 +1077,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-version-for-the-authenticated-user"""
 
@@ -1105,7 +1106,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-version-for-the-authenticated-user"""
 
@@ -1130,7 +1131,7 @@ class PackagesClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
@@ -1155,7 +1156,7 @@ class PackagesClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
@@ -1186,7 +1187,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-a-user"""
 
@@ -1225,7 +1226,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-packages-for-a-user"""
 
@@ -1262,7 +1263,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-a-user"""
 
@@ -1287,7 +1288,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-for-a-user"""
 
@@ -1312,7 +1313,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-for-a-user"""
 
@@ -1341,7 +1342,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-a-package-for-a-user"""
 
@@ -1371,7 +1372,7 @@ class PackagesClient:
         username: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-for-a-user"""
 
@@ -1406,7 +1407,7 @@ class PackagesClient:
         username: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-a-package-for-a-user"""
 
@@ -1440,7 +1441,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
@@ -1470,7 +1471,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
@@ -1501,7 +1502,7 @@ class PackagesClient:
         package_version_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-a-user"""
 
@@ -1527,7 +1528,7 @@ class PackagesClient:
         package_version_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#get-a-package-version-for-a-user"""
 
@@ -1553,7 +1554,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-package-version-for-a-user"""
 
@@ -1583,7 +1584,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#delete-package-version-for-a-user"""
 
@@ -1613,7 +1614,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-package-version-for-a-user"""
 
@@ -1643,7 +1644,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/packages/packages#restore-package-version-for-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/private_registries.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/private_registries.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -63,7 +64,7 @@ class PrivateRegistriesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesGetResponse200,
         OrgsOrgPrivateRegistriesGetResponse200Type,
@@ -99,7 +100,7 @@ class PrivateRegistriesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesGetResponse200,
         OrgsOrgPrivateRegistriesGetResponse200Type,
@@ -134,7 +135,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesPostBodyType,
     ) -> Response[
         OrgPrivateRegistryConfigurationWithSelectedRepositories,
@@ -147,7 +148,7 @@ class PrivateRegistriesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Literal["maven_repository"],
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: str,
@@ -163,7 +164,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -209,7 +210,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesPostBodyType,
     ) -> Response[
         OrgPrivateRegistryConfigurationWithSelectedRepositories,
@@ -222,7 +223,7 @@ class PrivateRegistriesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Literal["maven_repository"],
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: str,
@@ -238,7 +239,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -283,7 +284,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200,
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200Type,
@@ -310,7 +311,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200,
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200Type,
@@ -338,7 +339,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgPrivateRegistryConfiguration, OrgPrivateRegistryConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/private-registries/organization-configurations#get-a-private-registry-for-an-organization"""
 
@@ -363,7 +364,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgPrivateRegistryConfiguration, OrgPrivateRegistryConfigurationType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/private-registries/organization-configurations#get-a-private-registry-for-an-organization"""
 
@@ -388,7 +389,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/private-registries/organization-configurations#delete-a-private-registry-for-an-organization"""
 
@@ -413,7 +414,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/private-registries/organization-configurations#delete-a-private-registry-for-an-organization"""
 
@@ -439,7 +440,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesSecretNamePatchBodyType,
     ) -> Response: ...
 
@@ -450,7 +451,7 @@ class PrivateRegistriesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Missing[Literal["maven_repository"]] = UNSET,
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: Missing[str] = UNSET,
@@ -464,7 +465,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesSecretNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -508,7 +509,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesSecretNamePatchBodyType,
     ) -> Response: ...
 
@@ -519,7 +520,7 @@ class PrivateRegistriesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Missing[Literal["maven_repository"]] = UNSET,
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: Missing[str] = UNSET,
@@ -533,7 +534,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesSecretNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:

--- a/githubkit/versions/ghec_v2022_11_28/rest/projects.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/projects.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -80,7 +81,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-organization-projects"""
 
@@ -114,7 +115,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-organization-projects"""
 
@@ -146,7 +147,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -156,7 +157,7 @@ class ProjectsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -165,7 +166,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -211,7 +212,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -221,7 +222,7 @@ class ProjectsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -230,7 +231,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -275,7 +276,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#get-a-project-card"""
 
@@ -301,7 +302,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#get-a-project-card"""
 
@@ -327,7 +328,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#delete-a-project-card"""
 
@@ -352,7 +353,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#delete-a-project-card"""
 
@@ -378,7 +379,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -388,7 +389,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -397,7 +398,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectCard, ProjectCardType]:
@@ -442,7 +443,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -452,7 +453,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -461,7 +462,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectCard, ProjectCardType]:
@@ -506,7 +507,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsCardsCardIdMovesPostResponse201,
@@ -519,7 +520,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
     ) -> Response[
@@ -531,7 +532,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -581,7 +582,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsCardsCardIdMovesPostResponse201,
@@ -594,7 +595,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
     ) -> Response[
@@ -606,7 +607,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -655,7 +656,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#get-a-project-column"""
 
@@ -681,7 +682,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#get-a-project-column"""
 
@@ -707,7 +708,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#delete-a-project-column"""
 
@@ -731,7 +732,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#delete-a-project-column"""
 
@@ -756,7 +757,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -766,7 +767,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -774,7 +775,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -812,7 +813,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -822,7 +823,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -830,7 +831,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -870,7 +871,7 @@ class ProjectsClient:
         archived_state: Missing[Literal["all", "archived", "not_archived"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#list-project-cards"""
 
@@ -905,7 +906,7 @@ class ProjectsClient:
         archived_state: Missing[Literal["all", "archived", "not_archived"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/cards#list-project-cards"""
 
@@ -938,7 +939,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
@@ -951,7 +952,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Union[str, None],
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -961,7 +962,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content_id: int,
         content_type: str,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -970,7 +971,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
@@ -1031,7 +1032,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
@@ -1044,7 +1045,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Union[str, None],
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -1054,7 +1055,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content_id: int,
         content_type: str,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -1063,7 +1064,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
@@ -1124,7 +1125,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1137,7 +1138,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1148,7 +1149,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1195,7 +1196,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1208,7 +1209,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1219,7 +1220,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1265,7 +1266,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#get-a-project"""
 
@@ -1290,7 +1291,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#get-a-project"""
 
@@ -1315,7 +1316,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#delete-a-project"""
 
@@ -1341,7 +1342,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#delete-a-project"""
 
@@ -1368,7 +1369,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
     ) -> Response[Project, ProjectType]: ...
 
@@ -1378,7 +1379,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         state: Missing[str] = UNSET,
@@ -1392,7 +1393,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -1438,7 +1439,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
     ) -> Response[Project, ProjectType]: ...
 
@@ -1448,7 +1449,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         state: Missing[str] = UNSET,
@@ -1462,7 +1463,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -1510,7 +1511,7 @@ class ProjectsClient:
         affiliation: Missing[Literal["outside", "direct", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#list-project-collaborators"""
 
@@ -1547,7 +1548,7 @@ class ProjectsClient:
         affiliation: Missing[Literal["outside", "direct", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#list-project-collaborators"""
 
@@ -1583,7 +1584,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1596,7 +1597,7 @@ class ProjectsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -1605,7 +1606,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1655,7 +1656,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1668,7 +1669,7 @@ class ProjectsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -1677,7 +1678,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1726,7 +1727,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#remove-user-as-a-collaborator"""
 
@@ -1753,7 +1754,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#remove-user-as-a-collaborator"""
 
@@ -1780,7 +1781,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#get-project-permission-for-a-user"""
 
@@ -1808,7 +1809,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/collaborators#get-project-permission-for-a-user"""
 
@@ -1837,7 +1838,7 @@ class ProjectsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#list-project-columns"""
 
@@ -1870,7 +1871,7 @@ class ProjectsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/columns#list-project-columns"""
 
@@ -1902,7 +1903,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1912,7 +1913,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1920,7 +1921,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -1964,7 +1965,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1974,7 +1975,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1982,7 +1983,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -2029,7 +2030,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-repository-projects"""
 
@@ -2068,7 +2069,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-repository-projects"""
 
@@ -2105,7 +2106,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2116,7 +2117,7 @@ class ProjectsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2126,7 +2127,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2173,7 +2174,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2184,7 +2185,7 @@ class ProjectsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2194,7 +2195,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2239,7 +2240,7 @@ class ProjectsClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2248,7 +2249,7 @@ class ProjectsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2256,7 +2257,7 @@ class ProjectsClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2299,7 +2300,7 @@ class ProjectsClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2308,7 +2309,7 @@ class ProjectsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2316,7 +2317,7 @@ class ProjectsClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2362,7 +2363,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-user-projects"""
 
@@ -2396,7 +2397,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/projects/projects#list-user-projects"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/pulls.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/pulls.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -97,7 +98,7 @@ class PullsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests"""
 
@@ -142,7 +143,7 @@ class PullsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests"""
 
@@ -179,7 +180,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -190,7 +191,7 @@ class PullsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         head: str,
         head_repo: Missing[str] = UNSET,
@@ -206,7 +207,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -250,7 +251,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -261,7 +262,7 @@ class PullsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         head: str,
         head_repo: Missing[str] = UNSET,
@@ -277,7 +278,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -325,7 +326,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-in-a-repository"""
 
@@ -361,7 +362,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-in-a-repository"""
 
@@ -393,7 +394,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
@@ -419,7 +420,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
@@ -445,7 +446,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#delete-a-review-comment-for-a-pull-request"""
 
@@ -470,7 +471,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#delete-a-review-comment-for-a-pull-request"""
 
@@ -496,7 +497,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -508,7 +509,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -518,7 +519,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -559,7 +560,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -571,7 +572,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -581,7 +582,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -621,7 +622,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#get-a-pull-request"""
 
@@ -654,7 +655,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#get-a-pull-request"""
 
@@ -688,7 +689,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -700,7 +701,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
@@ -714,7 +715,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -759,7 +760,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -771,7 +772,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
@@ -785,7 +786,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -834,7 +835,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
@@ -871,7 +872,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
@@ -904,7 +905,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -916,7 +917,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         commit_id: str,
         path: str,
@@ -935,7 +936,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -982,7 +983,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -994,7 +995,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         commit_id: str,
         path: str,
@@ -1013,7 +1014,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -1061,7 +1062,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1074,7 +1075,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1085,7 +1086,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
@@ -1133,7 +1134,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1146,7 +1147,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1157,7 +1158,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
@@ -1205,7 +1206,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-commits-on-a-pull-request"""
 
@@ -1236,7 +1237,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-commits-on-a-pull-request"""
 
@@ -1267,7 +1268,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests-files"""
 
@@ -1308,7 +1309,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#list-pull-requests-files"""
 
@@ -1347,7 +1348,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#check-if-a-pull-request-has-been-merged"""
 
@@ -1368,7 +1369,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/pulls#check-if-a-pull-request-has-been-merged"""
 
@@ -1390,7 +1391,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1404,7 +1405,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_title: Missing[str] = UNSET,
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
@@ -1417,7 +1418,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1473,7 +1474,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1487,7 +1488,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_title: Missing[str] = UNSET,
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
@@ -1500,7 +1501,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1555,7 +1556,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
@@ -1578,7 +1579,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
@@ -1602,7 +1603,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1619,7 +1620,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1632,7 +1633,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1643,7 +1644,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1700,7 +1701,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1717,7 +1718,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1730,7 +1731,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1741,7 +1742,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1798,7 +1799,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
@@ -1810,7 +1811,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1821,7 +1822,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
@@ -1868,7 +1869,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
@@ -1880,7 +1881,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1891,7 +1892,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
@@ -1939,7 +1940,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
@@ -1970,7 +1971,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
@@ -2000,7 +2001,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2012,7 +2013,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_id: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         event: Missing[Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"]] = UNSET,
@@ -2027,7 +2028,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2074,7 +2075,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2086,7 +2087,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_id: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         event: Missing[Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"]] = UNSET,
@@ -2101,7 +2102,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2148,7 +2149,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
@@ -2175,7 +2176,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
@@ -2203,7 +2204,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2216,7 +2217,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2227,7 +2228,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2273,7 +2274,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2286,7 +2287,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2297,7 +2298,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2342,7 +2343,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
@@ -2370,7 +2371,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
@@ -2400,7 +2401,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
@@ -2435,7 +2436,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
@@ -2469,7 +2470,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2482,7 +2483,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2494,7 +2495,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
@@ -2546,7 +2547,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2559,7 +2560,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2571,7 +2572,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
@@ -2623,7 +2624,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2636,7 +2637,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2648,7 +2649,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
@@ -2699,7 +2700,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2712,7 +2713,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2724,7 +2725,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
@@ -2774,7 +2775,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
@@ -2791,7 +2792,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
     ) -> Response[
         ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
@@ -2804,7 +2805,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
@@ -2858,7 +2859,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
@@ -2875,7 +2876,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
     ) -> Response[
         ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
@@ -2888,7 +2889,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,

--- a/githubkit/versions/ghec_v2022_11_28/rest/rate_limit.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/rate_limit.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class RateLimitClient:
     def get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 
@@ -63,7 +64,7 @@ class RateLimitClient:
     async def async_get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/reactions.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/reactions.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -70,7 +71,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
@@ -108,7 +109,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
@@ -140,7 +141,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -153,7 +154,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -166,7 +167,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -211,7 +212,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -224,7 +225,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -237,7 +238,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -282,7 +283,7 @@ class ReactionsClient:
         comment_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-team-discussion-comment-reaction"""
 
@@ -304,7 +305,7 @@ class ReactionsClient:
         comment_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-team-discussion-comment-reaction"""
 
@@ -331,7 +332,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
@@ -368,7 +369,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
@@ -399,7 +400,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -411,7 +412,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -423,7 +424,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
@@ -466,7 +467,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -478,7 +479,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -490,7 +491,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
@@ -533,7 +534,7 @@ class ReactionsClient:
         discussion_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-team-discussion-reaction"""
 
@@ -554,7 +555,7 @@ class ReactionsClient:
         discussion_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-team-discussion-reaction"""
 
@@ -581,7 +582,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
@@ -621,7 +622,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
@@ -655,7 +656,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -667,7 +668,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -679,7 +680,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -724,7 +725,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -736,7 +737,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -748,7 +749,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -793,7 +794,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-a-commit-comment-reaction"""
 
@@ -814,7 +815,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-a-commit-comment-reaction"""
 
@@ -841,7 +842,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
@@ -881,7 +882,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
@@ -915,7 +916,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -927,7 +928,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -939,7 +940,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -986,7 +987,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -998,7 +999,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1010,7 +1011,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -1057,7 +1058,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-an-issue-comment-reaction"""
 
@@ -1078,7 +1079,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-an-issue-comment-reaction"""
 
@@ -1105,7 +1106,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue"""
 
@@ -1146,7 +1147,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-an-issue"""
 
@@ -1181,7 +1182,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1193,7 +1194,7 @@ class ReactionsClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1205,7 +1206,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1250,7 +1251,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1262,7 +1263,7 @@ class ReactionsClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1274,7 +1275,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1319,7 +1320,7 @@ class ReactionsClient:
         issue_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-an-issue-reaction"""
 
@@ -1340,7 +1341,7 @@ class ReactionsClient:
         issue_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-an-issue-reaction"""
 
@@ -1367,7 +1368,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
@@ -1407,7 +1408,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
@@ -1441,7 +1442,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1453,7 +1454,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1465,7 +1466,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -1512,7 +1513,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1524,7 +1525,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1536,7 +1537,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -1583,7 +1584,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-a-pull-request-comment-reaction"""
 
@@ -1606,7 +1607,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-a-pull-request-comment-reaction"""
 
@@ -1633,7 +1634,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-release"""
 
@@ -1671,7 +1672,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-release"""
 
@@ -1705,7 +1706,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1717,7 +1718,7 @@ class ReactionsClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1727,7 +1728,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1772,7 +1773,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1784,7 +1785,7 @@ class ReactionsClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1794,7 +1795,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1839,7 +1840,7 @@ class ReactionsClient:
         release_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-a-release-reaction"""
 
@@ -1860,7 +1861,7 @@ class ReactionsClient:
         release_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#delete-a-release-reaction"""
 
@@ -1887,7 +1888,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
@@ -1924,7 +1925,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
@@ -1955,7 +1956,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1967,7 +1968,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1979,7 +1980,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -2023,7 +2024,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -2035,7 +2036,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -2047,7 +2048,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -2096,7 +2097,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
@@ -2132,7 +2133,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
@@ -2162,7 +2163,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -2173,7 +2174,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -2184,7 +2185,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
@@ -2226,7 +2227,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -2237,7 +2238,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -2248,7 +2249,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,

--- a/githubkit/versions/ghec_v2022_11_28/rest/repos.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/repos.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -360,7 +361,7 @@ class ReposClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -370,7 +371,7 @@ class ReposClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -416,7 +417,7 @@ class ReposClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -458,7 +459,7 @@ class ReposClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -468,7 +469,7 @@ class ReposClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -514,7 +515,7 @@ class ReposClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -556,7 +557,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#get-an-enterprise-repository-ruleset"""
 
@@ -582,7 +583,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#get-an-enterprise-repository-ruleset"""
 
@@ -609,7 +610,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -620,7 +621,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -667,7 +668,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -712,7 +713,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -723,7 +724,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -770,7 +771,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[EnterprisesEnterpriseRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -814,7 +815,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#delete-an-enterprise-repository-ruleset"""
 
@@ -839,7 +840,7 @@ class ReposClient:
         enterprise: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/rules#delete-an-enterprise-repository-ruleset"""
 
@@ -870,7 +871,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-organization-repositories"""
 
@@ -907,7 +908,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-organization-repositories"""
 
@@ -938,7 +939,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -948,7 +949,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -986,7 +987,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -1029,7 +1030,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -1039,7 +1040,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -1077,7 +1078,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -1122,7 +1123,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-all-organization-repository-rulesets"""
 
@@ -1157,7 +1158,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-all-organization-repository-rulesets"""
 
@@ -1190,7 +1191,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -1200,7 +1201,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -1245,7 +1246,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -1283,7 +1284,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -1293,7 +1294,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -1338,7 +1339,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -1382,7 +1383,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#list-organization-rule-suites"""
 
@@ -1425,7 +1426,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#list-organization-rule-suites"""
 
@@ -1462,7 +1463,7 @@ class ReposClient:
         org: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
@@ -1488,7 +1489,7 @@ class ReposClient:
         org: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
@@ -1514,7 +1515,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-an-organization-repository-ruleset"""
 
@@ -1540,7 +1541,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#get-an-organization-repository-ruleset"""
 
@@ -1567,7 +1568,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -1578,7 +1579,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -1624,7 +1625,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -1667,7 +1668,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -1678,7 +1679,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -1724,7 +1725,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -1766,7 +1767,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#delete-an-organization-repository-ruleset"""
 
@@ -1791,7 +1792,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/orgs/rules#delete-an-organization-repository-ruleset"""
 
@@ -1816,7 +1817,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-a-repository"""
 
@@ -1842,7 +1843,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-a-repository"""
 
@@ -1868,7 +1869,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#delete-a-repository"""
 
@@ -1893,7 +1894,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#delete-a-repository"""
 
@@ -1919,7 +1920,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -1930,7 +1931,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -1969,7 +1970,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -2014,7 +2015,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -2025,7 +2026,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -2064,7 +2065,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -2127,7 +2128,7 @@ class ReposClient:
                 "merge_queue_merge",
             ]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-activities"""
 
@@ -2183,7 +2184,7 @@ class ReposClient:
                 "merge_queue_merge",
             ]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-activities"""
 
@@ -2221,7 +2222,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -2235,7 +2236,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -2247,7 +2248,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2294,7 +2295,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -2308,7 +2309,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -2320,7 +2321,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2370,7 +2371,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
@@ -2406,7 +2407,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
@@ -2438,7 +2439,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
@@ -2460,7 +2461,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
@@ -2483,7 +2484,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
     ) -> Response[Autolink, AutolinkType]: ...
 
@@ -2494,7 +2495,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
@@ -2505,7 +2506,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Autolink, AutolinkType]:
@@ -2543,7 +2544,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
     ) -> Response[Autolink, AutolinkType]: ...
 
@@ -2554,7 +2555,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
@@ -2565,7 +2566,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Autolink, AutolinkType]:
@@ -2603,7 +2604,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
@@ -2629,7 +2630,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
@@ -2655,7 +2656,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#delete-an-autolink-reference-from-a-repository"""
 
@@ -2680,7 +2681,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/autolinks#delete-an-autolink-reference-from-a-repository"""
 
@@ -2704,7 +2705,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
@@ -2727,7 +2728,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
@@ -2750,7 +2751,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#enable-automated-security-fixes"""
 
@@ -2769,7 +2770,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#enable-automated-security-fixes"""
 
@@ -2788,7 +2789,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#disable-automated-security-fixes"""
 
@@ -2807,7 +2808,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#disable-automated-security-fixes"""
 
@@ -2829,7 +2830,7 @@ class ReposClient:
         protected: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#list-branches"""
 
@@ -2864,7 +2865,7 @@ class ReposClient:
         protected: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#list-branches"""
 
@@ -2897,7 +2898,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#get-a-branch"""
 
@@ -2923,7 +2924,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branches#get-a-branch"""
 
@@ -2949,7 +2950,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-branch-protection"""
 
@@ -2975,7 +2976,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-branch-protection"""
 
@@ -3002,7 +3003,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
     ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
@@ -3014,7 +3015,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         required_status_checks: Union[
             ReposOwnerRepoBranchesBranchProtectionPutBodyPropRequiredStatusChecksType,
             None,
@@ -3042,7 +3043,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProtectedBranch, ProtectedBranchType]:
@@ -3090,7 +3091,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
     ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
@@ -3102,7 +3103,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         required_status_checks: Union[
             ReposOwnerRepoBranchesBranchProtectionPutBodyPropRequiredStatusChecksType,
             None,
@@ -3130,7 +3131,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProtectedBranch, ProtectedBranchType]:
@@ -3177,7 +3178,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-branch-protection"""
 
@@ -3202,7 +3203,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-branch-protection"""
 
@@ -3227,7 +3228,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-admin-branch-protection"""
 
@@ -3250,7 +3251,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-admin-branch-protection"""
 
@@ -3273,7 +3274,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-admin-branch-protection"""
 
@@ -3296,7 +3297,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#set-admin-branch-protection"""
 
@@ -3319,7 +3320,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-admin-branch-protection"""
 
@@ -3344,7 +3345,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-admin-branch-protection"""
 
@@ -3369,7 +3370,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
     ]:
@@ -3394,7 +3395,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
     ]:
@@ -3419,7 +3420,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-pull-request-review-protection"""
 
@@ -3444,7 +3445,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-pull-request-review-protection"""
 
@@ -3470,7 +3471,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3486,7 +3487,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         dismissal_restrictions: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropDismissalRestrictionsType
         ] = UNSET,
@@ -3507,7 +3508,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3557,7 +3558,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3573,7 +3574,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         dismissal_restrictions: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropDismissalRestrictionsType
         ] = UNSET,
@@ -3594,7 +3595,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3643,7 +3644,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-commit-signature-protection"""
 
@@ -3669,7 +3670,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-commit-signature-protection"""
 
@@ -3695,7 +3696,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#create-commit-signature-protection"""
 
@@ -3721,7 +3722,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#create-commit-signature-protection"""
 
@@ -3747,7 +3748,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-commit-signature-protection"""
 
@@ -3772,7 +3773,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-commit-signature-protection"""
 
@@ -3797,7 +3798,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-status-checks-protection"""
 
@@ -3825,7 +3826,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-status-checks-protection"""
 
@@ -3853,7 +3854,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-status-check-protection"""
 
@@ -3875,7 +3876,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#remove-status-check-protection"""
 
@@ -3898,7 +3899,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3912,7 +3913,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         strict: Missing[bool] = UNSET,
         contexts: Missing[list[str]] = UNSET,
         checks: Missing[
@@ -3928,7 +3929,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3980,7 +3981,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3994,7 +3995,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         strict: Missing[bool] = UNSET,
         contexts: Missing[list[str]] = UNSET,
         checks: Missing[
@@ -4010,7 +4011,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -4061,7 +4062,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-all-status-check-contexts"""
 
@@ -4087,7 +4088,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-all-status-check-contexts"""
 
@@ -4114,7 +4115,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -4131,7 +4132,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4141,7 +4142,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -4198,7 +4199,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -4215,7 +4216,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4225,7 +4226,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -4282,7 +4283,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -4299,7 +4300,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4309,7 +4310,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -4367,7 +4368,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -4384,7 +4385,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4394,7 +4395,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -4452,7 +4453,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4469,7 +4470,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4479,7 +4480,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4536,7 +4537,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4553,7 +4554,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4563,7 +4564,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4619,7 +4620,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-access-restrictions"""
 
@@ -4645,7 +4646,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-access-restrictions"""
 
@@ -4671,7 +4672,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-access-restrictions"""
 
@@ -4691,7 +4692,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#delete-access-restrictions"""
 
@@ -4711,7 +4712,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
@@ -4739,7 +4740,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
@@ -4768,7 +4769,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4782,7 +4783,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4794,7 +4795,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
@@ -4843,7 +4844,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4857,7 +4858,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4869,7 +4870,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
@@ -4918,7 +4919,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4932,7 +4933,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4944,7 +4945,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
@@ -4993,7 +4994,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -5007,7 +5008,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -5019,7 +5020,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
@@ -5068,7 +5069,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -5082,7 +5083,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -5094,7 +5095,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
@@ -5143,7 +5144,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -5157,7 +5158,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -5169,7 +5170,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
@@ -5217,7 +5218,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
@@ -5243,7 +5244,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
@@ -5270,7 +5271,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -5287,7 +5288,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5297,7 +5298,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -5353,7 +5354,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -5370,7 +5371,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5380,7 +5381,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -5436,7 +5437,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5453,7 +5454,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5463,7 +5464,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5519,7 +5520,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5536,7 +5537,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5546,7 +5547,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5602,7 +5603,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5619,7 +5620,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5629,7 +5630,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5685,7 +5686,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5702,7 +5703,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5712,7 +5713,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5767,7 +5768,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
@@ -5793,7 +5794,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
@@ -5820,7 +5821,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5832,7 +5833,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5842,7 +5843,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
@@ -5889,7 +5890,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5901,7 +5902,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5911,7 +5912,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
@@ -5958,7 +5959,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5970,7 +5971,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5980,7 +5981,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
@@ -6027,7 +6028,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -6039,7 +6040,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -6049,7 +6050,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
@@ -6096,7 +6097,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -6108,7 +6109,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -6118,7 +6119,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
@@ -6165,7 +6166,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -6177,7 +6178,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -6187,7 +6188,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
@@ -6234,7 +6235,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -6246,7 +6247,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: str,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -6256,7 +6257,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
@@ -6304,7 +6305,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -6316,7 +6317,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: str,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -6326,7 +6327,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
@@ -6380,7 +6381,7 @@ class ReposClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PushRuleBypassRequest], list[PushRuleBypassRequestType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/bypass-requests#list-repository-push-rule-bypass-requests"""
 
@@ -6424,7 +6425,7 @@ class ReposClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PushRuleBypassRequest], list[PushRuleBypassRequestType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/bypass-requests#list-repository-push-rule-bypass-requests"""
 
@@ -6461,7 +6462,7 @@ class ReposClient:
         repo: str,
         bypass_request_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PushRuleBypassRequest, PushRuleBypassRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/bypass-requests#get-a-repository-push-bypass-request"""
 
@@ -6490,7 +6491,7 @@ class ReposClient:
         repo: str,
         bypass_request_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PushRuleBypassRequest, PushRuleBypassRequestType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/bypass-requests#get-a-repository-push-bypass-request"""
 
@@ -6519,7 +6520,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-codeowners-errors"""
 
@@ -6548,7 +6549,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-codeowners-errors"""
 
@@ -6582,7 +6583,7 @@ class ReposClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#list-repository-collaborators"""
 
@@ -6621,7 +6622,7 @@ class ReposClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#list-repository-collaborators"""
 
@@ -6655,7 +6656,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#check-if-a-user-is-a-repository-collaborator"""
 
@@ -6676,7 +6677,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#check-if-a-user-is-a-repository-collaborator"""
 
@@ -6698,7 +6699,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6710,7 +6711,7 @@ class ReposClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6720,7 +6721,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -6767,7 +6768,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6779,7 +6780,7 @@ class ReposClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6789,7 +6790,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -6835,7 +6836,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#remove-a-repository-collaborator"""
 
@@ -6861,7 +6862,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/collaborators#remove-a-repository-collaborator"""
 
@@ -6887,7 +6888,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
     ]:
@@ -6915,7 +6916,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
     ]:
@@ -6944,7 +6945,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments-for-a-repository"""
 
@@ -6974,7 +6975,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments-for-a-repository"""
 
@@ -7003,7 +7004,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#get-a-commit-comment"""
 
@@ -7029,7 +7030,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#get-a-commit-comment"""
 
@@ -7055,7 +7056,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#delete-a-commit-comment"""
 
@@ -7080,7 +7081,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#delete-a-commit-comment"""
 
@@ -7106,7 +7107,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -7118,7 +7119,7 @@ class ReposClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -7128,7 +7129,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -7171,7 +7172,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -7183,7 +7184,7 @@ class ReposClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -7193,7 +7194,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -7242,7 +7243,7 @@ class ReposClient:
         until: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-commits"""
 
@@ -7290,7 +7291,7 @@ class ReposClient:
         until: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-commits"""
 
@@ -7331,7 +7332,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-branches-for-head-commit"""
 
@@ -7358,7 +7359,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-branches-for-head-commit"""
 
@@ -7387,7 +7388,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments"""
 
@@ -7418,7 +7419,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/comments#list-commit-comments"""
 
@@ -7448,7 +7449,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -7460,7 +7461,7 @@ class ReposClient:
         commit_sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
@@ -7473,7 +7474,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -7520,7 +7521,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -7532,7 +7533,7 @@ class ReposClient:
         commit_sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
@@ -7545,7 +7546,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -7593,7 +7594,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
@@ -7627,7 +7628,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
@@ -7661,7 +7662,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#get-a-commit"""
 
@@ -7704,7 +7705,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#get-a-commit"""
 
@@ -7747,7 +7748,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
@@ -7781,7 +7782,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
@@ -7815,7 +7816,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
@@ -7846,7 +7847,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
@@ -7874,7 +7875,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/community#get-community-profile-metrics"""
 
@@ -7896,7 +7897,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/community#get-community-profile-metrics"""
 
@@ -7921,7 +7922,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#compare-two-commits"""
 
@@ -7961,7 +7962,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/commits/commits#compare-two-commits"""
 
@@ -8000,7 +8001,7 @@ class ReposClient:
         path: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
@@ -8056,7 +8057,7 @@ class ReposClient:
         path: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
@@ -8112,7 +8113,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -8124,7 +8125,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         content: str,
         sha: Missing[str] = UNSET,
@@ -8139,7 +8140,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -8188,7 +8189,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -8200,7 +8201,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         content: str,
         sha: Missing[str] = UNSET,
@@ -8215,7 +8216,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -8264,7 +8265,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -8276,7 +8277,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         sha: str,
         branch: Missing[str] = UNSET,
@@ -8292,7 +8293,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -8340,7 +8341,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -8352,7 +8353,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         sha: str,
         branch: Missing[str] = UNSET,
@@ -8368,7 +8369,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -8417,7 +8418,7 @@ class ReposClient:
         anon: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-contributors"""
 
@@ -8453,7 +8454,7 @@ class ReposClient:
         anon: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-contributors"""
 
@@ -8492,7 +8493,7 @@ class ReposClient:
         environment: Missing[Union[str, None]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#list-deployments"""
 
@@ -8530,7 +8531,7 @@ class ReposClient:
         environment: Missing[Union[str, None]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#list-deployments"""
 
@@ -8563,7 +8564,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
     ) -> Response[Deployment, DeploymentType]: ...
 
@@ -8574,7 +8575,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         task: Missing[str] = UNSET,
         auto_merge: Missing[bool] = UNSET,
@@ -8593,7 +8594,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Deployment, DeploymentType]:
@@ -8635,7 +8636,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
     ) -> Response[Deployment, DeploymentType]: ...
 
@@ -8646,7 +8647,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         task: Missing[str] = UNSET,
         auto_merge: Missing[bool] = UNSET,
@@ -8665,7 +8666,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Deployment, DeploymentType]:
@@ -8707,7 +8708,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#get-a-deployment"""
 
@@ -8733,7 +8734,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#get-a-deployment"""
 
@@ -8759,7 +8760,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#delete-a-deployment"""
 
@@ -8785,7 +8786,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/deployments#delete-a-deployment"""
 
@@ -8813,7 +8814,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#list-deployment-statuses"""
 
@@ -8847,7 +8848,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#list-deployment-statuses"""
 
@@ -8880,7 +8881,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
     ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
@@ -8892,7 +8893,7 @@ class ReposClient:
         deployment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal[
             "error",
             "failure",
@@ -8916,7 +8917,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
@@ -8963,7 +8964,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
     ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
@@ -8975,7 +8976,7 @@ class ReposClient:
         deployment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal[
             "error",
             "failure",
@@ -8999,7 +9000,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
@@ -9046,7 +9047,7 @@ class ReposClient:
         deployment_id: int,
         status_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#get-a-deployment-status"""
 
@@ -9073,7 +9074,7 @@ class ReposClient:
         deployment_id: int,
         status_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/statuses#get-a-deployment-status"""
 
@@ -9099,7 +9100,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -9110,7 +9111,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         event_type: str,
         client_payload: Missing[
             ReposOwnerRepoDispatchesPostBodyPropClientPayloadType
@@ -9122,7 +9123,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDispatchesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -9164,7 +9165,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -9175,7 +9176,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         event_type: str,
         client_payload: Missing[
             ReposOwnerRepoDispatchesPostBodyPropClientPayloadType
@@ -9187,7 +9188,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDispatchesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -9230,7 +9231,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsGetResponse200,
         ReposOwnerRepoEnvironmentsGetResponse200Type,
@@ -9263,7 +9264,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsGetResponse200,
         ReposOwnerRepoEnvironmentsGetResponse200Type,
@@ -9295,7 +9296,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#get-an-environment"""
 
@@ -9318,7 +9319,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#get-an-environment"""
 
@@ -9342,7 +9343,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -9356,7 +9357,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         wait_timer: Missing[int] = UNSET,
         prevent_self_review: Missing[bool] = UNSET,
         reviewers: Missing[
@@ -9378,7 +9379,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -9427,7 +9428,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -9441,7 +9442,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         wait_timer: Missing[int] = UNSET,
         prevent_self_review: Missing[bool] = UNSET,
         reviewers: Missing[
@@ -9463,7 +9464,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -9511,7 +9512,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#delete-an-environment"""
 
@@ -9531,7 +9532,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/environments#delete-an-environment"""
 
@@ -9553,7 +9554,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
@@ -9589,7 +9590,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
@@ -9624,7 +9625,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9636,7 +9637,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
@@ -9647,7 +9648,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9687,7 +9688,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9699,7 +9700,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
@@ -9710,7 +9711,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9750,7 +9751,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
@@ -9774,7 +9775,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
@@ -9799,7 +9800,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9812,7 +9813,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9823,7 +9824,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9860,7 +9861,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9873,7 +9874,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9884,7 +9885,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9920,7 +9921,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#delete-a-deployment-branch-policy"""
 
@@ -9941,7 +9942,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/branch-policies#delete-a-deployment-branch-policy"""
 
@@ -9961,7 +9962,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
@@ -9989,7 +9990,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
@@ -10018,7 +10019,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -10030,7 +10031,7 @@ class ReposClient:
         owner: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         integration_id: Missing[int] = UNSET,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -10040,7 +10041,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
@@ -10084,7 +10085,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -10096,7 +10097,7 @@ class ReposClient:
         owner: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         integration_id: Missing[int] = UNSET,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -10106,7 +10107,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
@@ -10151,7 +10152,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
@@ -10187,7 +10188,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
@@ -10222,7 +10223,7 @@ class ReposClient:
         environment_name: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
@@ -10246,7 +10247,7 @@ class ReposClient:
         environment_name: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
@@ -10270,7 +10271,7 @@ class ReposClient:
         owner: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#disable-a-custom-protection-rule-for-an-environment"""
 
@@ -10291,7 +10292,7 @@ class ReposClient:
         owner: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deployments/protection-rules#disable-a-custom-protection-rule-for-an-environment"""
 
@@ -10313,7 +10314,7 @@ class ReposClient:
         sort: Missing[Literal["newest", "oldest", "stargazers", "watchers"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/forks#list-forks"""
 
@@ -10348,7 +10349,7 @@ class ReposClient:
         sort: Missing[Literal["newest", "oldest", "stargazers", "watchers"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/forks#list-forks"""
 
@@ -10381,7 +10382,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -10392,7 +10393,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
@@ -10403,7 +10404,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -10451,7 +10452,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -10462,7 +10463,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
@@ -10473,7 +10474,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -10522,7 +10523,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-repository-webhooks"""
 
@@ -10555,7 +10556,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-repository-webhooks"""
 
@@ -10587,7 +10588,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
     ) -> Response[Hook, HookType]: ...
 
@@ -10598,7 +10599,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
@@ -10610,7 +10611,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10657,7 +10658,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
     ) -> Response[Hook, HookType]: ...
 
@@ -10668,7 +10669,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
@@ -10680,7 +10681,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10727,7 +10728,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-repository-webhook"""
 
@@ -10753,7 +10754,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-repository-webhook"""
 
@@ -10779,7 +10780,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#delete-a-repository-webhook"""
 
@@ -10804,7 +10805,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#delete-a-repository-webhook"""
 
@@ -10830,7 +10831,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
     ) -> Response[Hook, HookType]: ...
 
@@ -10842,7 +10843,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[WebhookConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         add_events: Missing[list[str]] = UNSET,
@@ -10856,7 +10857,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10901,7 +10902,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
     ) -> Response[Hook, HookType]: ...
 
@@ -10913,7 +10914,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[WebhookConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         add_events: Missing[list[str]] = UNSET,
@@ -10927,7 +10928,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10971,7 +10972,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
@@ -10994,7 +10995,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
@@ -11018,7 +11019,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -11030,7 +11031,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -11043,7 +11044,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -11079,7 +11080,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -11091,7 +11092,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -11104,7 +11105,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -11141,7 +11142,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
@@ -11176,7 +11177,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
@@ -11210,7 +11211,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
@@ -11238,7 +11239,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
@@ -11266,7 +11267,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -11301,7 +11302,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -11335,7 +11336,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#ping-a-repository-webhook"""
 
@@ -11360,7 +11361,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#ping-a-repository-webhook"""
 
@@ -11385,7 +11386,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#test-the-push-repository-webhook"""
 
@@ -11410,7 +11411,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/webhooks#test-the-push-repository-webhook"""
 
@@ -11436,7 +11437,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations"""
 
@@ -11466,7 +11467,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations"""
 
@@ -11495,7 +11496,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#delete-a-repository-invitation"""
 
@@ -11515,7 +11516,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#delete-a-repository-invitation"""
 
@@ -11536,7 +11537,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -11548,7 +11549,7 @@ class ReposClient:
         invitation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
@@ -11560,7 +11561,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -11601,7 +11602,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -11613,7 +11614,7 @@ class ReposClient:
         invitation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
@@ -11625,7 +11626,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -11666,7 +11667,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
@@ -11696,7 +11697,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
@@ -11725,7 +11726,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
     ) -> Response[DeployKey, DeployKeyType]: ...
 
@@ -11736,7 +11737,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
@@ -11747,7 +11748,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[DeployKey, DeployKeyType]:
@@ -11785,7 +11786,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
     ) -> Response[DeployKey, DeployKeyType]: ...
 
@@ -11796,7 +11797,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
@@ -11807,7 +11808,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[DeployKey, DeployKeyType]:
@@ -11845,7 +11846,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
@@ -11871,7 +11872,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
@@ -11897,7 +11898,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#delete-a-deploy-key"""
 
@@ -11917,7 +11918,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/deploy-keys/deploy-keys#delete-a-deploy-key"""
 
@@ -11936,7 +11937,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-languages"""
 
@@ -11958,7 +11959,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-languages"""
 
@@ -11980,7 +11981,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -12006,7 +12007,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -12032,7 +12033,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/lfs#disable-git-lfs-for-a-repository"""
 
@@ -12051,7 +12052,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/lfs#disable-git-lfs-for-a-repository"""
 
@@ -12071,7 +12072,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -12082,7 +12083,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         branch: str,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -12091,7 +12092,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MergedUpstream, MergedUpstreamType]:
@@ -12127,7 +12128,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -12138,7 +12139,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         branch: str,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -12147,7 +12148,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MergedUpstream, MergedUpstreamType]:
@@ -12183,7 +12184,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
     ) -> Response[Commit, CommitType]: ...
 
@@ -12194,7 +12195,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
@@ -12205,7 +12206,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Commit, CommitType]:
@@ -12249,7 +12250,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
     ) -> Response[Commit, CommitType]: ...
 
@@ -12260,7 +12261,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
@@ -12271,7 +12272,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Commit, CommitType]:
@@ -12314,7 +12315,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-apiname-pages-site"""
 
@@ -12339,7 +12340,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-apiname-pages-site"""
 
@@ -12365,7 +12366,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPutBodyAnyof0Type,
             ReposOwnerRepoPagesPutBodyAnyof1Type,
@@ -12382,7 +12383,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Literal["legacy", "workflow"],
@@ -12402,7 +12403,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12420,7 +12421,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Union[str, None],
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12440,7 +12441,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12460,7 +12461,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: bool,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12478,7 +12479,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPutBodyAnyof0Type,
@@ -12544,7 +12545,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPutBodyAnyof0Type,
             ReposOwnerRepoPagesPutBodyAnyof1Type,
@@ -12561,7 +12562,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Literal["legacy", "workflow"],
@@ -12581,7 +12582,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12599,7 +12600,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Union[str, None],
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12619,7 +12620,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12639,7 +12640,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: bool,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -12657,7 +12658,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPutBodyAnyof0Type,
@@ -12723,7 +12724,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPostBodyAnyof0Type,
             None,
@@ -12739,7 +12740,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
     ) -> Response[Page, PageType]: ...
@@ -12751,7 +12752,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
     ) -> Response[Page, PageType]: ...
@@ -12761,7 +12762,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPostBodyAnyof0Type,
@@ -12823,7 +12824,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPostBodyAnyof0Type,
             None,
@@ -12839,7 +12840,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
     ) -> Response[Page, PageType]: ...
@@ -12851,7 +12852,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
     ) -> Response[Page, PageType]: ...
@@ -12861,7 +12862,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPostBodyAnyof0Type,
@@ -12922,7 +12923,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#delete-a-apiname-pages-site"""
 
@@ -12948,7 +12949,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#delete-a-apiname-pages-site"""
 
@@ -12976,7 +12977,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#list-apiname-pages-builds"""
 
@@ -13006,7 +13007,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#list-apiname-pages-builds"""
 
@@ -13034,7 +13035,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#request-a-apiname-pages-build"""
 
@@ -13056,7 +13057,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#request-a-apiname-pages-build"""
 
@@ -13078,7 +13079,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-latest-pages-build"""
 
@@ -13100,7 +13101,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-latest-pages-build"""
 
@@ -13123,7 +13124,7 @@ class ReposClient:
         repo: str,
         build_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-apiname-pages-build"""
 
@@ -13146,7 +13147,7 @@ class ReposClient:
         repo: str,
         build_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-apiname-pages-build"""
 
@@ -13169,7 +13170,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
     ) -> Response[PageDeployment, PageDeploymentType]: ...
 
@@ -13180,7 +13181,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         artifact_id: Missing[float] = UNSET,
         artifact_url: Missing[str] = UNSET,
         environment: Missing[str] = UNSET,
@@ -13193,7 +13194,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PageDeployment, PageDeploymentType]:
@@ -13238,7 +13239,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
     ) -> Response[PageDeployment, PageDeploymentType]: ...
 
@@ -13249,7 +13250,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         artifact_id: Missing[float] = UNSET,
         artifact_url: Missing[str] = UNSET,
         environment: Missing[str] = UNSET,
@@ -13262,7 +13263,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PageDeployment, PageDeploymentType]:
@@ -13307,7 +13308,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
@@ -13333,7 +13334,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
@@ -13359,7 +13360,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#cancel-a-github-pages-deployment"""
 
@@ -13384,7 +13385,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#cancel-a-github-pages-deployment"""
 
@@ -13408,7 +13409,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
@@ -13433,7 +13434,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
@@ -13458,7 +13459,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
@@ -13489,7 +13490,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
@@ -13520,7 +13521,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository"""
 
@@ -13544,7 +13545,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository"""
 
@@ -13568,7 +13569,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository"""
 
@@ -13592,7 +13593,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository"""
 
@@ -13616,7 +13617,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
@@ -13642,7 +13643,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
@@ -13669,7 +13670,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -13680,7 +13681,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
 
@@ -13689,7 +13690,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -13732,7 +13733,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -13743,7 +13744,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
 
@@ -13752,7 +13753,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -13795,7 +13796,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme"""
 
@@ -13827,7 +13828,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme"""
 
@@ -13860,7 +13861,7 @@ class ReposClient:
         dir_: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
@@ -13893,7 +13894,7 @@ class ReposClient:
         dir_: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
@@ -13926,7 +13927,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#list-releases"""
 
@@ -13959,7 +13960,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#list-releases"""
 
@@ -13991,7 +13992,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -14002,7 +14003,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -14019,7 +14020,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -14063,7 +14064,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -14074,7 +14075,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -14091,7 +14092,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -14135,7 +14136,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#get-a-release-asset"""
 
@@ -14161,7 +14162,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#get-a-release-asset"""
 
@@ -14187,7 +14188,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#delete-a-release-asset"""
 
@@ -14207,7 +14208,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#delete-a-release-asset"""
 
@@ -14228,7 +14229,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
     ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
@@ -14240,7 +14241,7 @@ class ReposClient:
         asset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
@@ -14252,7 +14253,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
@@ -14290,7 +14291,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
     ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
@@ -14302,7 +14303,7 @@ class ReposClient:
         asset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
@@ -14314,7 +14315,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
@@ -14351,7 +14352,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
@@ -14362,7 +14363,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
@@ -14374,7 +14375,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
@@ -14418,7 +14419,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
@@ -14429,7 +14430,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
@@ -14441,7 +14442,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
@@ -14484,7 +14485,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-the-latest-release"""
 
@@ -14506,7 +14507,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-the-latest-release"""
 
@@ -14529,7 +14530,7 @@ class ReposClient:
         repo: str,
         tag: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release-by-tag-name"""
 
@@ -14555,7 +14556,7 @@ class ReposClient:
         repo: str,
         tag: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release-by-tag-name"""
 
@@ -14581,7 +14582,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release"""
 
@@ -14605,7 +14606,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#get-a-release"""
 
@@ -14629,7 +14630,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#delete-a-release"""
 
@@ -14649,7 +14650,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/releases#delete-a-release"""
 
@@ -14670,7 +14671,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -14682,7 +14683,7 @@ class ReposClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: Missing[str] = UNSET,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -14699,7 +14700,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -14742,7 +14743,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -14754,7 +14755,7 @@ class ReposClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: Missing[str] = UNSET,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -14771,7 +14772,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -14815,7 +14816,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#list-release-assets"""
 
@@ -14846,7 +14847,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#list-release-assets"""
 
@@ -14877,7 +14878,7 @@ class ReposClient:
         *,
         name: str,
         label: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: FileTypes,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#upload-a-release-asset"""
@@ -14917,7 +14918,7 @@ class ReposClient:
         *,
         name: str,
         label: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: FileTypes,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/releases/assets#upload-a-release-asset"""
@@ -14957,7 +14958,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -15071,7 +15072,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -15186,7 +15187,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         includes_parents: Missing[bool] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-all-repository-rulesets"""
 
@@ -15224,7 +15225,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         includes_parents: Missing[bool] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-all-repository-rulesets"""
 
@@ -15259,7 +15260,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -15270,7 +15271,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -15310,7 +15311,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -15353,7 +15354,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -15364,7 +15365,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -15404,7 +15405,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -15452,7 +15453,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#list-repository-rule-suites"""
 
@@ -15494,7 +15495,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#list-repository-rule-suites"""
 
@@ -15531,7 +15532,7 @@ class ReposClient:
         repo: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#get-a-repository-rule-suite"""
 
@@ -15558,7 +15559,7 @@ class ReposClient:
         repo: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rule-suites#get-a-repository-rule-suite"""
 
@@ -15586,7 +15587,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         includes_parents: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-a-repository-ruleset"""
 
@@ -15619,7 +15620,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         includes_parents: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#get-a-repository-ruleset"""
 
@@ -15652,7 +15653,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -15664,7 +15665,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -15705,7 +15706,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -15749,7 +15750,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -15761,7 +15762,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -15802,7 +15803,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -15845,7 +15846,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#delete-a-repository-ruleset"""
 
@@ -15871,7 +15872,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/rules#delete-a-repository-ruleset"""
 
@@ -15896,7 +15897,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-activity"""
 
@@ -15917,7 +15918,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-activity"""
 
@@ -15938,7 +15939,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
@@ -15960,7 +15961,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
@@ -15982,7 +15983,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-all-contributor-commit-activity"""
 
@@ -16004,7 +16005,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-all-contributor-commit-activity"""
 
@@ -16026,7 +16027,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-count"""
 
@@ -16051,7 +16052,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-weekly-commit-count"""
 
@@ -16076,7 +16077,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
@@ -16096,7 +16097,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
@@ -16118,7 +16119,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
     ) -> Response[Status, StatusType]: ...
 
@@ -16130,7 +16131,7 @@ class ReposClient:
         sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["error", "failure", "pending", "success"],
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
@@ -16143,7 +16144,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Status, StatusType]:
@@ -16179,7 +16180,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
     ) -> Response[Status, StatusType]: ...
 
@@ -16191,7 +16192,7 @@ class ReposClient:
         sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["error", "failure", "pending", "success"],
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
@@ -16204,7 +16205,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Status, StatusType]:
@@ -16240,7 +16241,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-tags"""
 
@@ -16270,7 +16271,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-tags"""
 
@@ -16298,7 +16299,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
@@ -16324,7 +16325,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
@@ -16351,7 +16352,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -16362,7 +16363,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pattern: str,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -16371,7 +16372,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TagProtection, TagProtectionType]:
@@ -16414,7 +16415,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -16425,7 +16426,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pattern: str,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -16434,7 +16435,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TagProtection, TagProtectionType]:
@@ -16477,7 +16478,7 @@ class ReposClient:
         repo: str,
         tag_protection_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---delete-a-tag-protection-state-for-a-repository"""
 
@@ -16503,7 +16504,7 @@ class ReposClient:
         repo: str,
         tag_protection_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/tags#closing-down---delete-a-tag-protection-state-for-a-repository"""
 
@@ -16529,7 +16530,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#download-a-repository-archive-tar"""
 
@@ -16549,7 +16550,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#download-a-repository-archive-tar"""
 
@@ -16570,7 +16571,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-teams"""
 
@@ -16603,7 +16604,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repository-teams"""
 
@@ -16636,7 +16637,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-all-repository-topics"""
 
@@ -16669,7 +16670,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#get-all-repository-topics"""
 
@@ -16701,7 +16702,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
     ) -> Response[Topic, TopicType]: ...
 
@@ -16712,7 +16713,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         names: list[str],
     ) -> Response[Topic, TopicType]: ...
 
@@ -16721,7 +16722,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Topic, TopicType]:
@@ -16765,7 +16766,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
     ) -> Response[Topic, TopicType]: ...
 
@@ -16776,7 +16777,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         names: list[str],
     ) -> Response[Topic, TopicType]: ...
 
@@ -16785,7 +16786,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Topic, TopicType]:
@@ -16829,7 +16830,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-repository-clones"""
 
@@ -16860,7 +16861,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-repository-clones"""
 
@@ -16890,7 +16891,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-paths"""
 
@@ -16915,7 +16916,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-paths"""
 
@@ -16940,7 +16941,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-sources"""
 
@@ -16965,7 +16966,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-top-referral-sources"""
 
@@ -16991,7 +16992,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-page-views"""
 
@@ -17022,7 +17023,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/metrics/traffic#get-page-views"""
 
@@ -17053,7 +17054,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
     ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
@@ -17064,7 +17065,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
@@ -17075,7 +17076,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MinimalRepository, MinimalRepositoryType]:
@@ -17110,7 +17111,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
     ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
@@ -17121,7 +17122,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
@@ -17132,7 +17133,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MinimalRepository, MinimalRepositoryType]:
@@ -17166,7 +17167,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository"""
 
@@ -17186,7 +17187,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository"""
 
@@ -17206,7 +17207,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#enable-vulnerability-alerts"""
 
@@ -17225,7 +17226,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#enable-vulnerability-alerts"""
 
@@ -17244,7 +17245,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#disable-vulnerability-alerts"""
 
@@ -17263,7 +17264,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#disable-vulnerability-alerts"""
 
@@ -17283,7 +17284,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#download-a-repository-archive-zip"""
 
@@ -17303,7 +17304,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/contents#download-a-repository-archive-zip"""
 
@@ -17323,7 +17324,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -17334,7 +17335,7 @@ class ReposClient:
         template_repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         owner: Missing[str] = UNSET,
         name: str,
         description: Missing[str] = UNSET,
@@ -17347,7 +17348,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -17387,7 +17388,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -17398,7 +17399,7 @@ class ReposClient:
         template_repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         owner: Missing[str] = UNSET,
         name: str,
         description: Missing[str] = UNSET,
@@ -17411,7 +17412,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -17449,7 +17450,7 @@ class ReposClient:
         self,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-public-repositories"""
 
@@ -17478,7 +17479,7 @@ class ReposClient:
         self,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-public-repositories"""
 
@@ -17515,7 +17516,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         before: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
@@ -17562,7 +17563,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         before: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
@@ -17599,7 +17600,10 @@ class ReposClient:
 
     @overload
     def create_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
@@ -17607,7 +17611,7 @@ class ReposClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -17640,7 +17644,7 @@ class ReposClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -17683,7 +17687,10 @@ class ReposClient:
 
     @overload
     async def async_create_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
@@ -17691,7 +17698,7 @@ class ReposClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -17724,7 +17731,7 @@ class ReposClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -17770,7 +17777,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
@@ -17803,7 +17810,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
@@ -17835,7 +17842,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#decline-a-repository-invitation"""
 
@@ -17860,7 +17867,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#decline-a-repository-invitation"""
 
@@ -17885,7 +17892,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#accept-a-repository-invitation"""
 
@@ -17910,7 +17917,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/collaborators/invitations#accept-a-repository-invitation"""
 
@@ -17940,7 +17947,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-a-user"""
 
@@ -17975,7 +17982,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/repos/repos#list-repositories-for-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/scim.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/scim.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -61,7 +62,7 @@ class ScimClient:
         start_index: Missing[int] = UNSET,
         count: Missing[int] = UNSET,
         filter_: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimUserList, ScimUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#list-scim-provisioned-identities"""
 
@@ -98,7 +99,7 @@ class ScimClient:
         start_index: Missing[int] = UNSET,
         count: Missing[int] = UNSET,
         filter_: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimUserList, ScimUserListType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#list-scim-provisioned-identities"""
 
@@ -133,7 +134,7 @@ class ScimClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersPostBodyType,
     ) -> Response[ScimUser, ScimUserType]: ...
 
@@ -143,7 +144,7 @@ class ScimClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         user_name: str,
         display_name: Missing[str] = UNSET,
         name: ScimV2OrganizationsOrgUsersPostBodyPropNameType,
@@ -158,7 +159,7 @@ class ScimClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ScimUser, ScimUserType]:
@@ -199,7 +200,7 @@ class ScimClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersPostBodyType,
     ) -> Response[ScimUser, ScimUserType]: ...
 
@@ -209,7 +210,7 @@ class ScimClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         user_name: str,
         display_name: Missing[str] = UNSET,
         name: ScimV2OrganizationsOrgUsersPostBodyPropNameType,
@@ -224,7 +225,7 @@ class ScimClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ScimUser, ScimUserType]:
@@ -265,7 +266,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#get-scim-provisioning-information-for-a-user"""
 
@@ -291,7 +292,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ScimUser, ScimUserType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#get-scim-provisioning-information-for-a-user"""
 
@@ -318,7 +319,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPutBodyType,
     ) -> Response[ScimUser, ScimUserType]: ...
 
@@ -329,7 +330,7 @@ class ScimClient:
         scim_user_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: Missing[list[str]] = UNSET,
         display_name: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -345,7 +346,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ScimUser, ScimUserType]:
@@ -390,7 +391,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPutBodyType,
     ) -> Response[ScimUser, ScimUserType]: ...
 
@@ -401,7 +402,7 @@ class ScimClient:
         scim_user_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: Missing[list[str]] = UNSET,
         display_name: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -417,7 +418,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ScimUser, ScimUserType]:
@@ -461,7 +462,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#delete-a-scim-user-from-an-organization"""
 
@@ -486,7 +487,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/scim/scim#delete-a-scim-user-from-an-organization"""
 
@@ -512,7 +513,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType,
     ) -> Response[ScimUser, ScimUserType]: ...
 
@@ -523,7 +524,7 @@ class ScimClient:
         scim_user_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: Missing[list[str]] = UNSET,
         operations: list[
             ScimV2OrganizationsOrgUsersScimUserIdPatchBodyPropOperationsItemsType
@@ -535,7 +536,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ScimUser, ScimUserType]:
@@ -583,7 +584,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType,
     ) -> Response[ScimUser, ScimUserType]: ...
 
@@ -594,7 +595,7 @@ class ScimClient:
         scim_user_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         schemas: Missing[list[str]] = UNSET,
         operations: list[
             ScimV2OrganizationsOrgUsersScimUserIdPatchBodyPropOperationsItemsType
@@ -606,7 +607,7 @@ class ScimClient:
         org: str,
         scim_user_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ScimV2OrganizationsOrgUsersScimUserIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ScimUser, ScimUserType]:

--- a/githubkit/versions/ghec_v2022_11_28/rest/search.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/search.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional
 from weakref import ref
 
@@ -66,7 +67,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-code"""
 
@@ -110,7 +111,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-code"""
 
@@ -154,7 +155,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-commits"""
 
@@ -188,7 +189,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-commits"""
 
@@ -236,7 +237,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-issues-and-pull-requests"""
 
@@ -294,7 +295,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-issues-and-pull-requests"""
 
@@ -339,7 +340,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-labels"""
 
@@ -380,7 +381,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-labels"""
 
@@ -422,7 +423,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
     ]:
@@ -468,7 +469,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
     ]:
@@ -510,7 +511,7 @@ class SearchClient:
         q: str,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-topics"""
 
@@ -540,7 +541,7 @@ class SearchClient:
         q: str,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-topics"""
 
@@ -572,7 +573,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-users"""
 
@@ -614,7 +615,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/search/search#search-users"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/secret_scanning.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/secret_scanning.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -74,7 +75,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -131,7 +132,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -189,7 +190,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -248,7 +249,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -308,7 +309,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
@@ -364,7 +365,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
@@ -409,7 +410,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
@@ -438,7 +439,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
@@ -468,7 +469,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
@@ -480,7 +481,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "resolved"],
         resolution: Missing[
             Union[
@@ -496,7 +497,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
@@ -543,7 +544,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
@@ -555,7 +556,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "resolved"],
         resolution: Missing[
             Union[
@@ -571,7 +572,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
@@ -619,7 +620,7 @@ class SecretScanningClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
@@ -656,7 +657,7 @@ class SecretScanningClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
@@ -691,7 +692,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
     ) -> Response[
         SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
@@ -704,7 +705,7 @@ class SecretScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
     ) -> Response[
@@ -716,7 +717,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
@@ -764,7 +765,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
     ) -> Response[
         SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
@@ -777,7 +778,7 @@ class SecretScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
     ) -> Response[
@@ -789,7 +790,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
@@ -836,7 +837,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningScanHistory, SecretScanningScanHistoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#get-secret-scanning-scan-history-for-a-repository"""
 
@@ -864,7 +865,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningScanHistory, SecretScanningScanHistoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/secret-scanning/secret-scanning#get-secret-scanning-scan-history-for-a-repository"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/security_advisories.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/security_advisories.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -104,7 +105,7 @@ class SecurityAdvisoriesClient:
         sort: Missing[
             Literal["updated", "published", "epss_percentage", "epss_percentile"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#list-global-security-advisories"""
 
@@ -188,7 +189,7 @@ class SecurityAdvisoriesClient:
         sort: Missing[
             Literal["updated", "published", "epss_percentage", "epss_percentile"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#list-global-security-advisories"""
 
@@ -235,7 +236,7 @@ class SecurityAdvisoriesClient:
         self,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
@@ -259,7 +260,7 @@ class SecurityAdvisoriesClient:
         self,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
@@ -289,7 +290,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
@@ -330,7 +331,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
@@ -372,7 +373,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
@@ -414,7 +415,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
@@ -451,7 +452,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -462,7 +463,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -483,7 +484,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -528,7 +529,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -539,7 +540,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -560,7 +561,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -605,7 +606,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -616,7 +617,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         vulnerabilities: Missing[
@@ -637,7 +638,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -682,7 +683,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -693,7 +694,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         vulnerabilities: Missing[
@@ -714,7 +715,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -759,7 +760,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
@@ -786,7 +787,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
@@ -814,7 +815,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -826,7 +827,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -852,7 +853,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -898,7 +899,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -910,7 +911,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -936,7 +937,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -981,7 +982,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1017,7 +1018,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1053,7 +1054,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 
@@ -1082,7 +1083,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/server_statistics.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/server_statistics.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -46,7 +47,7 @@ class ServerStatisticsClient:
         *,
         date_start: Missing[str] = UNSET,
         date_end: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ServerStatisticsItems], list[ServerStatisticsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/admin-stats#get-github-enterprise-server-statistics"""
 
@@ -75,7 +76,7 @@ class ServerStatisticsClient:
         *,
         date_start: Missing[str] = UNSET,
         date_end: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ServerStatisticsItems], list[ServerStatisticsItemsType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/enterprise-admin/admin-stats#get-github-enterprise-server-statistics"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/teams.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/teams.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -102,7 +103,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ExternalGroup, ExternalGroupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#get-an-external-group"""
 
@@ -132,7 +133,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ExternalGroup, ExternalGroupType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#get-an-external-group"""
 
@@ -162,7 +163,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-external-groups-in-an-organization"""
 
@@ -193,7 +194,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         display_name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-external-groups-in-an-organization"""
 
@@ -224,7 +225,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[str] = UNSET,
         q: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-an-organization"""
 
@@ -255,7 +256,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[str] = UNSET,
         q: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-an-organization"""
 
@@ -285,7 +286,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams"""
 
@@ -317,7 +318,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams"""
 
@@ -348,7 +349,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -358,7 +359,7 @@ class TeamsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         maintainers: Missing[list[str]] = UNSET,
@@ -375,7 +376,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -413,7 +414,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -423,7 +424,7 @@ class TeamsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         maintainers: Missing[list[str]] = UNSET,
@@ -440,7 +441,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -478,7 +479,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-by-name"""
 
@@ -503,7 +504,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-by-name"""
 
@@ -528,7 +529,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#delete-a-team"""
 
@@ -547,7 +548,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#delete-a-team"""
 
@@ -567,7 +568,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -578,7 +579,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -594,7 +595,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -639,7 +640,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -650,7 +651,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -666,7 +667,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -714,7 +715,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         pinned: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions"""
 
@@ -748,7 +749,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         pinned: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions"""
 
@@ -779,7 +780,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -790,7 +791,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -801,7 +802,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -836,7 +837,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -847,7 +848,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -858,7 +859,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -893,7 +894,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion"""
 
@@ -916,7 +917,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion"""
 
@@ -939,7 +940,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#delete-a-discussion"""
 
@@ -959,7 +960,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#delete-a-discussion"""
 
@@ -980,7 +981,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -994,7 +995,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -1005,7 +1006,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -1048,7 +1049,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -1062,7 +1063,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -1073,7 +1074,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -1118,7 +1119,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments"""
 
@@ -1151,7 +1152,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments"""
 
@@ -1182,7 +1183,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1194,7 +1195,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1204,7 +1205,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -1247,7 +1248,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1259,7 +1260,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1269,7 +1270,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -1312,7 +1313,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment"""
 
@@ -1336,7 +1337,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment"""
 
@@ -1360,7 +1361,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#delete-a-discussion-comment"""
 
@@ -1381,7 +1382,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#delete-a-discussion-comment"""
 
@@ -1403,7 +1404,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1416,7 +1417,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1427,7 +1428,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -1472,7 +1473,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1485,7 +1486,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1496,7 +1497,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -1538,7 +1539,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team"""
 
@@ -1560,7 +1561,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ExternalGroups, ExternalGroupsType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#list-a-connection-between-an-external-group-and-a-team"""
 
@@ -1582,7 +1583,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#remove-the-connection-between-an-external-group-and-a-team"""
 
@@ -1601,7 +1602,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/external-groups#remove-the-connection-between-an-external-group-and-a-team"""
 
@@ -1621,7 +1622,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType,
     ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
@@ -1632,7 +1633,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         group_id: int,
     ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
@@ -1641,7 +1642,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ExternalGroup, ExternalGroupType]:
@@ -1678,7 +1679,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType,
     ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
@@ -1689,7 +1690,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         group_id: int,
     ) -> Response[ExternalGroup, ExternalGroupType]: ...
 
@@ -1698,7 +1699,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugExternalGroupsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ExternalGroup, ExternalGroupType]:
@@ -1736,7 +1737,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations"""
 
@@ -1766,7 +1767,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations"""
 
@@ -1797,7 +1798,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members"""
 
@@ -1829,7 +1830,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members"""
 
@@ -1859,7 +1860,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user"""
 
@@ -1883,7 +1884,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user"""
 
@@ -1908,7 +1909,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1920,7 +1921,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1930,7 +1931,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -1972,7 +1973,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1984,7 +1985,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1994,7 +1995,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -2035,7 +2036,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#remove-team-membership-for-a-user"""
 
@@ -2056,7 +2057,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#remove-team-membership-for-a-user"""
 
@@ -2078,7 +2079,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects"""
 
@@ -2108,7 +2109,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects"""
 
@@ -2137,7 +2138,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project"""
 
@@ -2161,7 +2162,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project"""
 
@@ -2186,7 +2187,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -2200,7 +2201,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -2210,7 +2211,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -2257,7 +2258,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -2271,7 +2272,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -2281,7 +2282,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -2327,7 +2328,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-project-from-a-team"""
 
@@ -2347,7 +2348,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-project-from-a-team"""
 
@@ -2368,7 +2369,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories"""
 
@@ -2398,7 +2399,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories"""
 
@@ -2428,7 +2429,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository"""
 
@@ -2453,7 +2454,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository"""
 
@@ -2479,7 +2480,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -2492,7 +2493,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -2503,7 +2504,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2539,7 +2540,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -2552,7 +2553,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -2563,7 +2564,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2598,7 +2599,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-repository-from-a-team"""
 
@@ -2619,7 +2620,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-repository-from-a-team"""
 
@@ -2638,7 +2639,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team"""
 
@@ -2660,7 +2661,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team"""
 
@@ -2683,7 +2684,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType,
     ) -> Response[GroupMapping, GroupMappingType]: ...
 
@@ -2694,7 +2695,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         groups: Missing[
             list[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyPropGroupsItemsType]
         ] = UNSET,
@@ -2705,7 +2706,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GroupMapping, GroupMappingType]:
@@ -2745,7 +2746,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType,
     ) -> Response[GroupMapping, GroupMappingType]: ...
 
@@ -2756,7 +2757,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         groups: Missing[
             list[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyPropGroupsItemsType]
         ] = UNSET,
@@ -2767,7 +2768,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GroupMapping, GroupMappingType]:
@@ -2808,7 +2809,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams"""
 
@@ -2838,7 +2839,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams"""
 
@@ -2865,7 +2866,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-legacy"""
 
@@ -2889,7 +2890,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#get-a-team-legacy"""
 
@@ -2913,7 +2914,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#delete-a-team-legacy"""
 
@@ -2937,7 +2938,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#delete-a-team-legacy"""
 
@@ -2962,7 +2963,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -2972,7 +2973,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -2987,7 +2988,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -3026,7 +3027,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -3036,7 +3037,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -3051,7 +3052,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -3092,7 +3093,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions-legacy"""
 
@@ -3123,7 +3124,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#list-discussions-legacy"""
 
@@ -3152,7 +3153,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -3162,7 +3163,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -3172,7 +3173,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -3206,7 +3207,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -3216,7 +3217,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -3226,7 +3227,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -3260,7 +3261,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion-legacy"""
 
@@ -3282,7 +3283,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#get-a-discussion-legacy"""
 
@@ -3304,7 +3305,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#delete-a-discussion-legacy"""
 
@@ -3323,7 +3324,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussions#delete-a-discussion-legacy"""
 
@@ -3343,7 +3344,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -3354,7 +3355,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -3364,7 +3365,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -3404,7 +3405,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -3415,7 +3416,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -3425,7 +3426,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -3467,7 +3468,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
@@ -3499,7 +3500,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
@@ -3529,7 +3530,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3540,7 +3541,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3549,7 +3550,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -3591,7 +3592,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3602,7 +3603,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3611,7 +3612,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -3653,7 +3654,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
@@ -3676,7 +3677,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
@@ -3699,7 +3700,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#delete-a-discussion-comment-legacy"""
 
@@ -3719,7 +3720,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/discussion-comments#delete-a-discussion-comment-legacy"""
 
@@ -3740,7 +3741,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3752,7 +3753,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3762,7 +3763,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -3806,7 +3807,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3818,7 +3819,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3828,7 +3829,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -3871,7 +3872,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations-legacy"""
 
@@ -3900,7 +3901,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-pending-team-invitations-legacy"""
 
@@ -3930,7 +3931,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members-legacy"""
 
@@ -3964,7 +3965,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#list-team-members-legacy"""
 
@@ -3996,7 +3997,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-member-legacy"""
 
@@ -4016,7 +4017,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-member-legacy"""
 
@@ -4036,7 +4037,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#add-team-member-legacy"""
 
@@ -4060,7 +4061,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#add-team-member-legacy"""
 
@@ -4084,7 +4085,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#remove-team-member-legacy"""
 
@@ -4104,7 +4105,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#remove-team-member-legacy"""
 
@@ -4124,7 +4125,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user-legacy"""
 
@@ -4149,7 +4150,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#get-team-membership-for-a-user-legacy"""
 
@@ -4175,7 +4176,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -4186,7 +4187,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -4195,7 +4196,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -4237,7 +4238,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -4248,7 +4249,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -4257,7 +4258,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -4298,7 +4299,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#remove-team-membership-for-a-user-legacy"""
 
@@ -4318,7 +4319,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/members#remove-team-membership-for-a-user-legacy"""
 
@@ -4339,7 +4340,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects-legacy"""
 
@@ -4371,7 +4372,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-projects-legacy"""
 
@@ -4402,7 +4403,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
@@ -4425,7 +4426,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
@@ -4449,7 +4450,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -4460,7 +4461,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -4469,7 +4470,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4513,7 +4514,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -4524,7 +4525,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -4533,7 +4534,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4576,7 +4577,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-project-from-a-team-legacy"""
 
@@ -4601,7 +4602,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-project-from-a-team-legacy"""
 
@@ -4627,7 +4628,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories-legacy"""
 
@@ -4659,7 +4660,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-team-repositories-legacy"""
 
@@ -4691,7 +4692,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
@@ -4715,7 +4716,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
@@ -4740,7 +4741,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -4752,7 +4753,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -4762,7 +4763,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4805,7 +4806,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -4817,7 +4818,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -4827,7 +4828,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4869,7 +4870,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-repository-from-a-team-legacy"""
 
@@ -4889,7 +4890,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#remove-a-repository-from-a-team-legacy"""
 
@@ -4907,7 +4908,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team-legacy"""
 
@@ -4932,7 +4933,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GroupMapping, GroupMappingType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/team-sync#list-idp-groups-for-a-team-legacy"""
 
@@ -4958,7 +4959,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdTeamSyncGroupMappingsPatchBodyType,
     ) -> Response[GroupMapping, GroupMappingType]: ...
 
@@ -4968,7 +4969,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         groups: list[TeamsTeamIdTeamSyncGroupMappingsPatchBodyPropGroupsItemsType],
         synced_at: Missing[str] = UNSET,
     ) -> Response[GroupMapping, GroupMappingType]: ...
@@ -4977,7 +4978,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GroupMapping, GroupMappingType]:
@@ -5020,7 +5021,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdTeamSyncGroupMappingsPatchBodyType,
     ) -> Response[GroupMapping, GroupMappingType]: ...
 
@@ -5030,7 +5031,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         groups: list[TeamsTeamIdTeamSyncGroupMappingsPatchBodyPropGroupsItemsType],
         synced_at: Missing[str] = UNSET,
     ) -> Response[GroupMapping, GroupMappingType]: ...
@@ -5039,7 +5040,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdTeamSyncGroupMappingsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GroupMapping, GroupMappingType]:
@@ -5083,7 +5084,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams-legacy"""
 
@@ -5117,7 +5118,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-child-teams-legacy"""
 
@@ -5150,7 +5151,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams-for-the-authenticated-user"""
 
@@ -5182,7 +5183,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/teams/teams#list-teams-for-the-authenticated-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/rest/users.py
+++ b/githubkit/versions/ghec_v2022_11_28/rest/users.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Literal, Optional, overload
 from weakref import ref
 
@@ -81,7 +82,7 @@ class UsersClient:
     def get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -109,7 +110,7 @@ class UsersClient:
     async def async_get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -138,7 +139,7 @@ class UsersClient:
     def update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
     ) -> Response[PrivateUser, PrivateUserType]: ...
 
@@ -147,7 +148,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
         blog: Missing[str] = UNSET,
@@ -161,7 +162,7 @@ class UsersClient:
     def update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PrivateUser, PrivateUserType]:
@@ -200,7 +201,7 @@ class UsersClient:
     async def async_update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
     ) -> Response[PrivateUser, PrivateUserType]: ...
 
@@ -209,7 +210,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
         blog: Missing[str] = UNSET,
@@ -223,7 +224,7 @@ class UsersClient:
     async def async_update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PrivateUser, PrivateUserType]:
@@ -263,7 +264,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
@@ -296,7 +297,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
@@ -328,7 +329,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#check-if-a-user-is-blocked-by-the-authenticated-user"""
 
@@ -353,7 +354,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#check-if-a-user-is-blocked-by-the-authenticated-user"""
 
@@ -378,7 +379,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#block-a-user"""
 
@@ -404,7 +405,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#block-a-user"""
 
@@ -430,7 +431,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#unblock-a-user"""
 
@@ -455,7 +456,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/blocking#unblock-a-user"""
 
@@ -480,7 +481,7 @@ class UsersClient:
     def set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -489,14 +490,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal["public", "private"],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     def set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -540,7 +541,7 @@ class UsersClient:
     async def async_set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -549,14 +550,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal["public", "private"],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -601,7 +602,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
@@ -634,7 +635,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
@@ -666,7 +667,7 @@ class UsersClient:
     def add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -675,14 +676,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     def add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -737,7 +738,7 @@ class UsersClient:
     async def async_add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -746,14 +747,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -808,7 +809,7 @@ class UsersClient:
     def delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response: ...
 
@@ -817,14 +818,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response: ...
 
     def delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response:
@@ -873,7 +874,7 @@ class UsersClient:
     async def async_delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response: ...
 
@@ -882,14 +883,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response: ...
 
     async def async_delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response:
@@ -939,7 +940,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-the-authenticated-user"""
 
@@ -971,7 +972,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-the-authenticated-user"""
 
@@ -1003,7 +1004,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
@@ -1035,7 +1036,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
@@ -1066,7 +1067,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#check-if-a-person-is-followed-by-the-authenticated-user"""
 
@@ -1091,7 +1092,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#check-if-a-person-is-followed-by-the-authenticated-user"""
 
@@ -1116,7 +1117,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#follow-a-user"""
 
@@ -1142,7 +1143,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#follow-a-user"""
 
@@ -1168,7 +1169,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#unfollow-a-user"""
 
@@ -1193,7 +1194,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#unfollow-a-user"""
 
@@ -1219,7 +1220,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
@@ -1252,7 +1253,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
@@ -1282,7 +1283,10 @@ class UsersClient:
 
     @overload
     def create_gpg_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserGpgKeysPostBodyType,
     ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
@@ -1290,7 +1294,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
     ) -> Response[GpgKey, GpgKeyType]: ...
@@ -1298,7 +1302,7 @@ class UsersClient:
     def create_gpg_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GpgKey, GpgKeyType]:
@@ -1335,7 +1339,10 @@ class UsersClient:
 
     @overload
     async def async_create_gpg_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserGpgKeysPostBodyType,
     ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
@@ -1343,7 +1350,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
     ) -> Response[GpgKey, GpgKeyType]: ...
@@ -1351,7 +1358,7 @@ class UsersClient:
     async def async_create_gpg_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GpgKey, GpgKeyType]:
@@ -1390,7 +1397,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
@@ -1416,7 +1423,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
@@ -1442,7 +1449,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user"""
 
@@ -1468,7 +1475,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user"""
 
@@ -1495,7 +1502,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
@@ -1528,7 +1535,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
@@ -1558,7 +1565,7 @@ class UsersClient:
 
     @overload
     def create_public_ssh_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: UserKeysPostBodyType
     ) -> Response[Key, KeyType]: ...
 
     @overload
@@ -1566,7 +1573,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[Key, KeyType]: ...
@@ -1574,7 +1581,7 @@ class UsersClient:
     def create_public_ssh_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Key, KeyType]:
@@ -1611,7 +1618,7 @@ class UsersClient:
 
     @overload
     async def async_create_public_ssh_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: UserKeysPostBodyType
     ) -> Response[Key, KeyType]: ...
 
     @overload
@@ -1619,7 +1626,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[Key, KeyType]: ...
@@ -1627,7 +1634,7 @@ class UsersClient:
     async def async_create_public_ssh_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Key, KeyType]:
@@ -1666,7 +1673,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1692,7 +1699,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1718,7 +1725,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1743,7 +1750,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1769,7 +1776,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
@@ -1802,7 +1809,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
@@ -1835,7 +1842,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
@@ -1868,7 +1875,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
@@ -1900,7 +1907,7 @@ class UsersClient:
     def add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
@@ -1909,14 +1916,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     def add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
@@ -1960,7 +1967,7 @@ class UsersClient:
     async def async_add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
@@ -1969,14 +1976,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     async def async_add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
@@ -2020,7 +2027,7 @@ class UsersClient:
     def delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsDeleteBodyType,
     ) -> Response: ...
 
@@ -2029,14 +2036,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response: ...
 
     def delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2074,7 +2081,7 @@ class UsersClient:
     async def async_delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsDeleteBodyType,
     ) -> Response: ...
 
@@ -2083,14 +2090,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response: ...
 
     async def async_delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2129,7 +2136,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
@@ -2162,7 +2169,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
@@ -2194,7 +2201,7 @@ class UsersClient:
     def create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
@@ -2203,7 +2210,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
@@ -2211,7 +2218,7 @@ class UsersClient:
     def create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
@@ -2255,7 +2262,7 @@ class UsersClient:
     async def async_create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
@@ -2264,7 +2271,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
@@ -2272,7 +2279,7 @@ class UsersClient:
     async def async_create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
@@ -2316,7 +2323,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2342,7 +2349,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2368,7 +2375,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2393,7 +2400,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2418,7 +2425,7 @@ class UsersClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2446,7 +2453,7 @@ class UsersClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2475,7 +2482,7 @@ class UsersClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#list-users"""
 
@@ -2503,7 +2510,7 @@ class UsersClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#list-users"""
 
@@ -2530,7 +2537,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2558,7 +2565,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2590,7 +2597,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UsersUsernameAttestationsSubjectDigestGetResponse200,
         UsersUsernameAttestationsSubjectDigestGetResponse200Type,
@@ -2631,7 +2638,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UsersUsernameAttestationsSubjectDigestGetResponse200,
         UsersUsernameAttestationsSubjectDigestGetResponse200Type,
@@ -2670,7 +2677,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-a-user"""
 
@@ -2699,7 +2706,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-followers-of-a-user"""
 
@@ -2728,7 +2735,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-a-user-follows"""
 
@@ -2757,7 +2764,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#list-the-people-a-user-follows"""
 
@@ -2785,7 +2792,7 @@ class UsersClient:
         username: str,
         target_user: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#check-if-a-user-follows-another-user"""
 
@@ -2805,7 +2812,7 @@ class UsersClient:
         username: str,
         target_user: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/followers#check-if-a-user-follows-another-user"""
 
@@ -2826,7 +2833,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
@@ -2855,7 +2862,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
@@ -2886,7 +2893,7 @@ class UsersClient:
             Literal["organization", "repository", "issue", "pull_request"]
         ] = UNSET,
         subject_id: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-contextual-information-for-a-user"""
 
@@ -2921,7 +2928,7 @@ class UsersClient:
             Literal["organization", "repository", "issue", "pull_request"]
         ] = UNSET,
         subject_id: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/users#get-contextual-information-for-a-user"""
 
@@ -2954,7 +2961,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-keys-for-a-user"""
 
@@ -2983,7 +2990,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/keys#list-public-keys-for-a-user"""
 
@@ -3012,7 +3019,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-a-user"""
 
@@ -3041,7 +3048,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/social-accounts#list-social-accounts-for-a-user"""
 
@@ -3070,7 +3077,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 
@@ -3099,7 +3106,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/enterprise-cloud@latest//rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 

--- a/githubkit/versions/ghec_v2022_11_28/webhooks/_namespace.py
+++ b/githubkit/versions/ghec_v2022_11_28/webhooks/_namespace.py
@@ -7,6 +7,7 @@ bash ./scripts/run-codegen.sh
 See https://github.com/github/rest-api-description for more information.
 """
 
+from collections.abc import Mapping
 import hmac
 import importlib
 import json
@@ -653,7 +654,7 @@ class WebhookNamespace:
         return type_validate_json(Event, payload)
 
     @staticmethod
-    def parse_obj_without_name(payload: dict[str, Any]) -> "WebhookEvent":
+    def parse_obj_without_name(payload: Mapping[str, Any]) -> "WebhookEvent":
         """Parse the webhook payload dict without event name.
 
         Note:
@@ -663,7 +664,7 @@ class WebhookNamespace:
             the result may not be the correct type as expected.
 
         Args:
-            payload (dict[str, Any]): webhook payload dict.
+            payload (Mapping[str, Any]): webhook payload dict.
         """
 
         from ._types import WebhookEvent
@@ -673,385 +674,391 @@ class WebhookNamespace:
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["branch_protection_configuration"], payload: dict[str, Any]
+        name: Literal["branch_protection_configuration"], payload: Mapping[str, Any]
     ) -> "BranchProtectionConfigurationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["branch_protection_rule"], payload: dict[str, Any]
+        name: Literal["branch_protection_rule"], payload: Mapping[str, Any]
     ) -> "BranchProtectionRuleEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["exemption_request_push_ruleset"], payload: dict[str, Any]
+        name: Literal["exemption_request_push_ruleset"], payload: Mapping[str, Any]
     ) -> "ExemptionRequestPushRulesetEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["exemption_request_secret_scanning"], payload: dict[str, Any]
+        name: Literal["exemption_request_secret_scanning"], payload: Mapping[str, Any]
     ) -> "ExemptionRequestSecretScanningEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["check_run"], payload: dict[str, Any]
+        name: Literal["check_run"], payload: Mapping[str, Any]
     ) -> "CheckRunEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["check_suite"], payload: dict[str, Any]
+        name: Literal["check_suite"], payload: Mapping[str, Any]
     ) -> "CheckSuiteEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["code_scanning_alert"], payload: dict[str, Any]
+        name: Literal["code_scanning_alert"], payload: Mapping[str, Any]
     ) -> "CodeScanningAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["commit_comment"], payload: dict[str, Any]
+        name: Literal["commit_comment"], payload: Mapping[str, Any]
     ) -> "CommitCommentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["create"], payload: dict[str, Any]
+        name: Literal["create"], payload: Mapping[str, Any]
     ) -> "CreateEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["custom_property"], payload: dict[str, Any]
+        name: Literal["custom_property"], payload: Mapping[str, Any]
     ) -> "CustomPropertyEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["custom_property_values"], payload: dict[str, Any]
+        name: Literal["custom_property_values"], payload: Mapping[str, Any]
     ) -> "CustomPropertyValuesEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["delete"], payload: dict[str, Any]
+        name: Literal["delete"], payload: Mapping[str, Any]
     ) -> "DeleteEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["dependabot_alert"], payload: dict[str, Any]
+        name: Literal["dependabot_alert"], payload: Mapping[str, Any]
     ) -> "DependabotAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deploy_key"], payload: dict[str, Any]
+        name: Literal["deploy_key"], payload: Mapping[str, Any]
     ) -> "DeployKeyEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment"], payload: dict[str, Any]
+        name: Literal["deployment"], payload: Mapping[str, Any]
     ) -> "DeploymentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment_protection_rule"], payload: dict[str, Any]
+        name: Literal["deployment_protection_rule"], payload: Mapping[str, Any]
     ) -> "DeploymentProtectionRuleEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment_review"], payload: dict[str, Any]
+        name: Literal["deployment_review"], payload: Mapping[str, Any]
     ) -> "DeploymentReviewEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment_status"], payload: dict[str, Any]
+        name: Literal["deployment_status"], payload: Mapping[str, Any]
     ) -> "DeploymentStatusEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["discussion"], payload: dict[str, Any]
+        name: Literal["discussion"], payload: Mapping[str, Any]
     ) -> "DiscussionEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["discussion_comment"], payload: dict[str, Any]
+        name: Literal["discussion_comment"], payload: Mapping[str, Any]
     ) -> "DiscussionCommentEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["fork"], payload: dict[str, Any]) -> "ForkEvent": ...
+    def parse_obj(name: Literal["fork"], payload: Mapping[str, Any]) -> "ForkEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["github_app_authorization"], payload: dict[str, Any]
+        name: Literal["github_app_authorization"], payload: Mapping[str, Any]
     ) -> "GithubAppAuthorizationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["gollum"], payload: dict[str, Any]
+        name: Literal["gollum"], payload: Mapping[str, Any]
     ) -> "GollumEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["installation"], payload: dict[str, Any]
+        name: Literal["installation"], payload: Mapping[str, Any]
     ) -> "InstallationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["installation_repositories"], payload: dict[str, Any]
+        name: Literal["installation_repositories"], payload: Mapping[str, Any]
     ) -> "InstallationRepositoriesEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["installation_target"], payload: dict[str, Any]
+        name: Literal["installation_target"], payload: Mapping[str, Any]
     ) -> "InstallationTargetEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["issue_comment"], payload: dict[str, Any]
+        name: Literal["issue_comment"], payload: Mapping[str, Any]
     ) -> "IssueCommentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["issues"], payload: dict[str, Any]
+        name: Literal["issues"], payload: Mapping[str, Any]
     ) -> "IssuesEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["label"], payload: dict[str, Any]) -> "LabelEvent": ...
+    def parse_obj(
+        name: Literal["label"], payload: Mapping[str, Any]
+    ) -> "LabelEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["marketplace_purchase"], payload: dict[str, Any]
+        name: Literal["marketplace_purchase"], payload: Mapping[str, Any]
     ) -> "MarketplacePurchaseEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["member"], payload: dict[str, Any]
+        name: Literal["member"], payload: Mapping[str, Any]
     ) -> "MemberEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["membership"], payload: dict[str, Any]
+        name: Literal["membership"], payload: Mapping[str, Any]
     ) -> "MembershipEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["merge_group"], payload: dict[str, Any]
+        name: Literal["merge_group"], payload: Mapping[str, Any]
     ) -> "MergeGroupEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["meta"], payload: dict[str, Any]) -> "MetaEvent": ...
+    def parse_obj(name: Literal["meta"], payload: Mapping[str, Any]) -> "MetaEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["milestone"], payload: dict[str, Any]
+        name: Literal["milestone"], payload: Mapping[str, Any]
     ) -> "MilestoneEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["org_block"], payload: dict[str, Any]
+        name: Literal["org_block"], payload: Mapping[str, Any]
     ) -> "OrgBlockEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["organization"], payload: dict[str, Any]
+        name: Literal["organization"], payload: Mapping[str, Any]
     ) -> "OrganizationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["package"], payload: dict[str, Any]
+        name: Literal["package"], payload: Mapping[str, Any]
     ) -> "PackageEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["page_build"], payload: dict[str, Any]
+        name: Literal["page_build"], payload: Mapping[str, Any]
     ) -> "PageBuildEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["personal_access_token_request"], payload: dict[str, Any]
+        name: Literal["personal_access_token_request"], payload: Mapping[str, Any]
     ) -> "PersonalAccessTokenRequestEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["ping"], payload: dict[str, Any]) -> "PingEvent": ...
+    def parse_obj(name: Literal["ping"], payload: Mapping[str, Any]) -> "PingEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["project_card"], payload: dict[str, Any]
+        name: Literal["project_card"], payload: Mapping[str, Any]
     ) -> "ProjectCardEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["project"], payload: dict[str, Any]
+        name: Literal["project"], payload: Mapping[str, Any]
     ) -> "ProjectEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["project_column"], payload: dict[str, Any]
+        name: Literal["project_column"], payload: Mapping[str, Any]
     ) -> "ProjectColumnEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["projects_v2"], payload: dict[str, Any]
+        name: Literal["projects_v2"], payload: Mapping[str, Any]
     ) -> "ProjectsV2Event": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["projects_v2_item"], payload: dict[str, Any]
+        name: Literal["projects_v2_item"], payload: Mapping[str, Any]
     ) -> "ProjectsV2ItemEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["projects_v2_status_update"], payload: dict[str, Any]
+        name: Literal["projects_v2_status_update"], payload: Mapping[str, Any]
     ) -> "ProjectsV2StatusUpdateEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["public"], payload: dict[str, Any]
+        name: Literal["public"], payload: Mapping[str, Any]
     ) -> "PublicEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request"], payload: dict[str, Any]
+        name: Literal["pull_request"], payload: Mapping[str, Any]
     ) -> "PullRequestEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request_review_comment"], payload: dict[str, Any]
+        name: Literal["pull_request_review_comment"], payload: Mapping[str, Any]
     ) -> "PullRequestReviewCommentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request_review"], payload: dict[str, Any]
+        name: Literal["pull_request_review"], payload: Mapping[str, Any]
     ) -> "PullRequestReviewEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request_review_thread"], payload: dict[str, Any]
+        name: Literal["pull_request_review_thread"], payload: Mapping[str, Any]
     ) -> "PullRequestReviewThreadEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["push"], payload: dict[str, Any]) -> "PushEvent": ...
+    def parse_obj(name: Literal["push"], payload: Mapping[str, Any]) -> "PushEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["registry_package"], payload: dict[str, Any]
+        name: Literal["registry_package"], payload: Mapping[str, Any]
     ) -> "RegistryPackageEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["release"], payload: dict[str, Any]
+        name: Literal["release"], payload: Mapping[str, Any]
     ) -> "ReleaseEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_advisory"], payload: dict[str, Any]
+        name: Literal["repository_advisory"], payload: Mapping[str, Any]
     ) -> "RepositoryAdvisoryEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository"], payload: dict[str, Any]
+        name: Literal["repository"], payload: Mapping[str, Any]
     ) -> "RepositoryEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_dispatch"], payload: dict[str, Any]
+        name: Literal["repository_dispatch"], payload: Mapping[str, Any]
     ) -> "RepositoryDispatchEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_import"], payload: dict[str, Any]
+        name: Literal["repository_import"], payload: Mapping[str, Any]
     ) -> "RepositoryImportEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_ruleset"], payload: dict[str, Any]
+        name: Literal["repository_ruleset"], payload: Mapping[str, Any]
     ) -> "RepositoryRulesetEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_vulnerability_alert"], payload: dict[str, Any]
+        name: Literal["repository_vulnerability_alert"], payload: Mapping[str, Any]
     ) -> "RepositoryVulnerabilityAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["secret_scanning_alert"], payload: dict[str, Any]
+        name: Literal["secret_scanning_alert"], payload: Mapping[str, Any]
     ) -> "SecretScanningAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["secret_scanning_alert_location"], payload: dict[str, Any]
+        name: Literal["secret_scanning_alert_location"], payload: Mapping[str, Any]
     ) -> "SecretScanningAlertLocationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["secret_scanning_scan"], payload: dict[str, Any]
+        name: Literal["secret_scanning_scan"], payload: Mapping[str, Any]
     ) -> "SecretScanningScanEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["security_advisory"], payload: dict[str, Any]
+        name: Literal["security_advisory"], payload: Mapping[str, Any]
     ) -> "SecurityAdvisoryEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["security_and_analysis"], payload: dict[str, Any]
+        name: Literal["security_and_analysis"], payload: Mapping[str, Any]
     ) -> "SecurityAndAnalysisEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["sponsorship"], payload: dict[str, Any]
+        name: Literal["sponsorship"], payload: Mapping[str, Any]
     ) -> "SponsorshipEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["star"], payload: dict[str, Any]) -> "StarEvent": ...
+    def parse_obj(name: Literal["star"], payload: Mapping[str, Any]) -> "StarEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["status"], payload: dict[str, Any]
+        name: Literal["status"], payload: Mapping[str, Any]
     ) -> "StatusEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["sub_issues"], payload: dict[str, Any]
+        name: Literal["sub_issues"], payload: Mapping[str, Any]
     ) -> "SubIssuesEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["team_add"], payload: dict[str, Any]
+        name: Literal["team_add"], payload: Mapping[str, Any]
     ) -> "TeamAddEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["team"], payload: dict[str, Any]) -> "TeamEvent": ...
-    @overload
-    @staticmethod
-    def parse_obj(name: Literal["watch"], payload: dict[str, Any]) -> "WatchEvent": ...
+    def parse_obj(name: Literal["team"], payload: Mapping[str, Any]) -> "TeamEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["workflow_dispatch"], payload: dict[str, Any]
+        name: Literal["watch"], payload: Mapping[str, Any]
+    ) -> "WatchEvent": ...
+    @overload
+    @staticmethod
+    def parse_obj(
+        name: Literal["workflow_dispatch"], payload: Mapping[str, Any]
     ) -> "WorkflowDispatchEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["workflow_job"], payload: dict[str, Any]
+        name: Literal["workflow_job"], payload: Mapping[str, Any]
     ) -> "WorkflowJobEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["workflow_run"], payload: dict[str, Any]
+        name: Literal["workflow_run"], payload: Mapping[str, Any]
     ) -> "WorkflowRunEvent": ...
 
     @overload
     @staticmethod
-    def parse_obj(name: EventNameType, payload: dict[str, Any]) -> "WebhookEvent": ...
+    def parse_obj(
+        name: EventNameType, payload: Mapping[str, Any]
+    ) -> "WebhookEvent": ...
 
     @overload
     @staticmethod
-    def parse_obj(name: str, payload: dict[str, Any]) -> "WebhookEvent": ...
+    def parse_obj(name: str, payload: Mapping[str, Any]) -> "WebhookEvent": ...
 
     @staticmethod
     def parse_obj(
-        name: Union[EventNameType, str], payload: dict[str, Any]
+        name: Union[EventNameType, str], payload: Mapping[str, Any]
     ) -> "WebhookEvent":
         """Parse the webhook payload dict with event name.
 
         Args:
             name (EventNameType): event name.
-            payload (dict[str, Any]): webhook payload dict.
+            payload (Mapping[str, Any]): webhook payload dict.
         """
 
         if name not in VALID_EVENT_NAMES:

--- a/githubkit/versions/v2022_11_28/rest/actions.py
+++ b/githubkit/versions/v2022_11_28/rest/actions.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -195,7 +196,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
@@ -216,7 +217,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageOrgEnterprise, ActionsCacheUsageOrgEnterpriseType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-an-organization"""
 
@@ -239,7 +240,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
@@ -271,7 +272,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200,
         OrgsOrgActionsCacheUsageByRepositoryGetResponse200Type,
@@ -301,7 +302,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
@@ -322,7 +323,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsOrganizationPermissions, ActionsOrganizationPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-an-organization"""
 
@@ -344,7 +345,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -354,7 +355,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled_repositories: Literal["all", "none", "selected"],
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -363,7 +364,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -396,7 +397,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -406,7 +407,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled_repositories: Literal["all", "none", "selected"],
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -415,7 +416,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -449,7 +450,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsPermissionsRepositoriesGetResponse200,
         OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
@@ -481,7 +482,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsPermissionsRepositoriesGetResponse200,
         OrgsOrgActionsPermissionsRepositoriesGetResponse200Type,
@@ -512,7 +513,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -522,7 +523,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -530,7 +531,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -565,7 +566,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsPermissionsRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -575,7 +576,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -583,7 +584,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsPermissionsRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -618,7 +619,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/permissions#enable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -637,7 +638,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/permissions#enable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -656,7 +657,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/permissions#disable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -675,7 +676,7 @@ class ActionsClient:
         org: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/permissions#disable-a-selected-repository-for-github-actions-in-an-organization"""
 
@@ -693,7 +694,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
@@ -714,7 +715,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization"""
 
@@ -736,7 +737,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -746,7 +747,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -756,7 +757,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -789,7 +790,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -799,7 +800,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -809,7 +810,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -841,7 +842,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -864,7 +865,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -888,7 +889,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
     ) -> Response: ...
 
@@ -898,7 +899,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -907,7 +908,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -940,7 +941,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
     ) -> Response: ...
 
@@ -950,7 +951,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -959,7 +960,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -994,7 +995,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         visible_to_repository: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsGetResponse200,
         OrgsOrgActionsRunnerGroupsGetResponse200Type,
@@ -1028,7 +1029,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         visible_to_repository: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsGetResponse200,
         OrgsOrgActionsRunnerGroupsGetResponse200Type,
@@ -1060,7 +1061,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1070,7 +1071,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -1084,7 +1085,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1118,7 +1119,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsPostBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1128,7 +1129,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -1142,7 +1143,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1176,7 +1177,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
@@ -1198,7 +1199,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#get-a-self-hosted-runner-group-for-an-organization"""
 
@@ -1220,7 +1221,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-organization"""
 
@@ -1239,7 +1240,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#delete-a-self-hosted-runner-group-from-an-organization"""
 
@@ -1259,7 +1260,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1270,7 +1271,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         allows_public_repositories: Missing[bool] = UNSET,
@@ -1283,7 +1284,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1323,7 +1324,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]: ...
 
@@ -1334,7 +1335,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         visibility: Missing[Literal["selected", "all", "private"]] = UNSET,
         allows_public_repositories: Missing[bool] = UNSET,
@@ -1347,7 +1348,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnerGroupsRunnerGroupIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RunnerGroupsOrg, RunnerGroupsOrgType]:
@@ -1388,7 +1389,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
@@ -1423,7 +1424,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesGetResponse200Type,
@@ -1457,7 +1458,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1468,7 +1469,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1477,7 +1478,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType
         ] = UNSET,
@@ -1515,7 +1516,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1526,7 +1527,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1535,7 +1536,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRepositoriesPutBodyType
         ] = UNSET,
@@ -1573,7 +1574,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#add-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -1593,7 +1594,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#add-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -1613,7 +1614,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -1633,7 +1634,7 @@ class ActionsClient:
         runner_group_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization"""
 
@@ -1654,7 +1655,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
@@ -1689,7 +1690,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200,
         OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersGetResponse200Type,
@@ -1723,7 +1724,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
     ) -> Response: ...
 
@@ -1734,7 +1735,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         runners: list[int],
     ) -> Response: ...
 
@@ -1743,7 +1744,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType
         ] = UNSET,
@@ -1781,7 +1782,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType,
     ) -> Response: ...
 
@@ -1792,7 +1793,7 @@ class ActionsClient:
         runner_group_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         runners: list[int],
     ) -> Response: ...
 
@@ -1801,7 +1802,7 @@ class ActionsClient:
         org: str,
         runner_group_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgActionsRunnerGroupsRunnerGroupIdRunnersPutBodyType
         ] = UNSET,
@@ -1839,7 +1840,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-organization"""
 
@@ -1859,7 +1860,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#add-a-self-hosted-runner-to-a-group-for-an-organization"""
 
@@ -1879,7 +1880,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-organization"""
 
@@ -1899,7 +1900,7 @@ class ActionsClient:
         runner_group_id: int,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runner-groups#remove-a-self-hosted-runner-from-a-group-for-an-organization"""
 
@@ -1920,7 +1921,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
     ]:
@@ -1953,7 +1954,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersGetResponse200, OrgsOrgActionsRunnersGetResponse200Type
     ]:
@@ -1983,7 +1984,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
@@ -2004,7 +2005,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-an-organization"""
 
@@ -2026,7 +2027,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
@@ -2039,7 +2040,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -2053,7 +2054,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2101,7 +2102,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
@@ -2114,7 +2115,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -2128,7 +2129,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersGenerateJitconfigPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2175,7 +2176,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
@@ -2196,7 +2197,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization"""
 
@@ -2217,7 +2218,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
@@ -2238,7 +2239,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-an-organization"""
 
@@ -2260,7 +2261,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
@@ -2282,7 +2283,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization"""
 
@@ -2304,7 +2305,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization"""
 
@@ -2323,7 +2324,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization"""
 
@@ -2342,7 +2343,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2373,7 +2374,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2405,7 +2406,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2419,7 +2420,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2431,7 +2432,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2480,7 +2481,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2494,7 +2495,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2506,7 +2507,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2555,7 +2556,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2569,7 +2570,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2581,7 +2582,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2630,7 +2631,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2644,7 +2645,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -2656,7 +2657,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -2704,7 +2705,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -2735,7 +2736,7 @@ class ActionsClient:
         org: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -2767,7 +2768,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2801,7 +2802,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -2835,7 +2836,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
     ]:
@@ -2866,7 +2867,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsGetResponse200, OrgsOrgActionsSecretsGetResponse200Type
     ]:
@@ -2895,7 +2896,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-public-key"""
 
@@ -2916,7 +2917,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-public-key"""
 
@@ -2938,7 +2939,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-secret"""
 
@@ -2960,7 +2961,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsSecret, OrganizationActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-organization-secret"""
 
@@ -2983,7 +2984,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2994,7 +2995,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -3006,7 +3007,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3041,7 +3042,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3052,7 +3053,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -3064,7 +3065,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3098,7 +3099,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#delete-an-organization-secret"""
 
@@ -3117,7 +3118,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#delete-an-organization-secret"""
 
@@ -3138,7 +3139,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3171,7 +3172,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgActionsSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3203,7 +3204,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3214,7 +3215,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3223,7 +3224,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3259,7 +3260,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3270,7 +3271,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3279,7 +3280,7 @@ class ActionsClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3315,7 +3316,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -3336,7 +3337,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -3357,7 +3358,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -3378,7 +3379,7 @@ class ActionsClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -3399,7 +3400,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
     ]:
@@ -3430,7 +3431,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesGetResponse200, OrgsOrgActionsVariablesGetResponse200Type
     ]:
@@ -3460,7 +3461,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3470,7 +3471,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
         visibility: Literal["all", "private", "selected"],
@@ -3481,7 +3482,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3515,7 +3516,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -3525,7 +3526,7 @@ class ActionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
         visibility: Literal["all", "private", "selected"],
@@ -3536,7 +3537,7 @@ class ActionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3570,7 +3571,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-organization-variable"""
 
@@ -3592,7 +3593,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationActionsVariable, OrganizationActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-organization-variable"""
 
@@ -3614,7 +3615,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#delete-an-organization-variable"""
 
@@ -3633,7 +3634,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#delete-an-organization-variable"""
 
@@ -3653,7 +3654,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -3664,7 +3665,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
         visibility: Missing[Literal["all", "private", "selected"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -3675,7 +3676,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3709,7 +3710,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -3720,7 +3721,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
         visibility: Missing[Literal["all", "private", "selected"]] = UNSET,
         selected_repository_ids: Missing[list[int]] = UNSET,
@@ -3731,7 +3732,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3766,7 +3767,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
@@ -3800,7 +3801,7 @@ class ActionsClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200,
         OrgsOrgActionsVariablesNameRepositoriesGetResponse200Type,
@@ -3833,7 +3834,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3844,7 +3845,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3853,7 +3854,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3890,7 +3891,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgActionsVariablesNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3901,7 +3902,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3910,7 +3911,7 @@ class ActionsClient:
         org: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgActionsVariablesNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3947,7 +3948,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#add-selected-repository-to-an-organization-variable"""
 
@@ -3968,7 +3969,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#add-selected-repository-to-an-organization-variable"""
 
@@ -3989,7 +3990,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#remove-selected-repository-from-an-organization-variable"""
 
@@ -4010,7 +4011,7 @@ class ActionsClient:
         name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#remove-selected-repository-from-an-organization-variable"""
 
@@ -4033,7 +4034,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsArtifactsGetResponse200,
         ReposOwnerRepoActionsArtifactsGetResponse200Type,
@@ -4068,7 +4069,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsArtifactsGetResponse200,
         ReposOwnerRepoActionsArtifactsGetResponse200Type,
@@ -4101,7 +4102,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/rest/actions/artifacts#get-an-artifact"""
 
@@ -4124,7 +4125,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Artifact, ArtifactType]:
         """See also: https://docs.github.com/rest/actions/artifacts#get-an-artifact"""
 
@@ -4147,7 +4148,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/artifacts#delete-an-artifact"""
 
@@ -4167,7 +4168,7 @@ class ActionsClient:
         repo: str,
         artifact_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/artifacts#delete-an-artifact"""
 
@@ -4188,7 +4189,7 @@ class ActionsClient:
         artifact_id: int,
         archive_format: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/artifacts#download-an-artifact"""
 
@@ -4214,7 +4215,7 @@ class ActionsClient:
         artifact_id: int,
         archive_format: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/artifacts#download-an-artifact"""
 
@@ -4238,7 +4239,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
@@ -4260,7 +4261,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheUsageByRepository, ActionsCacheUsageByRepositoryType]:
         """See also: https://docs.github.com/rest/actions/cache#get-github-actions-cache-usage-for-a-repository"""
 
@@ -4290,7 +4291,7 @@ class ActionsClient:
             Literal["created_at", "last_accessed_at", "size_in_bytes"]
         ] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
@@ -4330,7 +4331,7 @@ class ActionsClient:
             Literal["created_at", "last_accessed_at", "size_in_bytes"]
         ] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#list-github-actions-caches-for-a-repository"""
 
@@ -4364,7 +4365,7 @@ class ActionsClient:
         *,
         key: str,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
@@ -4394,7 +4395,7 @@ class ActionsClient:
         *,
         key: str,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsCacheList, ActionsCacheListType]:
         """See also: https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key"""
 
@@ -4423,7 +4424,7 @@ class ActionsClient:
         repo: str,
         cache_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/cache#delete-a-github-actions-cache-for-a-repository-using-a-cache-id"""
 
@@ -4443,7 +4444,7 @@ class ActionsClient:
         repo: str,
         cache_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/cache#delete-a-github-actions-cache-for-a-repository-using-a-cache-id"""
 
@@ -4463,7 +4464,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
@@ -4486,7 +4487,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Job, JobType]:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run"""
 
@@ -4509,7 +4510,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run"""
 
@@ -4529,7 +4530,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run"""
 
@@ -4550,7 +4551,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -4564,7 +4565,7 @@ class ActionsClient:
         job_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -4574,7 +4575,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -4623,7 +4624,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -4637,7 +4638,7 @@ class ActionsClient:
         job_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -4647,7 +4648,7 @@ class ActionsClient:
         repo: str,
         job_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsJobsJobIdRerunPostBodyType, None]
         ] = UNSET,
@@ -4694,7 +4695,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
@@ -4720,7 +4721,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSubRepo, OidcCustomSubRepoType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository"""
 
@@ -4747,7 +4748,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -4758,7 +4759,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -4768,7 +4769,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -4815,7 +4816,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsOidcCustomizationSubPutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -4826,7 +4827,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_default: bool,
         include_claim_keys: Missing[list[str]] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -4836,7 +4837,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsOidcCustomizationSubPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -4884,7 +4885,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
@@ -4917,7 +4918,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200,
         ReposOwnerRepoActionsOrganizationSecretsGetResponse200Type,
@@ -4950,7 +4951,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
@@ -4983,7 +4984,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200,
         ReposOwnerRepoActionsOrganizationVariablesGetResponse200Type,
@@ -5014,7 +5015,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
@@ -5036,7 +5037,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsRepositoryPermissions, ActionsRepositoryPermissionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-github-actions-permissions-for-a-repository"""
 
@@ -5059,7 +5060,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -5070,7 +5071,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -5080,7 +5081,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5114,7 +5115,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsPermissionsPutBodyType,
     ) -> Response: ...
 
@@ -5125,7 +5126,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enabled: bool,
         allowed_actions: Missing[Literal["all", "local_only", "selected"]] = UNSET,
     ) -> Response: ...
@@ -5135,7 +5136,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsPermissionsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5168,7 +5169,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
     ]:
@@ -5192,7 +5193,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsWorkflowAccessToRepository, ActionsWorkflowAccessToRepositoryType
     ]:
@@ -5217,7 +5218,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsWorkflowAccessToRepositoryType,
     ) -> Response: ...
 
@@ -5228,7 +5229,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_level: Literal["none", "user", "organization"],
     ) -> Response: ...
 
@@ -5237,7 +5238,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsWorkflowAccessToRepositoryType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5271,7 +5272,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsWorkflowAccessToRepositoryType,
     ) -> Response: ...
 
@@ -5282,7 +5283,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_level: Literal["none", "user", "organization"],
     ) -> Response: ...
 
@@ -5291,7 +5292,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsWorkflowAccessToRepositoryType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5324,7 +5325,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
@@ -5346,7 +5347,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SelectedActions, SelectedActionsType]:
         """See also: https://docs.github.com/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-a-repository"""
 
@@ -5369,7 +5370,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -5380,7 +5381,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -5391,7 +5392,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5425,7 +5426,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
     ) -> Response: ...
 
@@ -5436,7 +5437,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         github_owned_allowed: Missing[bool] = UNSET,
         verified_allowed: Missing[bool] = UNSET,
         patterns_allowed: Missing[list[str]] = UNSET,
@@ -5447,7 +5448,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SelectedActionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5480,7 +5481,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -5504,7 +5505,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ActionsGetDefaultWorkflowPermissions, ActionsGetDefaultWorkflowPermissionsType
     ]:
@@ -5529,7 +5530,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsSetDefaultWorkflowPermissionsType,
     ) -> Response: ...
 
@@ -5540,7 +5541,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -5550,7 +5551,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5585,7 +5586,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ActionsSetDefaultWorkflowPermissionsType,
     ) -> Response: ...
 
@@ -5596,7 +5597,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_workflow_permissions: Missing[Literal["read", "write"]] = UNSET,
         can_approve_pull_request_reviews: Missing[bool] = UNSET,
     ) -> Response: ...
@@ -5606,7 +5607,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ActionsSetDefaultWorkflowPermissionsType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5643,7 +5644,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunnersGetResponse200,
         ReposOwnerRepoActionsRunnersGetResponse200Type,
@@ -5678,7 +5679,7 @@ class ActionsClient:
         name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunnersGetResponse200,
         ReposOwnerRepoActionsRunnersGetResponse200Type,
@@ -5710,7 +5711,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
@@ -5732,7 +5733,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RunnerApplication], list[RunnerApplicationType]]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#list-runner-applications-for-a-repository"""
 
@@ -5755,7 +5756,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
@@ -5769,7 +5770,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -5784,7 +5785,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
@@ -5835,7 +5836,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersGenerateJitconfigPostResponse201,
@@ -5849,7 +5850,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         runner_group_id: int,
         labels: list[str],
@@ -5864,7 +5865,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunnersGenerateJitconfigPostBodyType
         ] = UNSET,
@@ -5914,7 +5915,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
@@ -5936,7 +5937,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository"""
 
@@ -5958,7 +5959,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
@@ -5980,7 +5981,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[AuthenticationToken, AuthenticationTokenType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"""
 
@@ -6003,7 +6004,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
@@ -6026,7 +6027,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Runner, RunnerType]:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-a-repository"""
 
@@ -6049,7 +6050,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-a-repository"""
 
@@ -6069,7 +6070,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-a-repository"""
 
@@ -6089,7 +6090,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -6121,7 +6122,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -6154,7 +6155,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6169,7 +6170,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6182,7 +6183,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6232,7 +6233,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6247,7 +6248,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6260,7 +6261,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6310,7 +6311,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6325,7 +6326,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6338,7 +6339,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6388,7 +6389,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6403,7 +6404,7 @@ class ActionsClient:
         runner_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: list[str],
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
@@ -6416,7 +6417,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsRunnersRunnerIdLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -6465,7 +6466,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -6497,7 +6498,7 @@ class ActionsClient:
         repo: str,
         runner_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsDeleteResponse200Type,
@@ -6530,7 +6531,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -6565,7 +6566,7 @@ class ActionsClient:
         runner_id: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200,
         OrgsOrgActionsRunnersRunnerIdLabelsGetResponse200Type,
@@ -6625,7 +6626,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsGetResponse200,
         ReposOwnerRepoActionsRunsGetResponse200Type,
@@ -6691,7 +6692,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsGetResponse200,
         ReposOwnerRepoActionsRunsGetResponse200Type,
@@ -6732,7 +6733,7 @@ class ActionsClient:
         run_id: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run"""
 
@@ -6761,7 +6762,7 @@ class ActionsClient:
         run_id: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run"""
 
@@ -6789,7 +6790,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#delete-a-workflow-run"""
 
@@ -6809,7 +6810,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#delete-a-workflow-run"""
 
@@ -6829,7 +6830,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
@@ -6852,7 +6853,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[EnvironmentApprovals], list[EnvironmentApprovalsType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-the-review-history-for-a-workflow-run"""
 
@@ -6875,7 +6876,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
@@ -6902,7 +6903,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#approve-a-workflow-run-for-a-fork-pull-request"""
 
@@ -6932,7 +6933,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
@@ -6968,7 +6969,7 @@ class ActionsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdArtifactsGetResponse200Type,
@@ -7003,7 +7004,7 @@ class ActionsClient:
         attempt_number: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
@@ -7033,7 +7034,7 @@ class ActionsClient:
         attempt_number: int,
         *,
         exclude_pull_requests: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRun, WorkflowRunType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run-attempt"""
 
@@ -7064,7 +7065,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
@@ -7105,7 +7106,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdAttemptsAttemptNumberJobsGetResponse200Type,
@@ -7144,7 +7145,7 @@ class ActionsClient:
         run_id: int,
         attempt_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-attempt-logs"""
 
@@ -7165,7 +7166,7 @@ class ActionsClient:
         run_id: int,
         attempt_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-attempt-logs"""
 
@@ -7185,7 +7186,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#cancel-a-workflow-run"""
 
@@ -7211,7 +7212,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#cancel-a-workflow-run"""
 
@@ -7238,7 +7239,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
         ],
@@ -7252,7 +7253,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         comment: str,
     ) -> Response: ...
@@ -7265,7 +7266,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         state: Literal["approved", "rejected"],
         comment: Missing[str] = UNSET,
@@ -7277,7 +7278,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
@@ -7324,7 +7325,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
         ],
@@ -7338,7 +7339,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         comment: str,
     ) -> Response: ...
@@ -7351,7 +7352,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_name: str,
         state: Literal["approved", "rejected"],
         comment: Missing[str] = UNSET,
@@ -7363,7 +7364,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReviewCustomGatesCommentRequiredType, ReviewCustomGatesStateRequiredType
@@ -7409,7 +7410,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
@@ -7435,7 +7436,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#force-cancel-a-workflow-run"""
 
@@ -7464,7 +7465,7 @@ class ActionsClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
@@ -7500,7 +7501,7 @@ class ActionsClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200,
         ReposOwnerRepoActionsRunsRunIdJobsGetResponse200Type,
@@ -7533,7 +7534,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-logs"""
 
@@ -7553,7 +7554,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-logs"""
 
@@ -7573,7 +7574,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#delete-workflow-run-logs"""
 
@@ -7599,7 +7600,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflow-runs#delete-workflow-run-logs"""
 
@@ -7625,7 +7626,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
@@ -7648,7 +7649,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PendingDeployment], list[PendingDeploymentType]]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run"""
 
@@ -7672,7 +7673,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
     ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
@@ -7684,7 +7685,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
@@ -7696,7 +7697,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
@@ -7739,7 +7740,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType,
     ) -> Response[list[Deployment], list[DeploymentType]]: ...
 
@@ -7751,7 +7752,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         environment_ids: list[int],
         state: Literal["approved", "rejected"],
         comment: str,
@@ -7763,7 +7764,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsRunsRunIdPendingDeploymentsPostBodyType
         ] = UNSET,
@@ -7806,7 +7807,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -7820,7 +7821,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -7830,7 +7831,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -7872,7 +7873,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -7886,7 +7887,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -7896,7 +7897,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunPostBodyType, None]
         ] = UNSET,
@@ -7938,7 +7939,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -7952,7 +7953,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -7962,7 +7963,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8007,7 +8008,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8021,7 +8022,7 @@ class ActionsClient:
         run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         enable_debug_logging: Missing[bool] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8031,7 +8032,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoActionsRunsRunIdRerunFailedJobsPostBodyType, None]
         ] = UNSET,
@@ -8075,7 +8076,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-workflow-run-usage"""
 
@@ -8098,7 +8099,7 @@ class ActionsClient:
         repo: str,
         run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowRunUsage, WorkflowRunUsageType]:
         """See also: https://docs.github.com/rest/actions/workflow-runs#get-workflow-run-usage"""
 
@@ -8122,7 +8123,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsSecretsGetResponse200,
         ReposOwnerRepoActionsSecretsGetResponse200Type,
@@ -8155,7 +8156,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsSecretsGetResponse200,
         ReposOwnerRepoActionsSecretsGetResponse200Type,
@@ -8186,7 +8187,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-public-key"""
 
@@ -8208,7 +8209,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-public-key"""
 
@@ -8231,7 +8232,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-secret"""
 
@@ -8254,7 +8255,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-a-repository-secret"""
 
@@ -8278,7 +8279,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8290,7 +8291,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8301,7 +8302,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -8339,7 +8340,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8351,7 +8352,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8362,7 +8363,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -8399,7 +8400,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#delete-a-repository-secret"""
 
@@ -8419,7 +8420,7 @@ class ActionsClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#delete-a-repository-secret"""
 
@@ -8440,7 +8441,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsVariablesGetResponse200,
         ReposOwnerRepoActionsVariablesGetResponse200Type,
@@ -8473,7 +8474,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsVariablesGetResponse200,
         ReposOwnerRepoActionsVariablesGetResponse200Type,
@@ -8505,7 +8506,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8516,7 +8517,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8526,7 +8527,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -8561,7 +8562,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -8572,7 +8573,7 @@ class ActionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -8582,7 +8583,7 @@ class ActionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -8617,7 +8618,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-a-repository-variable"""
 
@@ -8640,7 +8641,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-a-repository-variable"""
 
@@ -8663,7 +8664,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#delete-a-repository-variable"""
 
@@ -8683,7 +8684,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#delete-a-repository-variable"""
 
@@ -8704,7 +8705,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -8716,7 +8717,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -8726,7 +8727,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -8763,7 +8764,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -8775,7 +8776,7 @@ class ActionsClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -8785,7 +8786,7 @@ class ActionsClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoActionsVariablesNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -8822,7 +8823,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsGetResponse200,
         ReposOwnerRepoActionsWorkflowsGetResponse200Type,
@@ -8855,7 +8856,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsGetResponse200,
         ReposOwnerRepoActionsWorkflowsGetResponse200Type,
@@ -8887,7 +8888,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-a-workflow"""
 
@@ -8910,7 +8911,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Workflow, WorkflowType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-a-workflow"""
 
@@ -8933,7 +8934,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflows#disable-a-workflow"""
 
@@ -8953,7 +8954,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflows#disable-a-workflow"""
 
@@ -8974,7 +8975,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -8986,7 +8987,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         inputs: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType
@@ -8999,7 +9000,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType
         ] = UNSET,
@@ -9038,7 +9039,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -9050,7 +9051,7 @@ class ActionsClient:
         workflow_id: Union[int, str],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         inputs: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyPropInputsType
@@ -9063,7 +9064,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBodyType
         ] = UNSET,
@@ -9101,7 +9102,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflows#enable-a-workflow"""
 
@@ -9121,7 +9122,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/workflows#enable-a-workflow"""
 
@@ -9168,7 +9169,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
@@ -9235,7 +9236,7 @@ class ActionsClient:
         exclude_pull_requests: Missing[bool] = UNSET,
         check_suite_id: Missing[int] = UNSET,
         head_sha: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200,
         ReposOwnerRepoActionsWorkflowsWorkflowIdRunsGetResponse200Type,
@@ -9275,7 +9276,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-workflow-usage"""
 
@@ -9298,7 +9299,7 @@ class ActionsClient:
         repo: str,
         workflow_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WorkflowUsage, WorkflowUsageType]:
         """See also: https://docs.github.com/rest/actions/workflows#get-workflow-usage"""
 
@@ -9323,7 +9324,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
@@ -9359,7 +9360,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameSecretsGetResponse200Type,
@@ -9393,7 +9394,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key"""
 
@@ -9418,7 +9419,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsPublicKey, ActionsPublicKeyType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-public-key"""
 
@@ -9444,7 +9445,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-secret"""
 
@@ -9468,7 +9469,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsSecret, ActionsSecretType]:
         """See also: https://docs.github.com/rest/actions/secrets#get-an-environment-secret"""
 
@@ -9493,7 +9494,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -9506,7 +9507,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: str,
         key_id: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -9518,7 +9519,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
@@ -9562,7 +9563,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -9575,7 +9576,7 @@ class ActionsClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: str,
         key_id: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -9587,7 +9588,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameSecretsSecretNamePutBodyType
         ] = UNSET,
@@ -9630,7 +9631,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#delete-an-environment-secret"""
 
@@ -9651,7 +9652,7 @@ class ActionsClient:
         environment_name: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/secrets#delete-an-environment-secret"""
 
@@ -9673,7 +9674,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
@@ -9709,7 +9710,7 @@ class ActionsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameVariablesGetResponse200Type,
@@ -9744,7 +9745,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -9756,7 +9757,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -9767,7 +9768,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
@@ -9810,7 +9811,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -9822,7 +9823,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         value: str,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -9833,7 +9834,7 @@ class ActionsClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesPostBodyType
         ] = UNSET,
@@ -9876,7 +9877,7 @@ class ActionsClient:
         environment_name: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-environment-variable"""
 
@@ -9900,7 +9901,7 @@ class ActionsClient:
         environment_name: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsVariable, ActionsVariableType]:
         """See also: https://docs.github.com/rest/actions/variables#get-an-environment-variable"""
 
@@ -9924,7 +9925,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#delete-an-environment-variable"""
 
@@ -9945,7 +9946,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/actions/variables#delete-an-environment-variable"""
 
@@ -9967,7 +9968,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -9980,7 +9981,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -9991,7 +9992,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType
         ] = UNSET,
@@ -10033,7 +10034,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType,
     ) -> Response: ...
 
@@ -10046,7 +10047,7 @@ class ActionsClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -10057,7 +10058,7 @@ class ActionsClient:
         name: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameVariablesNamePatchBodyType
         ] = UNSET,

--- a/githubkit/versions/v2022_11_28/rest/activity.py
+++ b/githubkit/versions/v2022_11_28/rest/activity.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -81,7 +82,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events"""
 
@@ -117,7 +118,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events"""
 
@@ -151,7 +152,7 @@ class ActivityClient:
     def get_feeds(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/rest/activity/feeds#get-feeds"""
 
@@ -171,7 +172,7 @@ class ActivityClient:
     async def async_get_feeds(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Feed, FeedType]:
         """See also: https://docs.github.com/rest/activity/feeds#get-feeds"""
 
@@ -195,7 +196,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
@@ -229,7 +230,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-network-of-repositories"""
 
@@ -265,7 +266,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
@@ -306,7 +307,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-notifications-for-the-authenticated-user"""
 
@@ -342,7 +343,7 @@ class ActivityClient:
     def mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
@@ -351,7 +352,7 @@ class ActivityClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
@@ -359,7 +360,7 @@ class ActivityClient:
     def mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
@@ -400,7 +401,7 @@ class ActivityClient:
     async def async_mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
 
@@ -409,7 +410,7 @@ class ActivityClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
         read: Missing[bool] = UNSET,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]: ...
@@ -417,7 +418,7 @@ class ActivityClient:
     async def async_mark_notifications_as_read(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[NotificationsPutResponse202, NotificationsPutResponse202Type]:
@@ -458,7 +459,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread"""
 
@@ -483,7 +484,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Thread, ThreadType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread"""
 
@@ -508,7 +509,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-done"""
 
@@ -526,7 +527,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-done"""
 
@@ -544,7 +545,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-read"""
 
@@ -567,7 +568,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/notifications#mark-a-thread-as-read"""
 
@@ -590,7 +591,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
@@ -615,7 +616,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
         """See also: https://docs.github.com/rest/activity/notifications#get-a-thread-subscription-for-the-authenticated-user"""
 
@@ -641,7 +642,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -651,7 +652,7 @@ class ActivityClient:
         thread_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ignored: Missing[bool] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -659,7 +660,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
@@ -703,7 +704,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -713,7 +714,7 @@ class ActivityClient:
         thread_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ignored: Missing[bool] = UNSET,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]: ...
 
@@ -721,7 +722,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[NotificationsThreadsThreadIdSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ThreadSubscription, ThreadSubscriptionType]:
@@ -764,7 +765,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/notifications#delete-a-thread-subscription"""
 
@@ -788,7 +789,7 @@ class ActivityClient:
         self,
         thread_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/notifications#delete-a-thread-subscription"""
 
@@ -814,7 +815,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-organization-events"""
 
@@ -843,7 +844,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-organization-events"""
 
@@ -873,7 +874,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-repository-events"""
 
@@ -903,7 +904,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-repository-events"""
 
@@ -937,7 +938,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
@@ -975,7 +976,7 @@ class ActivityClient:
         before: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Thread], list[ThreadType]]:
         """See also: https://docs.github.com/rest/activity/notifications#list-repository-notifications-for-the-authenticated-user"""
 
@@ -1008,7 +1009,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1022,7 +1023,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1034,7 +1035,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1075,7 +1076,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1089,7 +1090,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         last_read_at: Missing[datetime] = UNSET,
     ) -> Response[
         ReposOwnerRepoNotificationsPutResponse202,
@@ -1101,7 +1102,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoNotificationsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1143,7 +1144,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[SimpleUser], list[Stargazer]],
         Union[list[SimpleUserType], list[StargazerType]],
@@ -1181,7 +1182,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[SimpleUser], list[Stargazer]],
         Union[list[SimpleUserType], list[StargazerType]],
@@ -1219,7 +1220,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-watchers"""
 
@@ -1249,7 +1250,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-watchers"""
 
@@ -1277,7 +1278,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/rest/activity/watching#get-a-repository-subscription"""
 
@@ -1302,7 +1303,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
         """See also: https://docs.github.com/rest/activity/watching#get-a-repository-subscription"""
 
@@ -1328,7 +1329,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
@@ -1339,7 +1340,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
@@ -1349,7 +1350,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
@@ -1384,7 +1385,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
 
@@ -1395,7 +1396,7 @@ class ActivityClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         subscribed: Missing[bool] = UNSET,
         ignored: Missing[bool] = UNSET,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]: ...
@@ -1405,7 +1406,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoSubscriptionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositorySubscription, RepositorySubscriptionType]:
@@ -1439,7 +1440,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/watching#delete-a-repository-subscription"""
 
@@ -1458,7 +1459,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/watching#delete-a-repository-subscription"""
 
@@ -1479,7 +1480,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
@@ -1515,7 +1516,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/activity/starring#list-repositories-starred-by-the-authenticated-user"""
 
@@ -1549,7 +1550,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user"""
 
@@ -1575,7 +1576,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user"""
 
@@ -1601,7 +1602,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/starring#star-a-repository-for-the-authenticated-user"""
 
@@ -1627,7 +1628,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/starring#star-a-repository-for-the-authenticated-user"""
 
@@ -1653,7 +1654,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/starring#unstar-a-repository-for-the-authenticated-user"""
 
@@ -1679,7 +1680,7 @@ class ActivityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/activity/starring#unstar-a-repository-for-the-authenticated-user"""
 
@@ -1705,7 +1706,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
@@ -1737,7 +1738,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-the-authenticated-user"""
 
@@ -1770,7 +1771,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-for-the-authenticated-user"""
 
@@ -1799,7 +1800,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-for-the-authenticated-user"""
 
@@ -1829,7 +1830,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
@@ -1859,7 +1860,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-organization-events-for-the-authenticated-user"""
 
@@ -1888,7 +1889,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-user"""
 
@@ -1917,7 +1918,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-for-a-user"""
 
@@ -1946,7 +1947,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-received-by-the-authenticated-user"""
 
@@ -1975,7 +1976,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-events-received-by-the-authenticated-user"""
 
@@ -2004,7 +2005,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-received-by-a-user"""
 
@@ -2033,7 +2034,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Event], list[EventType]]:
         """See also: https://docs.github.com/rest/activity/events#list-public-events-received-by-a-user"""
 
@@ -2064,7 +2065,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[StarredRepository], list[Repository]],
         Union[list[StarredRepositoryType], list[RepositoryType]],
@@ -2102,7 +2103,7 @@ class ActivityClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[list[StarredRepository], list[Repository]],
         Union[list[StarredRepositoryType], list[RepositoryType]],
@@ -2138,7 +2139,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-a-user"""
 
@@ -2167,7 +2168,7 @@ class ActivityClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/activity/watching#list-repositories-watched-by-a-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/apps.py
+++ b/githubkit/versions/v2022_11_28/rest/apps.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -91,7 +92,7 @@ class AppsClient:
     def get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-the-authenticated-app"""
 
@@ -113,7 +114,7 @@ class AppsClient:
     async def async_get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-the-authenticated-app"""
 
@@ -136,7 +137,7 @@ class AppsClient:
         self,
         code: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppManifestsCodeConversionsPostResponse201,
         AppManifestsCodeConversionsPostResponse201Type,
@@ -168,7 +169,7 @@ class AppsClient:
         self,
         code: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppManifestsCodeConversionsPostResponse201,
         AppManifestsCodeConversionsPostResponse201Type,
@@ -199,7 +200,7 @@ class AppsClient:
     def get_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
@@ -219,7 +220,7 @@ class AppsClient:
     async def async_get_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-webhook-configuration-for-an-app"""
 
@@ -240,7 +241,7 @@ class AppsClient:
     def update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AppHookConfigPatchBodyType,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -249,7 +250,7 @@ class AppsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -259,7 +260,7 @@ class AppsClient:
     def update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -292,7 +293,7 @@ class AppsClient:
     async def async_update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: AppHookConfigPatchBodyType,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -301,7 +302,7 @@ class AppsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -311,7 +312,7 @@ class AppsClient:
     async def async_update_webhook_config_for_app(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppHookConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -345,7 +346,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
@@ -377,7 +378,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/apps/webhooks#list-deliveries-for-an-app-webhook"""
 
@@ -408,7 +409,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
@@ -433,7 +434,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/apps/webhooks#get-a-delivery-for-an-app-webhook"""
 
@@ -458,7 +459,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -490,7 +491,7 @@ class AppsClient:
         self,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -523,7 +524,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
     ]:
@@ -556,7 +557,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[IntegrationInstallationRequest], list[IntegrationInstallationRequestType]
     ]:
@@ -591,7 +592,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         outdated: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/rest/apps/apps#list-installations-for-the-authenticated-app"""
 
@@ -623,7 +624,7 @@ class AppsClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         outdated: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Installation], list[InstallationType]]:
         """See also: https://docs.github.com/rest/apps/apps#list-installations-for-the-authenticated-app"""
 
@@ -652,7 +653,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
@@ -676,7 +677,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-installation-for-the-authenticated-app"""
 
@@ -700,7 +701,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/apps#delete-an-installation-for-the-authenticated-app"""
 
@@ -723,7 +724,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/apps#delete-an-installation-for-the-authenticated-app"""
 
@@ -747,7 +748,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
     ) -> Response[InstallationToken, InstallationTokenType]: ...
 
@@ -757,7 +758,7 @@ class AppsClient:
         installation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
@@ -767,7 +768,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[InstallationToken, InstallationTokenType]:
@@ -814,7 +815,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
     ) -> Response[InstallationToken, InstallationTokenType]: ...
 
@@ -824,7 +825,7 @@ class AppsClient:
         installation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: Missing[list[str]] = UNSET,
         repository_ids: Missing[list[int]] = UNSET,
         permissions: Missing[AppPermissionsType] = UNSET,
@@ -834,7 +835,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[AppInstallationsInstallationIdAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[InstallationToken, InstallationTokenType]:
@@ -880,7 +881,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/apps#suspend-an-app-installation"""
 
@@ -903,7 +904,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/apps#suspend-an-app-installation"""
 
@@ -926,7 +927,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/apps#unsuspend-an-app-installation"""
 
@@ -949,7 +950,7 @@ class AppsClient:
         self,
         installation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/apps#unsuspend-an-app-installation"""
 
@@ -973,7 +974,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdGrantDeleteBodyType,
     ) -> Response: ...
 
@@ -983,7 +984,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -991,7 +992,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdGrantDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1027,7 +1028,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdGrantDeleteBodyType,
     ) -> Response: ...
 
@@ -1037,7 +1038,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -1045,7 +1046,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdGrantDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1081,7 +1082,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1091,7 +1092,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1099,7 +1100,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1142,7 +1143,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1152,7 +1153,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1160,7 +1161,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1203,7 +1204,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenDeleteBodyType,
     ) -> Response: ...
 
@@ -1213,7 +1214,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -1221,7 +1222,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1257,7 +1258,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenDeleteBodyType,
     ) -> Response: ...
 
@@ -1267,7 +1268,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response: ...
 
@@ -1275,7 +1276,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1311,7 +1312,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1321,7 +1322,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1329,7 +1330,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1370,7 +1371,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenPatchBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1380,7 +1381,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1388,7 +1389,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1429,7 +1430,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1439,7 +1440,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
         target: Missing[str] = UNSET,
         target_id: Missing[int] = UNSET,
@@ -1452,7 +1453,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1497,7 +1498,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ApplicationsClientIdTokenScopedPostBodyType,
     ) -> Response[Authorization, AuthorizationType]: ...
 
@@ -1507,7 +1508,7 @@ class AppsClient:
         client_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         access_token: str,
         target: Missing[str] = UNSET,
         target_id: Missing[int] = UNSET,
@@ -1520,7 +1521,7 @@ class AppsClient:
         self,
         client_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ApplicationsClientIdTokenScopedPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Authorization, AuthorizationType]:
@@ -1564,7 +1565,7 @@ class AppsClient:
         self,
         app_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-app"""
 
@@ -1591,7 +1592,7 @@ class AppsClient:
         self,
         app_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Union[Integration, None], Union[IntegrationType, None]]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-app"""
 
@@ -1619,7 +1620,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         InstallationRepositoriesGetResponse200,
         InstallationRepositoriesGetResponse200Type,
@@ -1654,7 +1655,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         InstallationRepositoriesGetResponse200,
         InstallationRepositoriesGetResponse200Type,
@@ -1687,7 +1688,7 @@ class AppsClient:
     def revoke_installation_access_token(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/installations#revoke-an-installation-access-token"""
 
@@ -1704,7 +1705,7 @@ class AppsClient:
     async def async_revoke_installation_access_token(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/installations#revoke-an-installation-access-token"""
 
@@ -1722,7 +1723,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
@@ -1747,7 +1748,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account"""
 
@@ -1773,7 +1774,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans"""
 
@@ -1805,7 +1806,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans"""
 
@@ -1840,7 +1841,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan"""
 
@@ -1878,7 +1879,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan"""
 
@@ -1912,7 +1913,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
@@ -1936,7 +1937,7 @@ class AppsClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[MarketplacePurchase, MarketplacePurchaseType]:
         """See also: https://docs.github.com/rest/apps/marketplace#get-a-subscription-plan-for-an-account-stubbed"""
 
@@ -1961,7 +1962,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans-stubbed"""
 
@@ -1992,7 +1993,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplaceListingPlan], list[MarketplaceListingPlanType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-plans-stubbed"""
 
@@ -2026,7 +2027,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
@@ -2062,7 +2063,7 @@ class AppsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MarketplacePurchase], list[MarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-accounts-for-a-plan-stubbed"""
 
@@ -2094,7 +2095,7 @@ class AppsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
@@ -2115,7 +2116,7 @@ class AppsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-an-organization-installation-for-the-authenticated-app"""
 
@@ -2137,7 +2138,7 @@ class AppsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
@@ -2162,7 +2163,7 @@ class AppsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app"""
 
@@ -2187,7 +2188,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
@@ -2219,7 +2220,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserInstallationsGetResponse200, UserInstallationsGetResponse200Type]:
         """See also: https://docs.github.com/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token"""
 
@@ -2252,7 +2253,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserInstallationsInstallationIdRepositoriesGetResponse200,
         UserInstallationsInstallationIdRepositoriesGetResponse200Type,
@@ -2291,7 +2292,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserInstallationsInstallationIdRepositoriesGetResponse200,
         UserInstallationsInstallationIdRepositoriesGetResponse200Type,
@@ -2329,7 +2330,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/installations#add-a-repository-to-an-app-installation"""
 
@@ -2354,7 +2355,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/installations#add-a-repository-to-an-app-installation"""
 
@@ -2379,7 +2380,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/installations#remove-a-repository-from-an-app-installation"""
 
@@ -2404,7 +2405,7 @@ class AppsClient:
         installation_id: int,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/apps/installations#remove-a-repository-from-an-app-installation"""
 
@@ -2429,7 +2430,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
@@ -2461,7 +2462,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user"""
 
@@ -2493,7 +2494,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
@@ -2524,7 +2525,7 @@ class AppsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserMarketplacePurchase], list[UserMarketplacePurchaseType]]:
         """See also: https://docs.github.com/rest/apps/marketplace#list-subscriptions-for-the-authenticated-user-stubbed"""
 
@@ -2554,7 +2555,7 @@ class AppsClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 
@@ -2575,7 +2576,7 @@ class AppsClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Installation, InstallationType]:
         """See also: https://docs.github.com/rest/apps/apps#get-a-user-installation-for-the-authenticated-app"""
 

--- a/githubkit/versions/v2022_11_28/rest/billing.py
+++ b/githubkit/versions/v2022_11_28/rest/billing.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -58,7 +59,7 @@ class BillingClient:
         month: Missing[int] = UNSET,
         day: Missing[int] = UNSET,
         hour: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/rest/billing/enhanced-billing#get-billing-usage-report-for-an-organization"""
 
@@ -101,7 +102,7 @@ class BillingClient:
         month: Missing[int] = UNSET,
         day: Missing[int] = UNSET,
         hour: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BillingUsageReport, BillingUsageReportType]:
         """See also: https://docs.github.com/rest/billing/enhanced-billing#get-billing-usage-report-for-an-organization"""
 
@@ -140,7 +141,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
@@ -161,7 +162,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-an-organization"""
 
@@ -182,7 +183,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
@@ -203,7 +204,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-an-organization"""
 
@@ -224,7 +225,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
@@ -245,7 +246,7 @@ class BillingClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-an-organization"""
 
@@ -266,7 +267,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-a-user"""
 
@@ -287,7 +288,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ActionsBillingUsage, ActionsBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-actions-billing-for-a-user"""
 
@@ -308,7 +309,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-a-user"""
 
@@ -329,7 +330,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackagesBillingUsage, PackagesBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-github-packages-billing-for-a-user"""
 
@@ -350,7 +351,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-a-user"""
 
@@ -371,7 +372,7 @@ class BillingClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedBillingUsage, CombinedBillingUsageType]:
         """See also: https://docs.github.com/rest/billing/billing#get-shared-storage-billing-for-a-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/checks.py
+++ b/githubkit/versions/v2022_11_28/rest/checks.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -81,7 +82,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
@@ -95,7 +96,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -126,7 +127,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -159,7 +160,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsPostBodyOneof0Type,
@@ -211,7 +212,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsPostBodyOneof0Type,
             ReposOwnerRepoCheckRunsPostBodyOneof1Type,
@@ -225,7 +226,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -256,7 +257,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         head_sha: str,
         details_url: Missing[str] = UNSET,
@@ -289,7 +290,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsPostBodyOneof0Type,
@@ -341,7 +342,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#get-a-check-run"""
 
@@ -364,7 +365,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckRun, CheckRunType]:
         """See also: https://docs.github.com/rest/checks/runs#get-a-check-run"""
 
@@ -388,7 +389,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
@@ -403,7 +404,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -436,7 +437,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -469,7 +470,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
@@ -522,7 +523,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
             ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof1Type,
@@ -537,7 +538,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -570,7 +571,7 @@ class ChecksClient:
         check_run_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         details_url: Missing[str] = UNSET,
         external_id: Missing[str] = UNSET,
@@ -603,7 +604,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCheckRunsCheckRunIdPatchBodyAnyof0Type,
@@ -657,7 +658,7 @@ class ChecksClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-run-annotations"""
 
@@ -688,7 +689,7 @@ class ChecksClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CheckAnnotation], list[CheckAnnotationType]]:
         """See also: https://docs.github.com/rest/checks/runs#list-check-run-annotations"""
 
@@ -717,7 +718,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/runs#rerequest-a-check-run"""
 
@@ -745,7 +746,7 @@ class ChecksClient:
         repo: str,
         check_run_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/runs#rerequest-a-check-run"""
 
@@ -773,7 +774,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -784,7 +785,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         head_sha: str,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -793,7 +794,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuite, CheckSuiteType]:
@@ -828,7 +829,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPostBodyType,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -839,7 +840,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         head_sha: str,
     ) -> Response[CheckSuite, CheckSuiteType]: ...
 
@@ -848,7 +849,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuite, CheckSuiteType]:
@@ -883,7 +884,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
@@ -894,7 +895,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         auto_trigger_checks: Missing[
             list[
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
@@ -907,7 +908,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
@@ -947,7 +948,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCheckSuitesPreferencesPatchBodyType,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]: ...
 
@@ -958,7 +959,7 @@ class ChecksClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         auto_trigger_checks: Missing[
             list[
                 ReposOwnerRepoCheckSuitesPreferencesPatchBodyPropAutoTriggerChecksItemsType
@@ -971,7 +972,7 @@ class ChecksClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCheckSuitesPreferencesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CheckSuitePreference, CheckSuitePreferenceType]:
@@ -1011,7 +1012,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/rest/checks/suites#get-a-check-suite"""
 
@@ -1034,7 +1035,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckSuite, CheckSuiteType]:
         """See also: https://docs.github.com/rest/checks/suites#get-a-check-suite"""
 
@@ -1062,7 +1063,7 @@ class ChecksClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
@@ -1104,7 +1105,7 @@ class ChecksClient:
         filter_: Missing[Literal["latest", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200,
         ReposOwnerRepoCheckSuitesCheckSuiteIdCheckRunsGetResponse200Type,
@@ -1141,7 +1142,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/suites#rerequest-a-check-suite"""
 
@@ -1164,7 +1165,7 @@ class ChecksClient:
         repo: str,
         check_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmptyObject, EmptyObjectType]:
         """See also: https://docs.github.com/rest/checks/suites#rerequest-a-check-suite"""
 
@@ -1193,7 +1194,7 @@ class ChecksClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         app_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
@@ -1235,7 +1236,7 @@ class ChecksClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         app_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200,
         ReposOwnerRepoCommitsRefCheckRunsGetResponse200Type,
@@ -1275,7 +1276,7 @@ class ChecksClient:
         check_name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,
@@ -1313,7 +1314,7 @@ class ChecksClient:
         check_name: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200,
         ReposOwnerRepoCommitsRefCheckSuitesGetResponse200Type,

--- a/githubkit/versions/v2022_11_28/rest/classroom.py
+++ b/githubkit/versions/v2022_11_28/rest/classroom.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -58,7 +59,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-an-assignment"""
 
@@ -82,7 +83,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ClassroomAssignment, ClassroomAssignmentType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-an-assignment"""
 
@@ -108,7 +109,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
     ]:
@@ -139,7 +140,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ClassroomAcceptedAssignment], list[ClassroomAcceptedAssignmentType]
     ]:
@@ -168,7 +169,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-assignment-grades"""
 
@@ -192,7 +193,7 @@ class ClassroomClient:
         self,
         assignment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ClassroomAssignmentGrade], list[ClassroomAssignmentGradeType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-assignment-grades"""
 
@@ -217,7 +218,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-classrooms"""
 
@@ -245,7 +246,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroom], list[SimpleClassroomType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-classrooms"""
 
@@ -272,7 +273,7 @@ class ClassroomClient:
         self,
         classroom_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-a-classroom"""
 
@@ -296,7 +297,7 @@ class ClassroomClient:
         self,
         classroom_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Classroom, ClassroomType]:
         """See also: https://docs.github.com/rest/classroom/classroom#get-a-classroom"""
 
@@ -322,7 +323,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-assignments-for-a-classroom"""
 
@@ -351,7 +352,7 @@ class ClassroomClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleClassroomAssignment], list[SimpleClassroomAssignmentType]]:
         """See also: https://docs.github.com/rest/classroom/classroom#list-assignments-for-a-classroom"""
 

--- a/githubkit/versions/v2022_11_28/rest/code_scanning.py
+++ b/githubkit/versions/v2022_11_28/rest/code_scanning.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -101,7 +102,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningOrganizationAlertItems],
         list[CodeScanningOrganizationAlertItemsType],
@@ -159,7 +160,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningOrganizationAlertItems],
         list[CodeScanningOrganizationAlertItemsType],
@@ -220,7 +221,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
@@ -281,7 +282,7 @@ class CodeScanningClient:
         severity: Missing[
             Literal["critical", "high", "medium", "low", "warning", "note", "error"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertItems], list[CodeScanningAlertItemsType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository"""
 
@@ -329,7 +330,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
@@ -361,7 +362,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-alert"""
 
@@ -394,7 +395,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
@@ -406,7 +407,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "dismissed"],
         dismissed_reason: Missing[
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
@@ -420,7 +421,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
@@ -468,7 +469,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]: ...
 
@@ -480,7 +481,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "dismissed"],
         dismissed_reason: Missing[
             Union[None, Literal["false positive", "won't fix", "used in tests"]]
@@ -494,7 +495,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningAlert, CodeScanningAlertType]:
@@ -541,7 +542,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-status-of-an-autofix-for-a-code-scanning-alert"""
 
@@ -574,7 +575,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-status-of-an-autofix-for-a-code-scanning-alert"""
 
@@ -607,7 +608,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#create-an-autofix-for-a-code-scanning-alert"""
 
@@ -640,7 +641,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAutofix, CodeScanningAutofixType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#create-an-autofix-for-a-code-scanning-alert"""
 
@@ -674,7 +675,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
     ) -> Response[
         CodeScanningAutofixCommitsResponse, CodeScanningAutofixCommitsResponseType
@@ -688,7 +689,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         target_ref: Missing[str] = UNSET,
         message: Missing[str] = UNSET,
     ) -> Response[
@@ -701,7 +702,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
         **kwargs,
     ) -> Response[
@@ -754,7 +755,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
     ) -> Response[
         CodeScanningAutofixCommitsResponse, CodeScanningAutofixCommitsResponseType
@@ -768,7 +769,7 @@ class CodeScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         target_ref: Missing[str] = UNSET,
         message: Missing[str] = UNSET,
     ) -> Response[
@@ -781,7 +782,7 @@ class CodeScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[CodeScanningAutofixCommitsType, None]] = UNSET,
         **kwargs,
     ) -> Response[
@@ -837,7 +838,7 @@ class CodeScanningClient:
         per_page: Missing[int] = UNSET,
         ref: Missing[str] = UNSET,
         pr: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
@@ -881,7 +882,7 @@ class CodeScanningClient:
         per_page: Missing[int] = UNSET,
         ref: Missing[str] = UNSET,
         pr: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAlertInstance], list[CodeScanningAlertInstanceType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-instances-of-a-code-scanning-alert"""
 
@@ -929,7 +930,7 @@ class CodeScanningClient:
         sarif_id: Missing[str] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         sort: Missing[Literal["created"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
@@ -982,7 +983,7 @@ class CodeScanningClient:
         sarif_id: Missing[str] = UNSET,
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         sort: Missing[Literal["created"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeScanningAnalysis], list[CodeScanningAnalysisType]]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository"""
 
@@ -1027,7 +1028,7 @@ class CodeScanningClient:
         repo: str,
         analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
@@ -1059,7 +1060,7 @@ class CodeScanningClient:
         repo: str,
         analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysis, CodeScanningAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-analysis-for-a-repository"""
 
@@ -1092,7 +1093,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         confirm_delete: Missing[Union[str, None]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
@@ -1131,7 +1132,7 @@ class CodeScanningClient:
         analysis_id: int,
         *,
         confirm_delete: Missing[Union[str, None]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningAnalysisDeletion, CodeScanningAnalysisDeletionType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-code-scanning-analysis-from-a-repository"""
 
@@ -1168,7 +1169,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
     ]:
@@ -1201,7 +1202,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeScanningCodeqlDatabase], list[CodeScanningCodeqlDatabaseType]
     ]:
@@ -1235,7 +1236,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
@@ -1267,7 +1268,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningCodeqlDatabase, CodeScanningCodeqlDatabaseType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository"""
 
@@ -1299,7 +1300,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-codeql-database"""
 
@@ -1329,7 +1330,7 @@ class CodeScanningClient:
         repo: str,
         language: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#delete-a-codeql-database"""
 
@@ -1359,7 +1360,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
@@ -1374,7 +1375,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1391,7 +1392,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1408,7 +1409,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1423,7 +1424,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
@@ -1485,7 +1486,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
             ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof1Type,
@@ -1500,7 +1501,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1517,7 +1518,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1534,7 +1535,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         language: Literal[
             "cpp", "csharp", "go", "java", "javascript", "python", "ruby", "swift"
         ],
@@ -1549,7 +1550,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoCodeScanningCodeqlVariantAnalysesPostBodyOneof0Type,
@@ -1611,7 +1612,7 @@ class CodeScanningClient:
         repo: str,
         codeql_variant_analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
@@ -1642,7 +1643,7 @@ class CodeScanningClient:
         repo: str,
         codeql_variant_analysis_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningVariantAnalysis, CodeScanningVariantAnalysisType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-the-summary-of-a-codeql-variant-analysis"""
 
@@ -1675,7 +1676,7 @@ class CodeScanningClient:
         repo_owner: str,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
     ]:
@@ -1710,7 +1711,7 @@ class CodeScanningClient:
         repo_owner: str,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeScanningVariantAnalysisRepoTask, CodeScanningVariantAnalysisRepoTaskType
     ]:
@@ -1742,7 +1743,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
@@ -1773,7 +1774,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningDefaultSetup, CodeScanningDefaultSetupType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-a-code-scanning-default-setup-configuration"""
 
@@ -1805,7 +1806,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1816,7 +1817,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Missing[Literal["configured", "not-configured"]] = UNSET,
         runner_type: Missing[Literal["standard", "labeled"]] = UNSET,
         runner_label: Missing[Union[str, None]] = UNSET,
@@ -1843,7 +1844,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1889,7 +1890,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CodeScanningDefaultSetupUpdateType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1900,7 +1901,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Missing[Literal["configured", "not-configured"]] = UNSET,
         runner_type: Missing[Literal["standard", "labeled"]] = UNSET,
         runner_label: Missing[Union[str, None]] = UNSET,
@@ -1927,7 +1928,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CodeScanningDefaultSetupUpdateType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1973,7 +1974,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
@@ -1984,7 +1985,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_sha: str,
         ref: str,
         sarif: str,
@@ -1999,7 +2000,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
@@ -2044,7 +2045,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodeScanningSarifsPostBodyType,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]: ...
 
@@ -2055,7 +2056,7 @@ class CodeScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_sha: str,
         ref: str,
         sarif: str,
@@ -2070,7 +2071,7 @@ class CodeScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodeScanningSarifsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeScanningSarifsReceipt, CodeScanningSarifsReceiptType]:
@@ -2115,7 +2116,7 @@ class CodeScanningClient:
         repo: str,
         sarif_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 
@@ -2146,7 +2147,7 @@ class CodeScanningClient:
         repo: str,
         sarif_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeScanningSarifsStatus, CodeScanningSarifsStatusType]:
         """See also: https://docs.github.com/rest/code-scanning/code-scanning#get-information-about-a-sarif-upload"""
 

--- a/githubkit/versions/v2022_11_28/rest/code_security.py
+++ b/githubkit/versions/v2022_11_28/rest/code_security.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -84,7 +85,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-code-security-configurations-for-an-enterprise"""
 
@@ -119,7 +120,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-code-security-configurations-for-an-enterprise"""
 
@@ -152,7 +153,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -162,7 +163,7 @@ class CodeSecurityClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -203,7 +204,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType
         ] = UNSET,
@@ -250,7 +251,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -260,7 +261,7 @@ class CodeSecurityClient:
         enterprise: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -301,7 +302,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsPostBodyType
         ] = UNSET,
@@ -347,7 +348,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -371,7 +372,7 @@ class CodeSecurityClient:
         self,
         enterprise: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -396,7 +397,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#retrieve-a-code-security-configuration-of-an-enterprise"""
 
@@ -424,7 +425,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#retrieve-a-code-security-configuration-of-an-enterprise"""
 
@@ -452,7 +453,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/code-security/configurations#delete-a-code-security-configuration-for-an-enterprise"""
 
@@ -481,7 +482,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/code-security/configurations#delete-a-code-security-configuration-for-an-enterprise"""
 
@@ -511,7 +512,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -522,7 +523,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -564,7 +565,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -615,7 +616,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -626,7 +627,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -668,7 +669,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -719,7 +720,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -733,7 +734,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal["all", "all_without_configurations"],
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -745,7 +746,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -797,7 +798,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -811,7 +812,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal["all", "all_without_configurations"],
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -823,7 +824,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -875,7 +876,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -889,7 +890,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -903,7 +904,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -954,7 +955,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -968,7 +969,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -982,7 +983,7 @@ class CodeSecurityClient:
         enterprise: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             EnterprisesEnterpriseCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -1036,7 +1037,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -1077,7 +1078,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -1117,7 +1118,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
@@ -1154,7 +1155,7 @@ class CodeSecurityClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeSecurityConfiguration], list[CodeSecurityConfigurationType]]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-code-security-configurations-for-an-organization"""
 
@@ -1188,7 +1189,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1198,7 +1199,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1245,7 +1246,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
@@ -1282,7 +1283,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsPostBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1292,7 +1293,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: str,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1339,7 +1340,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
@@ -1375,7 +1376,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -1403,7 +1404,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityDefaultConfigurationsItems],
         list[CodeSecurityDefaultConfigurationsItemsType],
@@ -1432,7 +1433,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType,
     ) -> Response: ...
 
@@ -1442,7 +1443,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: Missing[list[int]] = UNSET,
     ) -> Response: ...
 
@@ -1450,7 +1451,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1494,7 +1495,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType,
     ) -> Response: ...
 
@@ -1504,7 +1505,7 @@ class CodeSecurityClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: Missing[list[int]] = UNSET,
     ) -> Response: ...
 
@@ -1512,7 +1513,7 @@ class CodeSecurityClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodeSecurityConfigurationsDetachDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -1556,7 +1557,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-a-code-security-configuration"""
 
@@ -1582,7 +1583,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]:
         """See also: https://docs.github.com/rest/code-security/configurations#get-a-code-security-configuration"""
 
@@ -1608,7 +1609,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/code-security/configurations#delete-a-code-security-configuration"""
 
@@ -1635,7 +1636,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/code-security/configurations#delete-a-code-security-configuration"""
 
@@ -1663,7 +1664,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1674,7 +1675,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1722,7 +1723,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -1764,7 +1765,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType,
     ) -> Response[CodeSecurityConfiguration, CodeSecurityConfigurationType]: ...
 
@@ -1775,7 +1776,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         advanced_security: Missing[Literal["enabled", "disabled"]] = UNSET,
@@ -1823,7 +1824,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdPatchBodyType
         ] = UNSET,
@@ -1865,7 +1866,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -1879,7 +1880,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal[
             "all",
             "all_without_configurations",
@@ -1898,7 +1899,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -1943,7 +1944,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -1957,7 +1958,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         scope: Literal[
             "all",
             "all_without_configurations",
@@ -1976,7 +1977,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdAttachPostBodyType
         ] = UNSET,
@@ -2021,7 +2022,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -2035,7 +2036,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -2049,7 +2050,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -2099,7 +2100,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType,
     ) -> Response[
         OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutResponse200,
@@ -2113,7 +2114,7 @@ class CodeSecurityClient:
         configuration_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         default_for_new_repos: Missing[
             Literal["all", "none", "private_and_internal", "public"]
         ] = UNSET,
@@ -2127,7 +2128,7 @@ class CodeSecurityClient:
         org: str,
         configuration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodeSecurityConfigurationsConfigurationIdDefaultsPutBodyType
         ] = UNSET,
@@ -2180,7 +2181,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -2223,7 +2224,7 @@ class CodeSecurityClient:
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
         status: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[CodeSecurityConfigurationRepositories],
         list[CodeSecurityConfigurationRepositoriesType],
@@ -2262,7 +2263,7 @@ class CodeSecurityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeSecurityConfigurationForRepository,
         CodeSecurityConfigurationForRepositoryType,
@@ -2291,7 +2292,7 @@ class CodeSecurityClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodeSecurityConfigurationForRepository,
         CodeSecurityConfigurationForRepositoryType,

--- a/githubkit/versions/v2022_11_28/rest/codes_of_conduct.py
+++ b/githubkit/versions/v2022_11_28/rest/codes_of_conduct.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class CodesOfConductClient:
     def get_all_codes_of_conduct(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
@@ -60,7 +61,7 @@ class CodesOfConductClient:
     async def async_get_all_codes_of_conduct(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CodeOfConduct], list[CodeOfConductType]]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-all-codes-of-conduct"""
 
@@ -81,7 +82,7 @@ class CodesOfConductClient:
         self,
         key: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 
@@ -105,7 +106,7 @@ class CodesOfConductClient:
         self,
         key: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeOfConduct, CodeOfConductType]:
         """See also: https://docs.github.com/rest/codes-of-conduct/codes-of-conduct#get-a-code-of-conduct"""
 

--- a/githubkit/versions/v2022_11_28/rest/codespaces.py
+++ b/githubkit/versions/v2022_11_28/rest/codespaces.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -116,7 +117,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
@@ -151,7 +152,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgsOrgCodespacesGetResponse200, OrgsOrgCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/organizations#list-codespaces-for-the-organization"""
 
@@ -185,7 +186,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessPutBodyType,
     ) -> Response: ...
 
@@ -195,7 +196,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal[
             "disabled",
             "selected_members",
@@ -209,7 +210,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -247,7 +248,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessPutBodyType,
     ) -> Response: ...
 
@@ -257,7 +258,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal[
             "disabled",
             "selected_members",
@@ -271,7 +272,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -309,7 +310,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
     ) -> Response: ...
 
@@ -319,7 +320,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -327,7 +328,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -371,7 +372,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersPostBodyType,
     ) -> Response: ...
 
@@ -381,7 +382,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -389,7 +390,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -433,7 +434,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
     ) -> Response: ...
 
@@ -443,7 +444,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -451,7 +452,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -495,7 +496,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType,
     ) -> Response: ...
 
@@ -505,7 +506,7 @@ class CodespacesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response: ...
 
@@ -513,7 +514,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesAccessSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -558,7 +559,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsGetResponse200,
         OrgsOrgCodespacesSecretsGetResponse200Type,
@@ -590,7 +591,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsGetResponse200,
         OrgsOrgCodespacesSecretsGetResponse200Type,
@@ -620,7 +621,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
@@ -641,7 +642,7 @@ class CodespacesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-public-key"""
 
@@ -663,7 +664,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-secret"""
 
@@ -685,7 +686,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesOrgSecret, CodespacesOrgSecretType]:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#get-an-organization-secret"""
 
@@ -708,7 +709,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -719,7 +720,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -731,7 +732,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -775,7 +776,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -786,7 +787,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -798,7 +799,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -841,7 +842,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#delete-an-organization-secret"""
 
@@ -865,7 +866,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#delete-an-organization-secret"""
 
@@ -891,7 +892,7 @@ class CodespacesClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -930,7 +931,7 @@ class CodespacesClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -968,7 +969,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -979,7 +980,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -988,7 +989,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -1032,7 +1033,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -1043,7 +1044,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -1052,7 +1053,7 @@ class CodespacesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgCodespacesSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -1096,7 +1097,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -1124,7 +1125,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -1152,7 +1153,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -1180,7 +1181,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/organization-secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -1209,7 +1210,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgMembersUsernameCodespacesGetResponse200,
         OrgsOrgMembersUsernameCodespacesGetResponse200Type,
@@ -1248,7 +1249,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgMembersUsernameCodespacesGetResponse200,
         OrgsOrgMembersUsernameCodespacesGetResponse200Type,
@@ -1286,7 +1287,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1321,7 +1322,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1356,7 +1357,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
@@ -1385,7 +1386,7 @@ class CodespacesClient:
         username: str,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/organizations#stop-a-codespace-for-an-organization-user"""
 
@@ -1415,7 +1416,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesGetResponse200,
         ReposOwnerRepoCodespacesGetResponse200Type,
@@ -1454,7 +1455,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesGetResponse200,
         ReposOwnerRepoCodespacesGetResponse200Type,
@@ -1492,7 +1493,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -1503,7 +1504,7 @@ class CodespacesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -1524,7 +1525,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -1575,7 +1576,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -1586,7 +1587,7 @@ class CodespacesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -1607,7 +1608,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoCodespacesPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -1659,7 +1660,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesDevcontainersGetResponse200,
         ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
@@ -1702,7 +1703,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesDevcontainersGetResponse200,
         ReposOwnerRepoCodespacesDevcontainersGetResponse200Type,
@@ -1746,7 +1747,7 @@ class CodespacesClient:
         location: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesMachinesGetResponse200,
         ReposOwnerRepoCodespacesMachinesGetResponse200Type,
@@ -1787,7 +1788,7 @@ class CodespacesClient:
         location: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesMachinesGetResponse200,
         ReposOwnerRepoCodespacesMachinesGetResponse200Type,
@@ -1827,7 +1828,7 @@ class CodespacesClient:
         *,
         ref: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesNewGetResponse200,
         ReposOwnerRepoCodespacesNewGetResponse200Type,
@@ -1865,7 +1866,7 @@ class CodespacesClient:
         *,
         ref: Missing[str] = UNSET,
         client_ip: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesNewGetResponse200,
         ReposOwnerRepoCodespacesNewGetResponse200Type,
@@ -1903,7 +1904,7 @@ class CodespacesClient:
         *,
         ref: str,
         devcontainer_path: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodespacesPermissionsCheckForDevcontainer,
         CodespacesPermissionsCheckForDevcontainerType,
@@ -1948,7 +1949,7 @@ class CodespacesClient:
         *,
         ref: str,
         devcontainer_path: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         CodespacesPermissionsCheckForDevcontainer,
         CodespacesPermissionsCheckForDevcontainerType,
@@ -1993,7 +1994,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesSecretsGetResponse200,
         ReposOwnerRepoCodespacesSecretsGetResponse200Type,
@@ -2026,7 +2027,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoCodespacesSecretsGetResponse200,
         ReposOwnerRepoCodespacesSecretsGetResponse200Type,
@@ -2057,7 +2058,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
@@ -2079,7 +2080,7 @@ class CodespacesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesPublicKey, CodespacesPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-public-key"""
 
@@ -2102,7 +2103,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-secret"""
 
@@ -2125,7 +2126,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepoCodespacesSecret, RepoCodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#get-a-repository-secret"""
 
@@ -2149,7 +2150,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2161,7 +2162,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -2172,7 +2173,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2213,7 +2214,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2225,7 +2226,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -2236,7 +2237,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2276,7 +2277,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#delete-a-repository-secret"""
 
@@ -2296,7 +2297,7 @@ class CodespacesClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/repository-secrets#delete-a-repository-secret"""
 
@@ -2317,7 +2318,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2329,7 +2330,7 @@ class CodespacesClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         location: Missing[str] = UNSET,
         geo: Missing[
             Literal["EuropeWest", "SoutheastAsia", "UsEast", "UsWest"]
@@ -2350,7 +2351,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
@@ -2403,7 +2404,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2415,7 +2416,7 @@ class CodespacesClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         location: Missing[str] = UNSET,
         geo: Missing[
             Literal["EuropeWest", "SoutheastAsia", "UsEast", "UsWest"]
@@ -2436,7 +2437,7 @@ class CodespacesClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberCodespacesPostBodyType, None]
         ] = UNSET,
@@ -2488,7 +2489,7 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
@@ -2524,7 +2525,7 @@ class CodespacesClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_id: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[UserCodespacesGetResponse200, UserCodespacesGetResponse200Type]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#list-codespaces-for-the-authenticated-user"""
 
@@ -2558,7 +2559,7 @@ class CodespacesClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2567,7 +2568,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_id: int,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
@@ -2589,7 +2590,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pull_request: UserCodespacesPostBodyOneof1PropPullRequestType,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -2604,7 +2605,7 @@ class CodespacesClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
@@ -2655,7 +2656,7 @@ class CodespacesClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type],
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -2664,7 +2665,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_id: int,
         ref: Missing[str] = UNSET,
         location: Missing[str] = UNSET,
@@ -2686,7 +2687,7 @@ class CodespacesClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pull_request: UserCodespacesPostBodyOneof1PropPullRequestType,
         location: Missing[str] = UNSET,
         geo: Missing[
@@ -2701,7 +2702,7 @@ class CodespacesClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[UserCodespacesPostBodyOneof0Type, UserCodespacesPostBodyOneof1Type]
         ] = UNSET,
@@ -2753,7 +2754,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
     ]:
@@ -2783,7 +2784,7 @@ class CodespacesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsGetResponse200, UserCodespacesSecretsGetResponse200Type
     ]:
@@ -2811,7 +2812,7 @@ class CodespacesClient:
     def get_public_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
@@ -2831,7 +2832,7 @@ class CodespacesClient:
     async def async_get_public_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesUserPublicKey, CodespacesUserPublicKeyType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-public-key-for-the-authenticated-user"""
 
@@ -2852,7 +2853,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
@@ -2873,7 +2874,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespacesSecret, CodespacesSecretType]:
         """See also: https://docs.github.com/rest/codespaces/secrets#get-a-secret-for-the-authenticated-user"""
 
@@ -2895,7 +2896,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2905,7 +2906,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
@@ -2915,7 +2916,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -2958,7 +2959,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -2968,7 +2969,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: str,
         selected_repository_ids: Missing[list[Union[int, str]]] = UNSET,
@@ -2978,7 +2979,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -3020,7 +3021,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/secrets#delete-a-secret-for-the-authenticated-user"""
 
@@ -3038,7 +3039,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/secrets#delete-a-secret-for-the-authenticated-user"""
 
@@ -3056,7 +3057,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3089,7 +3090,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200,
         UserCodespacesSecretsSecretNameRepositoriesGetResponse200Type,
@@ -3123,7 +3124,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3133,7 +3134,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3141,7 +3142,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3185,7 +3186,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -3195,7 +3196,7 @@ class CodespacesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -3203,7 +3204,7 @@ class CodespacesClient:
         self,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesSecretsSecretNameRepositoriesPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3247,7 +3248,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/secrets#add-a-selected-repository-to-a-user-secret"""
 
@@ -3274,7 +3275,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/secrets#add-a-selected-repository-to-a-user-secret"""
 
@@ -3301,7 +3302,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/secrets#remove-a-selected-repository-from-a-user-secret"""
 
@@ -3328,7 +3329,7 @@ class CodespacesClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/codespaces/secrets#remove-a-selected-repository-from-a-user-secret"""
 
@@ -3354,7 +3355,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
@@ -3381,7 +3382,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-a-codespace-for-the-authenticated-user"""
 
@@ -3408,7 +3409,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -3441,7 +3442,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -3475,7 +3476,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -3485,7 +3486,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
@@ -3495,7 +3496,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -3534,7 +3535,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
     ) -> Response[Codespace, CodespaceType]: ...
 
@@ -3544,7 +3545,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         machine: Missing[str] = UNSET,
         display_name: Missing[str] = UNSET,
         recent_folders: Missing[list[str]] = UNSET,
@@ -3554,7 +3555,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Codespace, CodespaceType]:
@@ -3592,7 +3593,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
@@ -3620,7 +3621,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#export-a-codespace-for-the-authenticated-user"""
 
@@ -3649,7 +3650,7 @@ class CodespacesClient:
         codespace_name: str,
         export_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
@@ -3674,7 +3675,7 @@ class CodespacesClient:
         codespace_name: str,
         export_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodespaceExportDetails, CodespaceExportDetailsType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#get-details-about-a-codespace-export"""
 
@@ -3698,7 +3699,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesCodespaceNameMachinesGetResponse200,
         UserCodespacesCodespaceNameMachinesGetResponse200Type,
@@ -3731,7 +3732,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UserCodespacesCodespaceNameMachinesGetResponse200,
         UserCodespacesCodespaceNameMachinesGetResponse200Type,
@@ -3765,7 +3766,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
@@ -3775,7 +3776,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
@@ -3784,7 +3785,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
@@ -3831,7 +3832,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserCodespacesCodespaceNamePublishPostBodyType,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
 
@@ -3841,7 +3842,7 @@ class CodespacesClient:
         codespace_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         private: Missing[bool] = UNSET,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]: ...
@@ -3850,7 +3851,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserCodespacesCodespaceNamePublishPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CodespaceWithFullRepository, CodespaceWithFullRepositoryType]:
@@ -3896,7 +3897,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
@@ -3926,7 +3927,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#start-a-codespace-for-the-authenticated-user"""
 
@@ -3956,7 +3957,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 
@@ -3983,7 +3984,7 @@ class CodespacesClient:
         self,
         codespace_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Codespace, CodespaceType]:
         """See also: https://docs.github.com/rest/codespaces/codespaces#stop-a-codespace-for-the-authenticated-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/copilot.py
+++ b/githubkit/versions/v2022_11_28/rest/copilot.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -71,7 +72,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
@@ -98,7 +99,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotOrganizationDetails, CopilotOrganizationDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-information-and-settings-for-an-organization"""
 
@@ -127,7 +128,7 @@ class CopilotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCopilotBillingSeatsGetResponse200,
         OrgsOrgCopilotBillingSeatsGetResponse200Type,
@@ -165,7 +166,7 @@ class CopilotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgCopilotBillingSeatsGetResponse200,
         OrgsOrgCopilotBillingSeatsGetResponse200Type,
@@ -202,7 +203,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -215,7 +216,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -226,7 +227,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -275,7 +276,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -288,7 +289,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsPostResponse201,
@@ -299,7 +300,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -348,7 +349,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -361,7 +362,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -372,7 +373,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -421,7 +422,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -434,7 +435,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_teams: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedTeamsDeleteResponse200,
@@ -445,7 +446,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedTeamsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -494,7 +495,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -507,7 +508,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -518,7 +519,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -567,7 +568,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersPostBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -580,7 +581,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersPostResponse201,
@@ -591,7 +592,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -640,7 +641,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -653,7 +654,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -664,7 +665,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -713,7 +714,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgCopilotBillingSelectedUsersDeleteBodyType,
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -726,7 +727,7 @@ class CopilotClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_usernames: list[str],
     ) -> Response[
         OrgsOrgCopilotBillingSelectedUsersDeleteResponse200,
@@ -737,7 +738,7 @@ class CopilotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgCopilotBillingSelectedUsersDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -789,7 +790,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
@@ -828,7 +829,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-an-organization"""
 
@@ -867,7 +868,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
@@ -906,7 +907,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-organization-members"""
 
@@ -942,7 +943,7 @@ class CopilotClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
@@ -970,7 +971,7 @@ class CopilotClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CopilotSeatDetails, CopilotSeatDetailsType]:
         """See also: https://docs.github.com/rest/copilot/copilot-user-management#get-copilot-seat-assignment-details-for-a-user"""
 
@@ -1002,7 +1003,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
@@ -1042,7 +1043,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetricsDay], list[CopilotUsageMetricsDayType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-metrics#get-copilot-metrics-for-a-team"""
 
@@ -1082,7 +1083,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 
@@ -1122,7 +1123,7 @@ class CopilotClient:
         until: Missing[str] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CopilotUsageMetrics], list[CopilotUsageMetricsType]]:
         """See also: https://docs.github.com/rest/copilot/copilot-usage#get-a-summary-of-copilot-usage-for-a-team"""
 

--- a/githubkit/versions/v2022_11_28/rest/dependabot.py
+++ b/githubkit/versions/v2022_11_28/rest/dependabot.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -85,7 +86,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -145,7 +146,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -205,7 +206,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -266,7 +267,7 @@ class DependabotClient:
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[DependabotAlertWithRepository], list[DependabotAlertWithRepositoryType]
     ]:
@@ -317,7 +318,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsGetResponse200,
         OrgsOrgDependabotSecretsGetResponse200Type,
@@ -349,7 +350,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsGetResponse200,
         OrgsOrgDependabotSecretsGetResponse200Type,
@@ -379,7 +380,7 @@ class DependabotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-public-key"""
 
@@ -400,7 +401,7 @@ class DependabotClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-public-key"""
 
@@ -422,7 +423,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-secret"""
 
@@ -444,7 +445,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationDependabotSecret, OrganizationDependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-an-organization-secret"""
 
@@ -467,7 +468,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -478,7 +479,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -490,7 +491,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -525,7 +526,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -536,7 +537,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
         visibility: Literal["all", "private", "selected"],
@@ -548,7 +549,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -582,7 +583,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#delete-an-organization-secret"""
 
@@ -601,7 +602,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#delete-an-organization-secret"""
 
@@ -622,7 +623,7 @@ class DependabotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
@@ -657,7 +658,7 @@ class DependabotClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200,
         OrgsOrgDependabotSecretsSecretNameRepositoriesGetResponse200Type,
@@ -691,7 +692,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -702,7 +703,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -711,7 +712,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -749,7 +750,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType,
     ) -> Response: ...
 
@@ -760,7 +761,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         selected_repository_ids: list[int],
     ) -> Response: ...
 
@@ -769,7 +770,7 @@ class DependabotClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgDependabotSecretsSecretNameRepositoriesPutBodyType
         ] = UNSET,
@@ -807,7 +808,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -830,7 +831,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#add-selected-repository-to-an-organization-secret"""
 
@@ -853,7 +854,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -876,7 +877,7 @@ class DependabotClient:
         secret_name: str,
         repository_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#remove-selected-repository-from-an-organization-secret"""
 
@@ -912,7 +913,7 @@ class DependabotClient:
         after: Missing[str] = UNSET,
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
@@ -972,7 +973,7 @@ class DependabotClient:
         after: Missing[str] = UNSET,
         first: Missing[int] = UNSET,
         last: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependabotAlert], list[DependabotAlertType]]:
         """See also: https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository"""
 
@@ -1019,7 +1020,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/rest/dependabot/alerts#get-a-dependabot-alert"""
 
@@ -1046,7 +1047,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotAlert, DependabotAlertType]:
         """See also: https://docs.github.com/rest/dependabot/alerts#get-a-dependabot-alert"""
 
@@ -1074,7 +1075,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
     ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
@@ -1086,7 +1087,7 @@ class DependabotClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["dismissed", "open"],
         dismissed_reason: Missing[
             Literal[
@@ -1106,7 +1107,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[DependabotAlert, DependabotAlertType]:
@@ -1156,7 +1157,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType,
     ) -> Response[DependabotAlert, DependabotAlertType]: ...
 
@@ -1168,7 +1169,7 @@ class DependabotClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["dismissed", "open"],
         dismissed_reason: Missing[
             Literal[
@@ -1188,7 +1189,7 @@ class DependabotClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotAlertsAlertNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[DependabotAlert, DependabotAlertType]:
@@ -1238,7 +1239,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoDependabotSecretsGetResponse200,
         ReposOwnerRepoDependabotSecretsGetResponse200Type,
@@ -1271,7 +1272,7 @@ class DependabotClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoDependabotSecretsGetResponse200,
         ReposOwnerRepoDependabotSecretsGetResponse200Type,
@@ -1302,7 +1303,7 @@ class DependabotClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-public-key"""
 
@@ -1324,7 +1325,7 @@ class DependabotClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotPublicKey, DependabotPublicKeyType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-public-key"""
 
@@ -1347,7 +1348,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-secret"""
 
@@ -1370,7 +1371,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependabotSecret, DependabotSecretType]:
         """See also: https://docs.github.com/rest/dependabot/secrets#get-a-repository-secret"""
 
@@ -1394,7 +1395,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1406,7 +1407,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -1417,7 +1418,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1458,7 +1459,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDependabotSecretsSecretNamePutBodyType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -1470,7 +1471,7 @@ class DependabotClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         encrypted_value: Missing[str] = UNSET,
         key_id: Missing[str] = UNSET,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
@@ -1481,7 +1482,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDependabotSecretsSecretNamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -1521,7 +1522,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#delete-a-repository-secret"""
 
@@ -1541,7 +1542,7 @@ class DependabotClient:
         repo: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/dependabot/secrets#delete-a-repository-secret"""
 

--- a/githubkit/versions/v2022_11_28/rest/dependency_graph.py
+++ b/githubkit/versions/v2022_11_28/rest/dependency_graph.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -65,7 +66,7 @@ class DependencyGraphClient:
         basehead: str,
         *,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
@@ -98,7 +99,7 @@ class DependencyGraphClient:
         basehead: str,
         *,
         name: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DependencyGraphDiffItems], list[DependencyGraphDiffItemsType]]:
         """See also: https://docs.github.com/rest/dependency-graph/dependency-review#get-a-diff-of-the-dependencies-between-commits"""
 
@@ -129,7 +130,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
@@ -155,7 +156,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DependencyGraphSpdxSbom, DependencyGraphSpdxSbomType]:
         """See also: https://docs.github.com/rest/dependency-graph/sboms#export-a-software-bill-of-materials-sbom-for-a-repository"""
 
@@ -182,7 +183,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: SnapshotType,
     ) -> Response[
         ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
@@ -196,7 +197,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         version: int,
         job: SnapshotPropJobType,
         sha: str,
@@ -215,7 +216,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -256,7 +257,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: SnapshotType,
     ) -> Response[
         ReposOwnerRepoDependencyGraphSnapshotsPostResponse201,
@@ -270,7 +271,7 @@ class DependencyGraphClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         version: int,
         job: SnapshotPropJobType,
         sha: str,
@@ -289,7 +290,7 @@ class DependencyGraphClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[SnapshotType] = UNSET,
         **kwargs,
     ) -> Response[

--- a/githubkit/versions/v2022_11_28/rest/emojis.py
+++ b/githubkit/versions/v2022_11_28/rest/emojis.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class EmojisClient:
     def get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/rest/emojis/emojis#get-emojis"""
 
@@ -60,7 +61,7 @@ class EmojisClient:
     async def async_get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[EmojisGetResponse200, EmojisGetResponse200Type]:
         """See also: https://docs.github.com/rest/emojis/emojis#get-emojis"""
 

--- a/githubkit/versions/v2022_11_28/rest/gists.py
+++ b/githubkit/versions/v2022_11_28/rest/gists.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -63,7 +64,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-the-authenticated-user"""
 
@@ -96,7 +97,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-the-authenticated-user"""
 
@@ -125,7 +126,7 @@ class GistsClient:
 
     @overload
     def create(
-        self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: GistsPostBodyType
     ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
@@ -133,7 +134,7 @@ class GistsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
@@ -142,7 +143,7 @@ class GistsClient:
     def create(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -178,7 +179,7 @@ class GistsClient:
 
     @overload
     async def async_create(
-        self, *, headers: Optional[dict[str, str]] = None, data: GistsPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: GistsPostBodyType
     ) -> Response[GistSimple, GistSimpleType]: ...
 
     @overload
@@ -186,7 +187,7 @@ class GistsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: GistsPostBodyPropFilesType,
         public: Missing[Union[bool, Literal["true", "false"]]] = UNSET,
@@ -195,7 +196,7 @@ class GistsClient:
     async def async_create(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -235,7 +236,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-public-gists"""
 
@@ -269,7 +270,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-public-gists"""
 
@@ -303,7 +304,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-starred-gists"""
 
@@ -337,7 +338,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-starred-gists"""
 
@@ -369,7 +370,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist"""
 
@@ -394,7 +395,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist"""
 
@@ -419,7 +420,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#delete-a-gist"""
 
@@ -443,7 +444,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#delete-a-gist"""
 
@@ -468,7 +469,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
     ) -> Response[GistSimple, GistSimpleType]: ...
 
@@ -478,7 +479,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
     ) -> Response[GistSimple, GistSimpleType]: ...
@@ -487,7 +488,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -532,7 +533,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[GistsGistIdPatchBodyType, None],
     ) -> Response[GistSimple, GistSimpleType]: ...
 
@@ -542,7 +543,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         description: Missing[str] = UNSET,
         files: Missing[GistsGistIdPatchBodyPropFilesType] = UNSET,
     ) -> Response[GistSimple, GistSimpleType]: ...
@@ -551,7 +552,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[GistsGistIdPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[GistSimple, GistSimpleType]:
@@ -597,7 +598,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/rest/gists/comments#list-gist-comments"""
 
@@ -630,7 +631,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistComment], list[GistCommentType]]:
         """See also: https://docs.github.com/rest/gists/comments#list-gist-comments"""
 
@@ -662,7 +663,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -672,7 +673,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -680,7 +681,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -718,7 +719,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsPostBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -728,7 +729,7 @@ class GistsClient:
         gist_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -736,7 +737,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -774,7 +775,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#get-a-gist-comment"""
 
@@ -800,7 +801,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistComment, GistCommentType]:
         """See also: https://docs.github.com/rest/gists/comments#get-a-gist-comment"""
 
@@ -826,7 +827,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/comments#delete-a-gist-comment"""
 
@@ -851,7 +852,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/comments#delete-a-gist-comment"""
 
@@ -877,7 +878,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -888,7 +889,7 @@ class GistsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -897,7 +898,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -939,7 +940,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: GistsGistIdCommentsCommentIdPatchBodyType,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -950,7 +951,7 @@ class GistsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[GistComment, GistCommentType]: ...
 
@@ -959,7 +960,7 @@ class GistsClient:
         gist_id: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[GistsGistIdCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GistComment, GistCommentType]:
@@ -1001,7 +1002,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-commits"""
 
@@ -1034,7 +1035,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistCommit], list[GistCommitType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-commits"""
 
@@ -1067,7 +1068,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-forks"""
 
@@ -1100,7 +1101,7 @@ class GistsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GistSimple], list[GistSimpleType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gist-forks"""
 
@@ -1131,7 +1132,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/rest/gists/gists#fork-a-gist"""
 
@@ -1157,7 +1158,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BaseGist, BaseGistType]:
         """See also: https://docs.github.com/rest/gists/gists#fork-a-gist"""
 
@@ -1183,7 +1184,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#check-if-a-gist-is-starred"""
 
@@ -1207,7 +1208,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#check-if-a-gist-is-starred"""
 
@@ -1231,7 +1232,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#star-a-gist"""
 
@@ -1255,7 +1256,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#star-a-gist"""
 
@@ -1279,7 +1280,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#unstar-a-gist"""
 
@@ -1303,7 +1304,7 @@ class GistsClient:
         self,
         gist_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/gists/gists#unstar-a-gist"""
 
@@ -1328,7 +1329,7 @@ class GistsClient:
         gist_id: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist-revision"""
 
@@ -1355,7 +1356,7 @@ class GistsClient:
         gist_id: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GistSimple, GistSimpleType]:
         """See also: https://docs.github.com/rest/gists/gists#get-a-gist-revision"""
 
@@ -1384,7 +1385,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-a-user"""
 
@@ -1418,7 +1419,7 @@ class GistsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BaseGist], list[BaseGistType]]:
         """See also: https://docs.github.com/rest/gists/gists#list-gists-for-a-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/git.py
+++ b/githubkit/versions/v2022_11_28/rest/git.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -68,7 +69,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
     ) -> Response[ShortBlob, ShortBlobType]: ...
 
@@ -79,7 +80,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
     ) -> Response[ShortBlob, ShortBlobType]: ...
@@ -89,7 +90,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ShortBlob, ShortBlobType]:
@@ -138,7 +139,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitBlobsPostBodyType,
     ) -> Response[ShortBlob, ShortBlobType]: ...
 
@@ -149,7 +150,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: str,
         encoding: Missing[str] = UNSET,
     ) -> Response[ShortBlob, ShortBlobType]: ...
@@ -159,7 +160,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitBlobsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ShortBlob, ShortBlobType]:
@@ -208,7 +209,7 @@ class GitClient:
         repo: str,
         file_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/rest/git/blobs#get-a-blob"""
 
@@ -237,7 +238,7 @@ class GitClient:
         repo: str,
         file_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Blob, BlobType]:
         """See also: https://docs.github.com/rest/git/blobs#get-a-blob"""
 
@@ -266,7 +267,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
     ) -> Response[GitCommit, GitCommitType]: ...
 
@@ -277,7 +278,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         tree: str,
         parents: Missing[list[str]] = UNSET,
@@ -291,7 +292,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitCommit, GitCommitType]:
@@ -336,7 +337,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitCommitsPostBodyType,
     ) -> Response[GitCommit, GitCommitType]: ...
 
@@ -347,7 +348,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         tree: str,
         parents: Missing[list[str]] = UNSET,
@@ -361,7 +362,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitCommitsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitCommit, GitCommitType]:
@@ -406,7 +407,7 @@ class GitClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/rest/git/commits#get-a-commit-object"""
 
@@ -433,7 +434,7 @@ class GitClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitCommit, GitCommitType]:
         """See also: https://docs.github.com/rest/git/commits#get-a-commit-object"""
 
@@ -460,7 +461,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/rest/git/refs#list-matching-references"""
 
@@ -486,7 +487,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GitRef], list[GitRefType]]:
         """See also: https://docs.github.com/rest/git/refs#list-matching-references"""
 
@@ -512,7 +513,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#get-a-reference"""
 
@@ -539,7 +540,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitRef, GitRefType]:
         """See also: https://docs.github.com/rest/git/refs#get-a-reference"""
 
@@ -566,7 +567,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -577,7 +578,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         sha: str,
     ) -> Response[GitRef, GitRefType]: ...
@@ -587,7 +588,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -631,7 +632,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsPostBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -642,7 +643,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         sha: str,
     ) -> Response[GitRef, GitRefType]: ...
@@ -652,7 +653,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -696,7 +697,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/git/refs#delete-a-reference"""
 
@@ -722,7 +723,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/git/refs#delete-a-reference"""
 
@@ -749,7 +750,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -761,7 +762,7 @@ class GitClient:
         ref: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
     ) -> Response[GitRef, GitRefType]: ...
@@ -772,7 +773,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -817,7 +818,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitRefsRefPatchBodyType,
     ) -> Response[GitRef, GitRefType]: ...
 
@@ -829,7 +830,7 @@ class GitClient:
         ref: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sha: str,
         force: Missing[bool] = UNSET,
     ) -> Response[GitRef, GitRefType]: ...
@@ -840,7 +841,7 @@ class GitClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitRefsRefPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitRef, GitRefType]:
@@ -884,7 +885,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
     ) -> Response[GitTag, GitTagType]: ...
 
@@ -895,7 +896,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag: str,
         message: str,
         object_: str,
@@ -908,7 +909,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTag, GitTagType]:
@@ -952,7 +953,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTagsPostBodyType,
     ) -> Response[GitTag, GitTagType]: ...
 
@@ -963,7 +964,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag: str,
         message: str,
         object_: str,
@@ -976,7 +977,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTagsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTag, GitTagType]:
@@ -1020,7 +1021,7 @@ class GitClient:
         repo: str,
         tag_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/rest/git/tags#get-a-tag"""
 
@@ -1047,7 +1048,7 @@ class GitClient:
         repo: str,
         tag_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTag, GitTagType]:
         """See also: https://docs.github.com/rest/git/tags#get-a-tag"""
 
@@ -1074,7 +1075,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
     ) -> Response[GitTree, GitTreeType]: ...
 
@@ -1085,7 +1086,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
     ) -> Response[GitTree, GitTreeType]: ...
@@ -1095,7 +1096,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTree, GitTreeType]:
@@ -1141,7 +1142,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoGitTreesPostBodyType,
     ) -> Response[GitTree, GitTreeType]: ...
 
@@ -1152,7 +1153,7 @@ class GitClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tree: list[ReposOwnerRepoGitTreesPostBodyPropTreeItemsType],
         base_tree: Missing[str] = UNSET,
     ) -> Response[GitTree, GitTreeType]: ...
@@ -1162,7 +1163,7 @@ class GitClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoGitTreesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GitTree, GitTreeType]:
@@ -1209,7 +1210,7 @@ class GitClient:
         tree_sha: str,
         *,
         recursive: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/rest/git/trees#get-a-tree"""
 
@@ -1243,7 +1244,7 @@ class GitClient:
         tree_sha: str,
         *,
         recursive: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitTree, GitTreeType]:
         """See also: https://docs.github.com/rest/git/trees#get-a-tree"""
 

--- a/githubkit/versions/v2022_11_28/rest/gitignore.py
+++ b/githubkit/versions/v2022_11_28/rest/gitignore.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class GitignoreClient:
     def get_all_templates(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-all-gitignore-templates"""
 
@@ -58,7 +59,7 @@ class GitignoreClient:
     async def async_get_all_templates(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-all-gitignore-templates"""
 
@@ -77,7 +78,7 @@ class GitignoreClient:
         self,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-a-gitignore-template"""
 
@@ -98,7 +99,7 @@ class GitignoreClient:
         self,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GitignoreTemplate, GitignoreTemplateType]:
         """See also: https://docs.github.com/rest/gitignore/gitignore#get-a-gitignore-template"""
 

--- a/githubkit/versions/v2022_11_28/rest/interactions.py
+++ b/githubkit/versions/v2022_11_28/rest/interactions.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -60,7 +61,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -94,7 +95,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, OrgsOrgInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -129,7 +130,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -139,7 +140,7 @@ class InteractionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -150,7 +151,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -187,7 +188,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -197,7 +198,7 @@ class InteractionsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -208,7 +209,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -244,7 +245,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/interactions/orgs#remove-interaction-restrictions-for-an-organization"""
 
@@ -262,7 +263,7 @@ class InteractionsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/interactions/orgs#remove-interaction-restrictions-for-an-organization"""
 
@@ -281,7 +282,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             InteractionLimitResponse,
@@ -320,7 +321,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             InteractionLimitResponse,
@@ -360,7 +361,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -371,7 +372,7 @@ class InteractionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -383,7 +384,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -419,7 +420,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: InteractionLimitType,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
@@ -430,7 +431,7 @@ class InteractionsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -442,7 +443,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -477,7 +478,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/interactions/repos#remove-interaction-restrictions-for-a-repository"""
 
@@ -497,7 +498,7 @@ class InteractionsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/interactions/repos#remove-interaction-restrictions-for-a-repository"""
 
@@ -515,7 +516,7 @@ class InteractionsClient:
     def get_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -547,7 +548,7 @@ class InteractionsClient:
     async def async_get_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[InteractionLimitResponse, UserInteractionLimitsGetResponse200Anyof1],
         Union[
@@ -578,7 +579,7 @@ class InteractionsClient:
 
     @overload
     def set_restrictions_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: InteractionLimitType
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
@@ -586,7 +587,7 @@ class InteractionsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -596,7 +597,7 @@ class InteractionsClient:
     def set_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -630,7 +631,7 @@ class InteractionsClient:
 
     @overload
     async def async_set_restrictions_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: InteractionLimitType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: InteractionLimitType
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]: ...
 
     @overload
@@ -638,7 +639,7 @@ class InteractionsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         limit: Literal["existing_users", "contributors_only", "collaborators_only"],
         expiry: Missing[
             Literal["one_day", "three_days", "one_week", "one_month", "six_months"]
@@ -648,7 +649,7 @@ class InteractionsClient:
     async def async_set_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[InteractionLimitType] = UNSET,
         **kwargs,
     ) -> Response[InteractionLimitResponse, InteractionLimitResponseType]:
@@ -683,7 +684,7 @@ class InteractionsClient:
     def remove_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/interactions/user#remove-interaction-restrictions-from-your-public-repositories"""
 
@@ -700,7 +701,7 @@ class InteractionsClient:
     async def async_remove_restrictions_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/interactions/user#remove-interaction-restrictions-from-your-public-repositories"""
 

--- a/githubkit/versions/v2022_11_28/rest/issues.py
+++ b/githubkit/versions/v2022_11_28/rest/issues.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Literal, Optional, overload
 from weakref import ref
 
@@ -149,7 +150,7 @@ class IssuesClient:
         pulls: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
@@ -203,7 +204,7 @@ class IssuesClient:
         pulls: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-issues-assigned-to-the-authenticated-user"""
 
@@ -254,7 +255,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
@@ -300,7 +301,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-organization-issues-assigned-to-the-authenticated-user"""
 
@@ -339,7 +340,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/issues/assignees#list-assignees"""
 
@@ -372,7 +373,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/issues/assignees#list-assignees"""
 
@@ -404,7 +405,7 @@ class IssuesClient:
         repo: str,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned"""
 
@@ -429,7 +430,7 @@ class IssuesClient:
         repo: str,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned"""
 
@@ -464,7 +465,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-repository-issues"""
 
@@ -516,7 +517,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-repository-issues"""
 
@@ -558,7 +559,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -569,7 +570,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Union[str, int],
         body: Missing[str] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -585,7 +586,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -634,7 +635,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -645,7 +646,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Union[str, int],
         body: Missing[str] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -661,7 +662,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -714,7 +715,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments-for-a-repository"""
 
@@ -754,7 +755,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments-for-a-repository"""
 
@@ -790,7 +791,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#get-an-issue-comment"""
 
@@ -816,7 +817,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueComment, IssueCommentType]:
         """See also: https://docs.github.com/rest/issues/comments#get-an-issue-comment"""
 
@@ -842,7 +843,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/comments#delete-an-issue-comment"""
 
@@ -862,7 +863,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/comments#delete-an-issue-comment"""
 
@@ -883,7 +884,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -895,7 +896,7 @@ class IssuesClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -905,7 +906,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -950,7 +951,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -962,7 +963,7 @@ class IssuesClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -972,7 +973,7 @@ class IssuesClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -1017,7 +1018,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/rest/issues/events#list-issue-events-for-a-repository"""
 
@@ -1050,7 +1051,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueEvent], list[IssueEventType]]:
         """See also: https://docs.github.com/rest/issues/events#list-issue-events-for-a-repository"""
 
@@ -1082,7 +1083,7 @@ class IssuesClient:
         repo: str,
         event_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/rest/issues/events#get-an-issue-event"""
 
@@ -1110,7 +1111,7 @@ class IssuesClient:
         repo: str,
         event_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[IssueEvent, IssueEventType]:
         """See also: https://docs.github.com/rest/issues/events#get-an-issue-event"""
 
@@ -1138,7 +1139,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#get-an-issue"""
 
@@ -1165,7 +1166,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Issue, IssueType]:
         """See also: https://docs.github.com/rest/issues/issues#get-an-issue"""
 
@@ -1193,7 +1194,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1205,7 +1206,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[Union[str, int, None]] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -1231,7 +1232,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1280,7 +1281,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1292,7 +1293,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[Union[str, int, None]] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         assignee: Missing[Union[str, None]] = UNSET,
@@ -1318,7 +1319,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1367,7 +1368,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1379,7 +1380,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1389,7 +1390,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1427,7 +1428,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1439,7 +1440,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1449,7 +1450,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1487,7 +1488,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1499,7 +1500,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1509,7 +1510,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1547,7 +1548,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1559,7 +1560,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         assignees: Missing[list[str]] = UNSET,
     ) -> Response[Issue, IssueType]: ...
 
@@ -1569,7 +1570,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberAssigneesDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -1607,7 +1608,7 @@ class IssuesClient:
         issue_number: int,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned-to-a-issue"""
 
@@ -1633,7 +1634,7 @@ class IssuesClient:
         issue_number: int,
         assignee: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned-to-a-issue"""
 
@@ -1661,7 +1662,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments"""
 
@@ -1698,7 +1699,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[IssueComment], list[IssueCommentType]]:
         """See also: https://docs.github.com/rest/issues/comments#list-issue-comments"""
 
@@ -1733,7 +1734,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1745,7 +1746,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1755,7 +1756,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -1804,7 +1805,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1816,7 +1817,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[IssueComment, IssueCommentType]: ...
 
@@ -1826,7 +1827,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[IssueComment, IssueCommentType]:
@@ -1876,7 +1877,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -1986,7 +1987,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -2096,7 +2097,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-an-issue"""
 
@@ -2131,7 +2132,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-an-issue"""
 
@@ -2165,7 +2166,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2185,7 +2186,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2197,7 +2198,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2209,7 +2210,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2281,7 +2282,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2301,7 +2302,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2313,7 +2314,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2325,7 +2326,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPutBodyOneof0Type,
@@ -2397,7 +2398,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2417,7 +2418,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2429,7 +2430,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2441,7 +2442,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2513,7 +2514,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2533,7 +2534,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[list[str]] = UNSET,
     ) -> Response[list[Label], list[LabelType]]: ...
 
@@ -2545,7 +2546,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         labels: Missing[
             list[ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof2PropLabelsItemsType]
         ] = UNSET,
@@ -2557,7 +2558,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoIssuesIssueNumberLabelsPostBodyOneof0Type,
@@ -2628,7 +2629,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/labels#remove-all-labels-from-an-issue"""
 
@@ -2654,7 +2655,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/labels#remove-all-labels-from-an-issue"""
 
@@ -2681,7 +2682,7 @@ class IssuesClient:
         issue_number: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue"""
 
@@ -2709,7 +2710,7 @@ class IssuesClient:
         issue_number: int,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue"""
 
@@ -2737,7 +2738,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2751,7 +2752,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_reason: Missing[
             Literal["off-topic", "too heated", "resolved", "spam"]
         ] = UNSET,
@@ -2763,7 +2764,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2814,7 +2815,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2828,7 +2829,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_reason: Missing[
             Literal["off-topic", "too heated", "resolved", "spam"]
         ] = UNSET,
@@ -2840,7 +2841,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoIssuesIssueNumberLockPutBodyType, None]
         ] = UNSET,
@@ -2890,7 +2891,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/issues#unlock-an-issue"""
 
@@ -2916,7 +2917,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/issues#unlock-an-issue"""
 
@@ -2943,7 +2944,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -2955,7 +2956,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
     ) -> Response[Issue, IssueType]: ...
 
@@ -2965,7 +2966,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3011,7 +3012,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3023,7 +3024,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3033,7 +3034,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssueDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3080,7 +3081,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/sub-issues#list-sub-issues"""
 
@@ -3115,7 +3116,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/sub-issues#list-sub-issues"""
 
@@ -3149,7 +3150,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3161,7 +3162,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         replace_parent: Missing[bool] = UNSET,
     ) -> Response[Issue, IssueType]: ...
@@ -3172,7 +3173,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3221,7 +3222,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3233,7 +3234,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         replace_parent: Missing[bool] = UNSET,
     ) -> Response[Issue, IssueType]: ...
@@ -3244,7 +3245,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberSubIssuesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Issue, IssueType]:
@@ -3293,7 +3294,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3305,7 +3306,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         after_id: Missing[int] = UNSET,
         before_id: Missing[int] = UNSET,
@@ -3317,7 +3318,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType
         ] = UNSET,
@@ -3369,7 +3370,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType,
     ) -> Response[Issue, IssueType]: ...
 
@@ -3381,7 +3382,7 @@ class IssuesClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         sub_issue_id: int,
         after_id: Missing[int] = UNSET,
         before_id: Missing[int] = UNSET,
@@ -3393,7 +3394,7 @@ class IssuesClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesIssueNumberSubIssuesPriorityPatchBodyType
         ] = UNSET,
@@ -3446,7 +3447,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -3585,7 +3586,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -3723,7 +3724,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-a-repository"""
 
@@ -3756,7 +3757,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-a-repository"""
 
@@ -3788,7 +3789,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
     ) -> Response[Label, LabelType]: ...
 
@@ -3799,7 +3800,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -3810,7 +3811,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -3854,7 +3855,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoLabelsPostBodyType,
     ) -> Response[Label, LabelType]: ...
 
@@ -3865,7 +3866,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -3876,7 +3877,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -3920,7 +3921,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#get-a-label"""
 
@@ -3946,7 +3947,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Label, LabelType]:
         """See also: https://docs.github.com/rest/issues/labels#get-a-label"""
 
@@ -3972,7 +3973,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/labels#delete-a-label"""
 
@@ -3992,7 +3993,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/labels#delete-a-label"""
 
@@ -4013,7 +4014,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
     ) -> Response[Label, LabelType]: ...
 
@@ -4025,7 +4026,7 @@ class IssuesClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -4037,7 +4038,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -4073,7 +4074,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
     ) -> Response[Label, LabelType]: ...
 
@@ -4085,7 +4086,7 @@ class IssuesClient:
         name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: Missing[str] = UNSET,
         color: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
@@ -4097,7 +4098,7 @@ class IssuesClient:
         repo: str,
         name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoLabelsNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Label, LabelType]:
@@ -4136,7 +4137,7 @@ class IssuesClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/rest/issues/milestones#list-milestones"""
 
@@ -4175,7 +4176,7 @@ class IssuesClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Milestone], list[MilestoneType]]:
         """See also: https://docs.github.com/rest/issues/milestones#list-milestones"""
 
@@ -4210,7 +4211,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4221,7 +4222,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4233,7 +4234,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4277,7 +4278,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMilestonesPostBodyType,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4288,7 +4289,7 @@ class IssuesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4300,7 +4301,7 @@ class IssuesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4344,7 +4345,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#get-a-milestone"""
 
@@ -4370,7 +4371,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Milestone, MilestoneType]:
         """See also: https://docs.github.com/rest/issues/milestones#get-a-milestone"""
 
@@ -4396,7 +4397,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/milestones#delete-a-milestone"""
 
@@ -4421,7 +4422,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/issues/milestones#delete-a-milestone"""
 
@@ -4447,7 +4448,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4459,7 +4460,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4472,7 +4473,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4510,7 +4511,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
     ) -> Response[Milestone, MilestoneType]: ...
 
@@ -4522,7 +4523,7 @@ class IssuesClient:
         milestone_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
         description: Missing[str] = UNSET,
@@ -4535,7 +4536,7 @@ class IssuesClient:
         repo: str,
         milestone_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMilestonesMilestoneNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Milestone, MilestoneType]:
@@ -4574,7 +4575,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
@@ -4605,7 +4606,7 @@ class IssuesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Label], list[LabelType]]:
         """See also: https://docs.github.com/rest/issues/labels#list-labels-for-issues-in-a-milestone"""
 
@@ -4641,7 +4642,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 
@@ -4686,7 +4687,7 @@ class IssuesClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Issue], list[IssueType]]:
         """See also: https://docs.github.com/rest/issues/issues#list-user-account-issues-assigned-to-the-authenticated-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/licenses.py
+++ b/githubkit/versions/v2022_11_28/rest/licenses.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -46,7 +47,7 @@ class LicensesClient:
         featured: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-all-commonly-used-licenses"""
 
@@ -76,7 +77,7 @@ class LicensesClient:
         featured: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[LicenseSimple], list[LicenseSimpleType]]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-all-commonly-used-licenses"""
 
@@ -104,7 +105,7 @@ class LicensesClient:
         self,
         license_: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-a-license"""
 
@@ -129,7 +130,7 @@ class LicensesClient:
         self,
         license_: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[License, LicenseType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-a-license"""
 
@@ -156,7 +157,7 @@ class LicensesClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-the-license-for-a-repository"""
 
@@ -187,7 +188,7 @@ class LicensesClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[LicenseContent, LicenseContentType]:
         """See also: https://docs.github.com/rest/licenses/licenses#get-the-license-for-a-repository"""
 

--- a/githubkit/versions/v2022_11_28/rest/markdown.py
+++ b/githubkit/versions/v2022_11_28/rest/markdown.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -46,7 +47,7 @@ class MarkdownClient:
 
     @overload
     def render(
-        self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: MarkdownPostBodyType
     ) -> Response[str, str]: ...
 
     @overload
@@ -54,7 +55,7 @@ class MarkdownClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
@@ -63,7 +64,7 @@ class MarkdownClient:
     def render(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[str, str]:
@@ -94,7 +95,7 @@ class MarkdownClient:
 
     @overload
     async def async_render(
-        self, *, headers: Optional[dict[str, str]] = None, data: MarkdownPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: MarkdownPostBodyType
     ) -> Response[str, str]: ...
 
     @overload
@@ -102,7 +103,7 @@ class MarkdownClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         text: str,
         mode: Missing[Literal["markdown", "gfm"]] = UNSET,
         context: Missing[str] = UNSET,
@@ -111,7 +112,7 @@ class MarkdownClient:
     async def async_render(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[MarkdownPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[str, str]:
@@ -143,7 +144,7 @@ class MarkdownClient:
     def render_raw(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: str,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""
@@ -169,7 +170,7 @@ class MarkdownClient:
     async def async_render_raw(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: str,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/markdown/markdown#render-a-markdown-document-in-raw-mode"""

--- a/githubkit/versions/v2022_11_28/rest/meta.py
+++ b/githubkit/versions/v2022_11_28/rest/meta.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -45,7 +46,7 @@ class MetaClient:
     def root(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/rest/meta/meta#github-api-root"""
 
@@ -65,7 +66,7 @@ class MetaClient:
     async def async_root(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Root, RootType]:
         """See also: https://docs.github.com/rest/meta/meta#github-api-root"""
 
@@ -85,7 +86,7 @@ class MetaClient:
     def get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/rest/meta/meta#get-apiname-meta-information"""
 
@@ -105,7 +106,7 @@ class MetaClient:
     async def async_get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiOverview, ApiOverviewType]:
         """See also: https://docs.github.com/rest/meta/meta#get-apiname-meta-information"""
 
@@ -126,7 +127,7 @@ class MetaClient:
         self,
         *,
         s: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-octocat"""
 
@@ -150,7 +151,7 @@ class MetaClient:
         self,
         *,
         s: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-octocat"""
 
@@ -173,7 +174,7 @@ class MetaClient:
     def get_all_versions(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/rest/meta/meta#get-all-api-versions"""
 
@@ -198,7 +199,7 @@ class MetaClient:
     async def async_get_all_versions(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[date], list[date]]:
         """See also: https://docs.github.com/rest/meta/meta#get-all-api-versions"""
 
@@ -223,7 +224,7 @@ class MetaClient:
     def get_zen(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-the-zen-of-github"""
 
@@ -241,7 +242,7 @@ class MetaClient:
     async def async_get_zen(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[str, str]:
         """See also: https://docs.github.com/rest/meta/meta#get-the-zen-of-github"""
 

--- a/githubkit/versions/v2022_11_28/rest/migrations.py
+++ b/githubkit/versions/v2022_11_28/rest/migrations.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -70,7 +71,7 @@ class MigrationsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-organization-migrations"""
 
@@ -101,7 +102,7 @@ class MigrationsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-organization-migrations"""
 
@@ -130,7 +131,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -140,7 +141,7 @@ class MigrationsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: list[str],
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
@@ -156,7 +157,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -199,7 +200,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -209,7 +210,7 @@ class MigrationsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repositories: list[str],
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
@@ -225,7 +226,7 @@ class MigrationsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -269,7 +270,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/orgs#get-an-organization-migration-status"""
 
@@ -300,7 +301,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[Literal["repositories"]]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/orgs#get-an-organization-migration-status"""
 
@@ -330,7 +331,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/orgs#download-an-organization-migration-archive"""
 
@@ -354,7 +355,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/orgs#download-an-organization-migration-archive"""
 
@@ -378,7 +379,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/orgs#delete-an-organization-migration-archive"""
 
@@ -402,7 +403,7 @@ class MigrationsClient:
         org: str,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/orgs#delete-an-organization-migration-archive"""
 
@@ -427,7 +428,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/orgs#unlock-an-organization-repository"""
 
@@ -452,7 +453,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/orgs#unlock-an-organization-repository"""
 
@@ -478,7 +479,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
@@ -511,7 +512,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/orgs#list-repositories-in-an-organization-migration"""
 
@@ -542,7 +543,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-an-import-status"""
 
@@ -568,7 +569,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Import, ImportType]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-an-import-status"""
 
@@ -595,7 +596,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -606,7 +607,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_url: str,
         vcs: Missing[Literal["subversion", "git", "mercurial", "tfvc"]] = UNSET,
         vcs_username: Missing[str] = UNSET,
@@ -619,7 +620,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -664,7 +665,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportPutBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -675,7 +676,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_url: str,
         vcs: Missing[Literal["subversion", "git", "mercurial", "tfvc"]] = UNSET,
         vcs_username: Missing[str] = UNSET,
@@ -688,7 +689,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -732,7 +733,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/source-imports#cancel-an-import"""
 
@@ -756,7 +757,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/source-imports#cancel-an-import"""
 
@@ -781,7 +782,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
     ) -> Response[Import, ImportType]: ...
 
@@ -792,7 +793,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
@@ -804,7 +805,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -846,7 +847,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
     ) -> Response[Import, ImportType]: ...
 
@@ -857,7 +858,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         vcs_username: Missing[str] = UNSET,
         vcs_password: Missing[str] = UNSET,
         vcs: Missing[Literal["subversion", "tfvc", "git", "mercurial"]] = UNSET,
@@ -869,7 +870,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoImportPatchBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -911,7 +912,7 @@ class MigrationsClient:
         repo: str,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-commit-authors"""
 
@@ -943,7 +944,7 @@ class MigrationsClient:
         repo: str,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterAuthor], list[PorterAuthorType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-commit-authors"""
 
@@ -976,7 +977,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
@@ -988,7 +989,7 @@ class MigrationsClient:
         author_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
@@ -999,7 +1000,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PorterAuthor, PorterAuthorType]:
@@ -1047,7 +1048,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
 
@@ -1059,7 +1060,7 @@ class MigrationsClient:
         author_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         email: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
     ) -> Response[PorterAuthor, PorterAuthorType]: ...
@@ -1070,7 +1071,7 @@ class MigrationsClient:
         repo: str,
         author_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportAuthorsAuthorIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PorterAuthor, PorterAuthorType]:
@@ -1116,7 +1117,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-large-files"""
 
@@ -1141,7 +1142,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PorterLargeFile], list[PorterLargeFileType]]:
         """See also: https://docs.github.com/rest/migrations/source-imports#get-large-files"""
 
@@ -1167,7 +1168,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -1178,7 +1179,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
     ) -> Response[Import, ImportType]: ...
 
@@ -1187,7 +1188,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -1231,7 +1232,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoImportLfsPatchBodyType,
     ) -> Response[Import, ImportType]: ...
 
@@ -1242,7 +1243,7 @@ class MigrationsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         use_lfs: Literal["opt_in", "opt_out"],
     ) -> Response[Import, ImportType]: ...
 
@@ -1251,7 +1252,7 @@ class MigrationsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoImportLfsPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Import, ImportType]:
@@ -1294,7 +1295,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-user-migrations"""
 
@@ -1326,7 +1327,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Migration], list[MigrationType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-user-migrations"""
 
@@ -1357,7 +1358,7 @@ class MigrationsClient:
     def start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -1366,7 +1367,7 @@ class MigrationsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
         exclude_git_data: Missing[bool] = UNSET,
@@ -1381,7 +1382,7 @@ class MigrationsClient:
     def start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -1424,7 +1425,7 @@ class MigrationsClient:
     async def async_start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMigrationsPostBodyType,
     ) -> Response[Migration, MigrationType]: ...
 
@@ -1433,7 +1434,7 @@ class MigrationsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         lock_repositories: Missing[bool] = UNSET,
         exclude_metadata: Missing[bool] = UNSET,
         exclude_git_data: Missing[bool] = UNSET,
@@ -1448,7 +1449,7 @@ class MigrationsClient:
     async def async_start_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMigrationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Migration, MigrationType]:
@@ -1492,7 +1493,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[str]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/users#get-a-user-migration-status"""
 
@@ -1524,7 +1525,7 @@ class MigrationsClient:
         migration_id: int,
         *,
         exclude: Missing[list[str]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Migration, MigrationType]:
         """See also: https://docs.github.com/rest/migrations/users#get-a-user-migration-status"""
 
@@ -1555,7 +1556,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/users#download-a-user-migration-archive"""
 
@@ -1579,7 +1580,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/users#download-a-user-migration-archive"""
 
@@ -1603,7 +1604,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/users#delete-a-user-migration-archive"""
 
@@ -1628,7 +1629,7 @@ class MigrationsClient:
         self,
         migration_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/users#delete-a-user-migration-archive"""
 
@@ -1654,7 +1655,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/users#unlock-a-user-repository"""
 
@@ -1680,7 +1681,7 @@ class MigrationsClient:
         migration_id: int,
         repo_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/migrations/users#unlock-a-user-repository"""
 
@@ -1707,7 +1708,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-repositories-for-a-user-migration"""
 
@@ -1739,7 +1740,7 @@ class MigrationsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/migrations/users#list-repositories-for-a-user-migration"""
 

--- a/githubkit/versions/v2022_11_28/rest/oidc.py
+++ b/githubkit/versions/v2022_11_28/rest/oidc.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, overload
 from weakref import ref
 
@@ -45,7 +46,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
@@ -66,7 +67,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OidcCustomSub, OidcCustomSubType]:
         """See also: https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization"""
 
@@ -88,7 +89,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OidcCustomSubType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -98,7 +99,7 @@ class OidcClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         include_claim_keys: list[str],
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -106,7 +107,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:
@@ -144,7 +145,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OidcCustomSubType,
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -154,7 +155,7 @@ class OidcClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         include_claim_keys: list[str],
     ) -> Response[EmptyObject, EmptyObjectType]: ...
 
@@ -162,7 +163,7 @@ class OidcClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OidcCustomSubType] = UNSET,
         **kwargs,
     ) -> Response[EmptyObject, EmptyObjectType]:

--- a/githubkit/versions/v2022_11_28/rest/orgs.py
+++ b/githubkit/versions/v2022_11_28/rest/orgs.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -130,7 +131,7 @@ class OrgsClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations"""
 
@@ -158,7 +159,7 @@ class OrgsClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations"""
 
@@ -185,7 +186,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/rest/orgs/orgs#get-an-organization"""
 
@@ -209,7 +210,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationFull, OrganizationFullType]:
         """See also: https://docs.github.com/rest/orgs/orgs#get-an-organization"""
 
@@ -233,7 +234,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -264,7 +265,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -296,7 +297,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
     ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
@@ -306,7 +307,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         billing_email: Missing[str] = UNSET,
         company: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
@@ -349,7 +350,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationFull, OrganizationFullType]:
@@ -395,7 +396,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
     ) -> Response[OrganizationFull, OrganizationFullType]: ...
 
@@ -405,7 +406,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         billing_email: Missing[str] = UNSET,
         company: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
@@ -448,7 +449,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationFull, OrganizationFullType]:
@@ -497,7 +498,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgAttestationsSubjectDigestGetResponse200,
         OrgsOrgAttestationsSubjectDigestGetResponse200Type,
@@ -532,7 +533,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgAttestationsSubjectDigestGetResponse200,
         OrgsOrgAttestationsSubjectDigestGetResponse200Type,
@@ -565,7 +566,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
@@ -594,7 +595,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/blocking#list-users-blocked-by-an-organization"""
 
@@ -622,7 +623,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization"""
 
@@ -646,7 +647,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/blocking#check-if-a-user-is-blocked-by-an-organization"""
 
@@ -670,7 +671,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/blocking#block-a-user-from-an-organization"""
 
@@ -694,7 +695,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/blocking#block-a-user-from-an-organization"""
 
@@ -718,7 +719,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/blocking#unblock-a-user-from-an-organization"""
 
@@ -737,7 +738,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/blocking#unblock-a-user-from-an-organization"""
 
@@ -757,7 +758,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-failed-organization-invitations"""
 
@@ -789,7 +790,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-failed-organization-invitations"""
 
@@ -821,7 +822,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-organization-webhooks"""
 
@@ -853,7 +854,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgHook], list[OrgHookType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-organization-webhooks"""
 
@@ -884,7 +885,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -894,7 +895,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
@@ -905,7 +906,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -943,7 +944,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgHooksPostBodyType,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -953,7 +954,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         config: OrgsOrgHooksPostBodyPropConfigType,
         events: Missing[list[str]] = UNSET,
@@ -964,7 +965,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -1002,7 +1003,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-an-organization-webhook"""
 
@@ -1027,7 +1028,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgHook, OrgHookType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-an-organization-webhook"""
 
@@ -1052,7 +1053,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/webhooks#delete-an-organization-webhook"""
 
@@ -1076,7 +1077,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/webhooks#delete-an-organization-webhook"""
 
@@ -1101,7 +1102,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -1112,7 +1113,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[OrgsOrgHooksHookIdPatchBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
@@ -1124,7 +1125,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -1168,7 +1169,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
     ) -> Response[OrgHook, OrgHookType]: ...
 
@@ -1179,7 +1180,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[OrgsOrgHooksHookIdPatchBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         active: Missing[bool] = UNSET,
@@ -1191,7 +1192,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgHook, OrgHookType]:
@@ -1234,7 +1235,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
@@ -1256,7 +1257,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-configuration-for-an-organization"""
 
@@ -1279,7 +1280,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -1290,7 +1291,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -1302,7 +1303,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -1337,7 +1338,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -1348,7 +1349,7 @@ class OrgsClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -1360,7 +1361,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -1396,7 +1397,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
@@ -1430,7 +1431,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/orgs/webhooks#list-deliveries-for-an-organization-webhook"""
 
@@ -1463,7 +1464,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
@@ -1490,7 +1491,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/orgs/webhooks#get-a-webhook-delivery-for-an-organization-webhook"""
 
@@ -1517,7 +1518,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1551,7 +1552,7 @@ class OrgsClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1584,7 +1585,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/webhooks#ping-an-organization-webhook"""
 
@@ -1608,7 +1609,7 @@ class OrgsClient:
         org: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/webhooks#ping-an-organization-webhook"""
 
@@ -1657,7 +1658,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         api_route_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
     ]:
@@ -1717,7 +1718,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         api_route_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsRouteStatsItems], list[ApiInsightsRouteStatsItemsType]
     ]:
@@ -1768,7 +1769,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         subject_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
     ]:
@@ -1819,7 +1820,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         subject_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[ApiInsightsSubjectStatsItems], list[ApiInsightsSubjectStatsItemsType]
     ]:
@@ -1855,7 +1856,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats"""
 
@@ -1884,7 +1885,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats"""
 
@@ -1914,7 +1915,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-user"""
 
@@ -1944,7 +1945,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-user"""
 
@@ -1981,7 +1982,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-actor"""
 
@@ -2018,7 +2019,7 @@ class OrgsClient:
         *,
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ApiInsightsSummaryStats, ApiInsightsSummaryStatsType]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-summary-stats-by-actor"""
 
@@ -2048,7 +2049,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats"""
 
@@ -2079,7 +2080,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats"""
 
@@ -2111,7 +2112,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-user"""
 
@@ -2143,7 +2144,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-user"""
 
@@ -2182,7 +2183,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-actor"""
 
@@ -2221,7 +2222,7 @@ class OrgsClient:
         min_timestamp: str,
         max_timestamp: Missing[str] = UNSET,
         timestamp_increment: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsTimeStatsItems], list[ApiInsightsTimeStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-time-stats-by-actor"""
 
@@ -2267,7 +2268,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         actor_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-user-stats"""
 
@@ -2317,7 +2318,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         actor_name_substring: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ApiInsightsUserStatsItems], list[ApiInsightsUserStatsItemsType]]:
         """See also: https://docs.github.com/rest/orgs/api-insights#get-user-stats"""
 
@@ -2351,7 +2352,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
     ]:
@@ -2382,7 +2383,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgInstallationsGetResponse200, OrgsOrgInstallationsGetResponse200Type
     ]:
@@ -2419,7 +2420,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-pending-organization-invitations"""
 
@@ -2459,7 +2460,7 @@ class OrgsClient:
             ]
         ] = UNSET,
         invitation_source: Missing[Literal["all", "member", "scim"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-pending-organization-invitations"""
 
@@ -2492,7 +2493,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
@@ -2502,7 +2503,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         invitee_id: Missing[int] = UNSET,
         email: Missing[str] = UNSET,
         role: Missing[
@@ -2515,7 +2516,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
@@ -2558,7 +2559,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]: ...
 
@@ -2568,7 +2569,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         invitee_id: Missing[int] = UNSET,
         email: Missing[str] = UNSET,
         role: Missing[
@@ -2581,7 +2582,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgInvitationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrganizationInvitation, OrganizationInvitationType]:
@@ -2624,7 +2625,7 @@ class OrgsClient:
         org: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#cancel-an-organization-invitation"""
 
@@ -2649,7 +2650,7 @@ class OrgsClient:
         org: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#cancel-an-organization-invitation"""
 
@@ -2676,7 +2677,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-invitation-teams"""
 
@@ -2709,7 +2710,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-invitation-teams"""
 
@@ -2743,7 +2744,7 @@ class OrgsClient:
         role: Missing[Literal["all", "admin", "member"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-members"""
 
@@ -2779,7 +2780,7 @@ class OrgsClient:
         role: Missing[Literal["all", "admin", "member"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-members"""
 
@@ -2812,7 +2813,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#check-organization-membership-for-a-user"""
 
@@ -2832,7 +2833,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#check-organization-membership-for-a-user"""
 
@@ -2852,7 +2853,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#remove-an-organization-member"""
 
@@ -2876,7 +2877,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#remove-an-organization-member"""
 
@@ -2900,7 +2901,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-organization-membership-for-a-user"""
 
@@ -2926,7 +2927,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-organization-membership-for-a-user"""
 
@@ -2953,7 +2954,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -2964,7 +2965,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -2973,7 +2974,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -3017,7 +3018,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -3028,7 +3029,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["admin", "member"]] = UNSET,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -3037,7 +3038,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -3080,7 +3081,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#remove-organization-membership-for-a-user"""
 
@@ -3105,7 +3106,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#remove-organization-membership-for-a-user"""
 
@@ -3129,7 +3130,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgOrganizationRolesGetResponse200,
         OrgsOrgOrganizationRolesGetResponse200Type,
@@ -3161,7 +3162,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgOrganizationRolesGetResponse200,
         OrgsOrgOrganizationRolesGetResponse200Type,
@@ -3194,7 +3195,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-all-organization-roles-for-a-team"""
 
@@ -3213,7 +3214,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-all-organization-roles-for-a-team"""
 
@@ -3233,7 +3234,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#assign-an-organization-role-to-a-team"""
 
@@ -3254,7 +3255,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#assign-an-organization-role-to-a-team"""
 
@@ -3275,7 +3276,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-an-organization-role-from-a-team"""
 
@@ -3295,7 +3296,7 @@ class OrgsClient:
         team_slug: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-an-organization-role-from-a-team"""
 
@@ -3314,7 +3315,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-all-organization-roles-for-a-user"""
 
@@ -3333,7 +3334,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-all-organization-roles-for-a-user"""
 
@@ -3353,7 +3354,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#assign-an-organization-role-to-a-user"""
 
@@ -3374,7 +3375,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#assign-an-organization-role-to-a-user"""
 
@@ -3395,7 +3396,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-an-organization-role-from-a-user"""
 
@@ -3415,7 +3416,7 @@ class OrgsClient:
         username: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/organization-roles#remove-an-organization-role-from-a-user"""
 
@@ -3434,7 +3435,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#get-an-organization-role"""
 
@@ -3460,7 +3461,7 @@ class OrgsClient:
         org: str,
         role_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrganizationRole, OrganizationRoleType]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#get-an-organization-role"""
 
@@ -3488,7 +3489,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
@@ -3519,7 +3520,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamRoleAssignment], list[TeamRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-teams-that-are-assigned-to-an-organization-role"""
 
@@ -3550,7 +3551,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
@@ -3581,7 +3582,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[UserRoleAssignment], list[UserRoleAssignmentType]]:
         """See also: https://docs.github.com/rest/orgs/organization-roles#list-users-that-are-assigned-to-an-organization-role"""
 
@@ -3612,7 +3613,7 @@ class OrgsClient:
         filter_: Missing[Literal["2fa_disabled", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
@@ -3643,7 +3644,7 @@ class OrgsClient:
         filter_: Missing[Literal["2fa_disabled", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#list-outside-collaborators-for-an-organization"""
 
@@ -3673,7 +3674,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -3687,7 +3688,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         async_: Missing[bool] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -3699,7 +3700,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -3746,7 +3747,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -3760,7 +3761,7 @@ class OrgsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         async_: Missing[bool] = UNSET,
     ) -> Response[
         OrgsOrgOutsideCollaboratorsUsernamePutResponse202,
@@ -3772,7 +3773,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgOutsideCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -3818,7 +3819,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization"""
 
@@ -3842,7 +3843,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/outside-collaborators#remove-outside-collaborator-from-an-organization"""
 
@@ -3874,7 +3875,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrantRequest],
         list[OrganizationProgrammaticAccessGrantRequestType],
@@ -3930,7 +3931,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrantRequest],
         list[OrganizationProgrammaticAccessGrantRequestType],
@@ -3978,7 +3979,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -3991,7 +3992,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
@@ -4004,7 +4005,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -4054,7 +4055,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -4067,7 +4068,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pat_request_ids: Missing[list[int]] = UNSET,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
@@ -4080,7 +4081,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokenRequestsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -4131,7 +4132,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
     ) -> Response: ...
 
@@ -4142,7 +4143,7 @@ class OrgsClient:
         pat_request_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
     ) -> Response: ...
@@ -4152,7 +4153,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType
         ] = UNSET,
@@ -4200,7 +4201,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType,
     ) -> Response: ...
 
@@ -4211,7 +4212,7 @@ class OrgsClient:
         pat_request_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["approve", "deny"],
         reason: Missing[Union[str, None]] = UNSET,
     ) -> Response: ...
@@ -4221,7 +4222,7 @@ class OrgsClient:
         org: str,
         pat_request_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgPersonalAccessTokenRequestsPatRequestIdPostBodyType
         ] = UNSET,
@@ -4270,7 +4271,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
@@ -4307,7 +4308,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-requested-to-be-accessed-by-a-fine-grained-personal-access-token"""
 
@@ -4350,7 +4351,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrant],
         list[OrganizationProgrammaticAccessGrantType],
@@ -4406,7 +4407,7 @@ class OrgsClient:
         permission: Missing[str] = UNSET,
         last_used_before: Missing[datetime] = UNSET,
         last_used_after: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationProgrammaticAccessGrant],
         list[OrganizationProgrammaticAccessGrantType],
@@ -4454,7 +4455,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -4467,7 +4468,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
     ) -> Response[
@@ -4479,7 +4480,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -4527,7 +4528,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPostBodyType,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
@@ -4540,7 +4541,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
         pat_ids: list[int],
     ) -> Response[
@@ -4552,7 +4553,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -4601,7 +4602,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPatIdPostBodyType,
     ) -> Response: ...
 
@@ -4612,7 +4613,7 @@ class OrgsClient:
         pat_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
     ) -> Response: ...
 
@@ -4621,7 +4622,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPatIdPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4665,7 +4666,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPersonalAccessTokensPatIdPostBodyType,
     ) -> Response: ...
 
@@ -4676,7 +4677,7 @@ class OrgsClient:
         pat_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         action: Literal["revoke"],
     ) -> Response: ...
 
@@ -4685,7 +4686,7 @@ class OrgsClient:
         org: str,
         pat_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPersonalAccessTokensPatIdPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4730,7 +4731,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
@@ -4765,7 +4766,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/orgs/personal-access-tokens#list-repositories-a-fine-grained-personal-access-token-has-access-to"""
 
@@ -4797,7 +4798,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
@@ -4822,7 +4823,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-all-custom-properties-for-an-organization"""
 
@@ -4848,7 +4849,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -4858,7 +4859,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyType],
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -4866,7 +4867,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
@@ -4908,7 +4909,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesSchemaPatchBodyType,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -4918,7 +4919,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyType],
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]: ...
 
@@ -4926,7 +4927,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesSchemaPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[CustomProperty], list[CustomPropertyType]]:
@@ -4968,7 +4969,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
@@ -4994,7 +4995,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CustomProperty, CustomPropertyType]:
         """See also: https://docs.github.com/rest/orgs/custom-properties#get-a-custom-property-for-an-organization"""
 
@@ -5021,7 +5022,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CustomPropertySetPayloadType,
     ) -> Response[CustomProperty, CustomPropertyType]: ...
 
@@ -5032,7 +5033,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value_type: Literal["string", "single_select", "multi_select", "true_false"],
         required: Missing[bool] = UNSET,
         default_value: Missing[Union[str, list[str], None]] = UNSET,
@@ -5045,7 +5046,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CustomPropertySetPayloadType] = UNSET,
         **kwargs,
     ) -> Response[CustomProperty, CustomPropertyType]:
@@ -5084,7 +5085,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: CustomPropertySetPayloadType,
     ) -> Response[CustomProperty, CustomPropertyType]: ...
 
@@ -5095,7 +5096,7 @@ class OrgsClient:
         custom_property_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         value_type: Literal["string", "single_select", "multi_select", "true_false"],
         required: Missing[bool] = UNSET,
         default_value: Missing[Union[str, list[str], None]] = UNSET,
@@ -5108,7 +5109,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[CustomPropertySetPayloadType] = UNSET,
         **kwargs,
     ) -> Response[CustomProperty, CustomPropertyType]:
@@ -5146,7 +5147,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/custom-properties#remove-a-custom-property-for-an-organization"""
 
@@ -5171,7 +5172,7 @@ class OrgsClient:
         org: str,
         custom_property_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/custom-properties#remove-a-custom-property-for-an-organization"""
 
@@ -5198,7 +5199,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_query: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
     ]:
@@ -5235,7 +5236,7 @@ class OrgsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         repository_query: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrgRepoCustomPropertyValues], list[OrgRepoCustomPropertyValuesType]
     ]:
@@ -5270,7 +5271,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -5280,7 +5281,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_names: list[str],
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
@@ -5289,7 +5290,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5331,7 +5332,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -5341,7 +5342,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         repository_names: list[str],
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
@@ -5350,7 +5351,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5393,7 +5394,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-public-organization-members"""
 
@@ -5422,7 +5423,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-public-organization-members"""
 
@@ -5450,7 +5451,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#check-public-organization-membership-for-a-user"""
 
@@ -5470,7 +5471,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#check-public-organization-membership-for-a-user"""
 
@@ -5490,7 +5491,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#set-public-organization-membership-for-the-authenticated-user"""
 
@@ -5514,7 +5515,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#set-public-organization-membership-for-the-authenticated-user"""
 
@@ -5538,7 +5539,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#remove-public-organization-membership-for-the-authenticated-user"""
 
@@ -5557,7 +5558,7 @@ class OrgsClient:
         org: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/members#remove-public-organization-membership-for-the-authenticated-user"""
 
@@ -5575,7 +5576,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/security-managers#list-security-manager-teams"""
 
@@ -5596,7 +5597,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamSimple], list[TeamSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/security-managers#list-security-manager-teams"""
 
@@ -5618,7 +5619,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/security-managers#add-a-security-manager-team"""
 
@@ -5637,7 +5638,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/security-managers#add-a-security-manager-team"""
 
@@ -5656,7 +5657,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/security-managers#remove-a-security-manager-team"""
 
@@ -5675,7 +5676,7 @@ class OrgsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/security-managers#remove-a-security-manager-team"""
 
@@ -5704,7 +5705,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
     ) -> Response: ...
 
@@ -5724,7 +5725,7 @@ class OrgsClient:
         enablement: Literal["enable_all", "disable_all"],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         query_suite: Missing[Literal["default", "extended"]] = UNSET,
     ) -> Response: ...
 
@@ -5742,7 +5743,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5786,7 +5787,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
     ) -> Response: ...
 
@@ -5806,7 +5807,7 @@ class OrgsClient:
         enablement: Literal["enable_all", "disable_all"],
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         query_suite: Missing[Literal["default", "extended"]] = UNSET,
     ) -> Response: ...
 
@@ -5824,7 +5825,7 @@ class OrgsClient:
         ],
         enablement: Literal["enable_all", "disable_all"],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgSecurityProductEnablementPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -5859,7 +5860,7 @@ class OrgsClient:
         state: Missing[Literal["active", "pending"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
@@ -5894,7 +5895,7 @@ class OrgsClient:
         state: Missing[Literal["active", "pending"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrgMembership], list[OrgMembershipType]]:
         """See also: https://docs.github.com/rest/orgs/members#list-organization-memberships-for-the-authenticated-user"""
 
@@ -5927,7 +5928,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
@@ -5952,7 +5953,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgMembership, OrgMembershipType]:
         """See also: https://docs.github.com/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user"""
 
@@ -5978,7 +5979,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -5988,7 +5989,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["active"],
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -5996,7 +5997,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -6040,7 +6041,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserMembershipsOrgsOrgPatchBodyType,
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -6050,7 +6051,7 @@ class OrgsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["active"],
     ) -> Response[OrgMembership, OrgMembershipType]: ...
 
@@ -6058,7 +6059,7 @@ class OrgsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserMembershipsOrgsOrgPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[OrgMembership, OrgMembershipType]:
@@ -6102,7 +6103,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
@@ -6134,7 +6135,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-the-authenticated-user"""
 
@@ -6167,7 +6168,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-a-user"""
 
@@ -6196,7 +6197,7 @@ class OrgsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationSimple], list[OrganizationSimpleType]]:
         """See also: https://docs.github.com/rest/orgs/orgs#list-organizations-for-a-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/packages.py
+++ b/githubkit/versions/v2022_11_28/rest/packages.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional
 from weakref import ref
 
@@ -46,7 +47,7 @@ class PackagesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
@@ -71,7 +72,7 @@ class PackagesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-organization"""
 
@@ -102,7 +103,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-an-organization"""
 
@@ -141,7 +142,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-an-organization"""
 
@@ -178,7 +179,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization"""
 
@@ -203,7 +204,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-an-organization"""
 
@@ -228,7 +229,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-for-an-organization"""
 
@@ -257,7 +258,7 @@ class PackagesClient:
         package_name: str,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-for-an-organization"""
 
@@ -287,7 +288,7 @@ class PackagesClient:
         org: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-for-an-organization"""
 
@@ -322,7 +323,7 @@ class PackagesClient:
         org: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-for-an-organization"""
 
@@ -359,7 +360,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
@@ -399,7 +400,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization"""
 
@@ -437,7 +438,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization"""
 
@@ -463,7 +464,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-an-organization"""
 
@@ -489,7 +490,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-package-version-for-an-organization"""
 
@@ -519,7 +520,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-package-version-for-an-organization"""
 
@@ -549,7 +550,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-package-version-for-an-organization"""
 
@@ -579,7 +580,7 @@ class PackagesClient:
         org: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-package-version-for-an-organization"""
 
@@ -603,7 +604,7 @@ class PackagesClient:
     def list_docker_migration_conflicting_packages_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
@@ -623,7 +624,7 @@ class PackagesClient:
     async def async_list_docker_migration_conflicting_packages_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-authenticated-user"""
 
@@ -649,7 +650,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
@@ -684,7 +685,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-the-authenticated-users-namespace"""
 
@@ -717,7 +718,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
@@ -741,7 +742,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-the-authenticated-user"""
 
@@ -765,7 +766,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-for-the-authenticated-user"""
 
@@ -793,7 +794,7 @@ class PackagesClient:
         ],
         package_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-for-the-authenticated-user"""
 
@@ -822,7 +823,7 @@ class PackagesClient:
         package_name: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-for-the-authenticated-user"""
 
@@ -856,7 +857,7 @@ class PackagesClient:
         package_name: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-for-the-authenticated-user"""
 
@@ -892,7 +893,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
@@ -931,7 +932,7 @@ class PackagesClient:
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["active", "deleted"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-the-authenticated-user"""
 
@@ -968,7 +969,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
@@ -993,7 +994,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-the-authenticated-user"""
 
@@ -1018,7 +1019,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-version-for-the-authenticated-user"""
 
@@ -1047,7 +1048,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-version-for-the-authenticated-user"""
 
@@ -1076,7 +1077,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-version-for-the-authenticated-user"""
 
@@ -1105,7 +1106,7 @@ class PackagesClient:
         package_name: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-version-for-the-authenticated-user"""
 
@@ -1130,7 +1131,7 @@ class PackagesClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
@@ -1155,7 +1156,7 @@ class PackagesClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#get-list-of-conflicting-packages-during-docker-migration-for-user"""
 
@@ -1186,7 +1187,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-a-user"""
 
@@ -1225,7 +1226,7 @@ class PackagesClient:
         visibility: Missing[Literal["public", "private", "internal"]] = UNSET,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Package], list[PackageType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-packages-for-a-user"""
 
@@ -1262,7 +1263,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-a-user"""
 
@@ -1287,7 +1288,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Package, PackageType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-for-a-user"""
 
@@ -1312,7 +1313,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-for-a-user"""
 
@@ -1341,7 +1342,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-a-package-for-a-user"""
 
@@ -1371,7 +1372,7 @@ class PackagesClient:
         username: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-for-a-user"""
 
@@ -1406,7 +1407,7 @@ class PackagesClient:
         username: str,
         *,
         token: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-a-package-for-a-user"""
 
@@ -1440,7 +1441,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
@@ -1470,7 +1471,7 @@ class PackagesClient:
         package_name: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PackageVersion], list[PackageVersionType]]:
         """See also: https://docs.github.com/rest/packages/packages#list-package-versions-for-a-package-owned-by-a-user"""
 
@@ -1501,7 +1502,7 @@ class PackagesClient:
         package_version_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-a-user"""
 
@@ -1527,7 +1528,7 @@ class PackagesClient:
         package_version_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PackageVersion, PackageVersionType]:
         """See also: https://docs.github.com/rest/packages/packages#get-a-package-version-for-a-user"""
 
@@ -1553,7 +1554,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-package-version-for-a-user"""
 
@@ -1583,7 +1584,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#delete-package-version-for-a-user"""
 
@@ -1613,7 +1614,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-package-version-for-a-user"""
 
@@ -1643,7 +1644,7 @@ class PackagesClient:
         username: str,
         package_version_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/packages/packages#restore-package-version-for-a-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/private_registries.py
+++ b/githubkit/versions/v2022_11_28/rest/private_registries.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -63,7 +64,7 @@ class PrivateRegistriesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesGetResponse200,
         OrgsOrgPrivateRegistriesGetResponse200Type,
@@ -99,7 +100,7 @@ class PrivateRegistriesClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesGetResponse200,
         OrgsOrgPrivateRegistriesGetResponse200Type,
@@ -134,7 +135,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesPostBodyType,
     ) -> Response[
         OrgPrivateRegistryConfigurationWithSelectedRepositories,
@@ -147,7 +148,7 @@ class PrivateRegistriesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Literal["maven_repository"],
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: str,
@@ -163,7 +164,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -209,7 +210,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesPostBodyType,
     ) -> Response[
         OrgPrivateRegistryConfigurationWithSelectedRepositories,
@@ -222,7 +223,7 @@ class PrivateRegistriesClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Literal["maven_repository"],
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: str,
@@ -238,7 +239,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -283,7 +284,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200,
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200Type,
@@ -310,7 +311,7 @@ class PrivateRegistriesClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200,
         OrgsOrgPrivateRegistriesPublicKeyGetResponse200Type,
@@ -338,7 +339,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgPrivateRegistryConfiguration, OrgPrivateRegistryConfigurationType]:
         """See also: https://docs.github.com/rest/private-registries/organization-configurations#get-a-private-registry-for-an-organization"""
 
@@ -363,7 +364,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[OrgPrivateRegistryConfiguration, OrgPrivateRegistryConfigurationType]:
         """See also: https://docs.github.com/rest/private-registries/organization-configurations#get-a-private-registry-for-an-organization"""
 
@@ -388,7 +389,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/private-registries/organization-configurations#delete-a-private-registry-for-an-organization"""
 
@@ -413,7 +414,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/private-registries/organization-configurations#delete-a-private-registry-for-an-organization"""
 
@@ -439,7 +440,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesSecretNamePatchBodyType,
     ) -> Response: ...
 
@@ -450,7 +451,7 @@ class PrivateRegistriesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Missing[Literal["maven_repository"]] = UNSET,
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: Missing[str] = UNSET,
@@ -464,7 +465,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesSecretNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -508,7 +509,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgPrivateRegistriesSecretNamePatchBodyType,
     ) -> Response: ...
 
@@ -519,7 +520,7 @@ class PrivateRegistriesClient:
         secret_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         registry_type: Missing[Literal["maven_repository"]] = UNSET,
         username: Missing[Union[str, None]] = UNSET,
         encrypted_value: Missing[str] = UNSET,
@@ -533,7 +534,7 @@ class PrivateRegistriesClient:
         org: str,
         secret_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgPrivateRegistriesSecretNamePatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:

--- a/githubkit/versions/v2022_11_28/rest/projects.py
+++ b/githubkit/versions/v2022_11_28/rest/projects.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -80,7 +81,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-organization-projects"""
 
@@ -114,7 +115,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-organization-projects"""
 
@@ -146,7 +147,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -156,7 +157,7 @@ class ProjectsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -165,7 +166,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -211,7 +212,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -221,7 +222,7 @@ class ProjectsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -230,7 +231,7 @@ class ProjectsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -275,7 +276,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#get-a-project-card"""
 
@@ -301,7 +302,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCard, ProjectCardType]:
         """See also: https://docs.github.com/rest/projects/cards#get-a-project-card"""
 
@@ -327,7 +328,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/cards#delete-a-project-card"""
 
@@ -352,7 +353,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/cards#delete-a-project-card"""
 
@@ -378,7 +379,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -388,7 +389,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -397,7 +398,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectCard, ProjectCardType]:
@@ -442,7 +443,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -452,7 +453,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Missing[Union[str, None]] = UNSET,
         archived: Missing[bool] = UNSET,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -461,7 +462,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectCard, ProjectCardType]:
@@ -506,7 +507,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsCardsCardIdMovesPostResponse201,
@@ -519,7 +520,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
     ) -> Response[
@@ -531,7 +532,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -581,7 +582,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsCardsCardIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsCardsCardIdMovesPostResponse201,
@@ -594,7 +595,7 @@ class ProjectsClient:
         card_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
         column_id: Missing[int] = UNSET,
     ) -> Response[
@@ -606,7 +607,7 @@ class ProjectsClient:
         self,
         card_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsCardsCardIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -655,7 +656,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#get-a-project-column"""
 
@@ -681,7 +682,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectColumn, ProjectColumnType]:
         """See also: https://docs.github.com/rest/projects/columns#get-a-project-column"""
 
@@ -707,7 +708,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/columns#delete-a-project-column"""
 
@@ -731,7 +732,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/columns#delete-a-project-column"""
 
@@ -756,7 +757,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -766,7 +767,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -774,7 +775,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -812,7 +813,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdPatchBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -822,7 +823,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -830,7 +831,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -870,7 +871,7 @@ class ProjectsClient:
         archived_state: Missing[Literal["all", "archived", "not_archived"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/rest/projects/cards#list-project-cards"""
 
@@ -905,7 +906,7 @@ class ProjectsClient:
         archived_state: Missing[Literal["all", "archived", "not_archived"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectCard], list[ProjectCardType]]:
         """See also: https://docs.github.com/rest/projects/cards#list-project-cards"""
 
@@ -938,7 +939,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
@@ -951,7 +952,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Union[str, None],
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -961,7 +962,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content_id: int,
         content_type: str,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -970,7 +971,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
@@ -1031,7 +1032,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
             ProjectsColumnsColumnIdCardsPostBodyOneof1Type,
@@ -1044,7 +1045,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         note: Union[str, None],
     ) -> Response[ProjectCard, ProjectCardType]: ...
 
@@ -1054,7 +1055,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content_id: int,
         content_type: str,
     ) -> Response[ProjectCard, ProjectCardType]: ...
@@ -1063,7 +1064,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ProjectsColumnsColumnIdCardsPostBodyOneof0Type,
@@ -1124,7 +1125,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1137,7 +1138,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1148,7 +1149,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1195,7 +1196,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsColumnsColumnIdMovesPostBodyType,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1208,7 +1209,7 @@ class ProjectsClient:
         column_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         position: str,
     ) -> Response[
         ProjectsColumnsColumnIdMovesPostResponse201,
@@ -1219,7 +1220,7 @@ class ProjectsClient:
         self,
         column_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsColumnsColumnIdMovesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1265,7 +1266,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#get-a-project"""
 
@@ -1290,7 +1291,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Project, ProjectType]:
         """See also: https://docs.github.com/rest/projects/projects#get-a-project"""
 
@@ -1315,7 +1316,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/projects#delete-a-project"""
 
@@ -1341,7 +1342,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/projects#delete-a-project"""
 
@@ -1368,7 +1369,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
     ) -> Response[Project, ProjectType]: ...
 
@@ -1378,7 +1379,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         state: Missing[str] = UNSET,
@@ -1392,7 +1393,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -1438,7 +1439,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
     ) -> Response[Project, ProjectType]: ...
 
@@ -1448,7 +1449,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         body: Missing[Union[str, None]] = UNSET,
         state: Missing[str] = UNSET,
@@ -1462,7 +1463,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -1510,7 +1511,7 @@ class ProjectsClient:
         affiliation: Missing[Literal["outside", "direct", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/projects/collaborators#list-project-collaborators"""
 
@@ -1547,7 +1548,7 @@ class ProjectsClient:
         affiliation: Missing[Literal["outside", "direct", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/projects/collaborators#list-project-collaborators"""
 
@@ -1583,7 +1584,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1596,7 +1597,7 @@ class ProjectsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -1605,7 +1606,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1655,7 +1656,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1668,7 +1669,7 @@ class ProjectsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -1677,7 +1678,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ProjectsProjectIdCollaboratorsUsernamePutBodyType, None]
         ] = UNSET,
@@ -1726,7 +1727,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/collaborators#remove-user-as-a-collaborator"""
 
@@ -1753,7 +1754,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/projects/collaborators#remove-user-as-a-collaborator"""
 
@@ -1780,7 +1781,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/rest/projects/collaborators#get-project-permission-for-a-user"""
 
@@ -1808,7 +1809,7 @@ class ProjectsClient:
         project_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProjectCollaboratorPermission, ProjectCollaboratorPermissionType]:
         """See also: https://docs.github.com/rest/projects/collaborators#get-project-permission-for-a-user"""
 
@@ -1837,7 +1838,7 @@ class ProjectsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/rest/projects/columns#list-project-columns"""
 
@@ -1870,7 +1871,7 @@ class ProjectsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ProjectColumn], list[ProjectColumnType]]:
         """See also: https://docs.github.com/rest/projects/columns#list-project-columns"""
 
@@ -1902,7 +1903,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1912,7 +1913,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1920,7 +1921,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -1964,7 +1965,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ProjectsProjectIdColumnsPostBodyType,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1974,7 +1975,7 @@ class ProjectsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[ProjectColumn, ProjectColumnType]: ...
 
@@ -1982,7 +1983,7 @@ class ProjectsClient:
         self,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ProjectsProjectIdColumnsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProjectColumn, ProjectColumnType]:
@@ -2029,7 +2030,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-repository-projects"""
 
@@ -2068,7 +2069,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-repository-projects"""
 
@@ -2105,7 +2106,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2116,7 +2117,7 @@ class ProjectsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2126,7 +2127,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2173,7 +2174,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2184,7 +2185,7 @@ class ProjectsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[str] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2194,7 +2195,7 @@ class ProjectsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2239,7 +2240,7 @@ class ProjectsClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2248,7 +2249,7 @@ class ProjectsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2256,7 +2257,7 @@ class ProjectsClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2299,7 +2300,7 @@ class ProjectsClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserProjectsPostBodyType,
     ) -> Response[Project, ProjectType]: ...
 
@@ -2308,7 +2309,7 @@ class ProjectsClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         body: Missing[Union[str, None]] = UNSET,
     ) -> Response[Project, ProjectType]: ...
@@ -2316,7 +2317,7 @@ class ProjectsClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserProjectsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Project, ProjectType]:
@@ -2362,7 +2363,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-user-projects"""
 
@@ -2396,7 +2397,7 @@ class ProjectsClient:
         state: Missing[Literal["open", "closed", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Project], list[ProjectType]]:
         """See also: https://docs.github.com/rest/projects/projects#list-user-projects"""
 

--- a/githubkit/versions/v2022_11_28/rest/pulls.py
+++ b/githubkit/versions/v2022_11_28/rest/pulls.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -97,7 +98,7 @@ class PullsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests"""
 
@@ -142,7 +143,7 @@ class PullsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests"""
 
@@ -179,7 +180,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -190,7 +191,7 @@ class PullsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         head: str,
         head_repo: Missing[str] = UNSET,
@@ -206,7 +207,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -250,7 +251,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPostBodyType,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -261,7 +262,7 @@ class PullsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         head: str,
         head_repo: Missing[str] = UNSET,
@@ -277,7 +278,7 @@ class PullsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -325,7 +326,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-in-a-repository"""
 
@@ -361,7 +362,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-in-a-repository"""
 
@@ -393,7 +394,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
@@ -419,7 +420,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
         """See also: https://docs.github.com/rest/pulls/comments#get-a-review-comment-for-a-pull-request"""
 
@@ -445,7 +446,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pulls/comments#delete-a-review-comment-for-a-pull-request"""
 
@@ -470,7 +471,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pulls/comments#delete-a-review-comment-for-a-pull-request"""
 
@@ -496,7 +497,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -508,7 +509,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -518,7 +519,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -559,7 +560,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdPatchBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -571,7 +572,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -581,7 +582,7 @@ class PullsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -621,7 +622,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#get-a-pull-request"""
 
@@ -654,7 +655,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequest, PullRequestType]:
         """See also: https://docs.github.com/rest/pulls/pulls#get-a-pull-request"""
 
@@ -688,7 +689,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -700,7 +701,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
@@ -714,7 +715,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -759,7 +760,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
     ) -> Response[PullRequest, PullRequestType]: ...
 
@@ -771,7 +772,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         state: Missing[Literal["open", "closed"]] = UNSET,
@@ -785,7 +786,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequest, PullRequestType]:
@@ -834,7 +835,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
@@ -871,7 +872,7 @@ class PullsClient:
         since: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReviewComment], list[PullRequestReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/comments#list-review-comments-on-a-pull-request"""
 
@@ -904,7 +905,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -916,7 +917,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         commit_id: str,
         path: str,
@@ -935,7 +936,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -982,7 +983,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -994,7 +995,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         commit_id: str,
         path: str,
@@ -1013,7 +1014,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]:
@@ -1061,7 +1062,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1074,7 +1075,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1085,7 +1086,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
@@ -1133,7 +1134,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1146,7 +1147,7 @@ class PullsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReviewComment, PullRequestReviewCommentType]: ...
 
@@ -1157,7 +1158,7 @@ class PullsClient:
         pull_number: int,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberCommentsCommentIdRepliesPostBodyType
         ] = UNSET,
@@ -1205,7 +1206,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-commits-on-a-pull-request"""
 
@@ -1236,7 +1237,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-commits-on-a-pull-request"""
 
@@ -1267,7 +1268,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests-files"""
 
@@ -1308,7 +1309,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DiffEntry], list[DiffEntryType]]:
         """See also: https://docs.github.com/rest/pulls/pulls#list-pull-requests-files"""
 
@@ -1347,7 +1348,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pulls/pulls#check-if-a-pull-request-has-been-merged"""
 
@@ -1368,7 +1369,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pulls/pulls#check-if-a-pull-request-has-been-merged"""
 
@@ -1390,7 +1391,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1404,7 +1405,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_title: Missing[str] = UNSET,
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
@@ -1417,7 +1418,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1473,7 +1474,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1487,7 +1488,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_title: Missing[str] = UNSET,
         commit_message: Missing[str] = UNSET,
         sha: Missing[str] = UNSET,
@@ -1500,7 +1501,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberMergePutBodyType, None]
         ] = UNSET,
@@ -1555,7 +1556,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
@@ -1578,7 +1579,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReviewRequest, PullRequestReviewRequestType]:
         """See also: https://docs.github.com/rest/pulls/review-requests#get-all-requested-reviewers-for-a-pull-request"""
 
@@ -1602,7 +1603,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1619,7 +1620,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1632,7 +1633,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1643,7 +1644,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1700,7 +1701,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1717,7 +1718,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1730,7 +1731,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: Missing[list[str]] = UNSET,
         team_reviewers: list[str],
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1741,7 +1742,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPullsPullNumberRequestedReviewersPostBodyAnyof0Type,
@@ -1798,7 +1799,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
@@ -1810,7 +1811,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1821,7 +1822,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
@@ -1868,7 +1869,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
 
@@ -1880,7 +1881,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reviewers: list[str],
         team_reviewers: Missing[list[str]] = UNSET,
     ) -> Response[PullRequestSimple, PullRequestSimpleType]: ...
@@ -1891,7 +1892,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberRequestedReviewersDeleteBodyType
         ] = UNSET,
@@ -1939,7 +1940,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
@@ -1970,7 +1971,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestReview], list[PullRequestReviewType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-reviews-for-a-pull-request"""
 
@@ -2000,7 +2001,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2012,7 +2013,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_id: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         event: Missing[Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"]] = UNSET,
@@ -2027,7 +2028,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2074,7 +2075,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2086,7 +2087,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         commit_id: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
         event: Missing[Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"]] = UNSET,
@@ -2101,7 +2102,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2148,7 +2149,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
@@ -2175,7 +2176,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#get-a-review-for-a-pull-request"""
 
@@ -2203,7 +2204,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2216,7 +2217,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2227,7 +2228,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2273,7 +2274,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2286,7 +2287,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2297,7 +2298,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPullsPullNumberReviewsReviewIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
@@ -2342,7 +2343,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
@@ -2370,7 +2371,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PullRequestReview, PullRequestReviewType]:
         """See also: https://docs.github.com/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request"""
 
@@ -2400,7 +2401,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
@@ -2435,7 +2436,7 @@ class PullsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReviewComment], list[ReviewCommentType]]:
         """See also: https://docs.github.com/rest/pulls/reviews#list-comments-for-a-pull-request-review"""
 
@@ -2469,7 +2470,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2482,7 +2483,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2494,7 +2495,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
@@ -2546,7 +2547,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2559,7 +2560,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         event: Missing[Literal["DISMISS"]] = UNSET,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2571,7 +2572,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdDismissalsPutBodyType
         ] = UNSET,
@@ -2623,7 +2624,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2636,7 +2637,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2648,7 +2649,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
@@ -2699,7 +2700,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType,
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
 
@@ -2712,7 +2713,7 @@ class PullsClient:
         review_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: Missing[str] = UNSET,
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
     ) -> Response[PullRequestReview, PullRequestReviewType]: ...
@@ -2724,7 +2725,7 @@ class PullsClient:
         pull_number: int,
         review_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsPullNumberReviewsReviewIdEventsPostBodyType
         ] = UNSET,
@@ -2774,7 +2775,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
@@ -2791,7 +2792,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
     ) -> Response[
         ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
@@ -2804,7 +2805,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
@@ -2858,7 +2859,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,
@@ -2875,7 +2876,7 @@ class PullsClient:
         pull_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         expected_head_sha: Missing[str] = UNSET,
     ) -> Response[
         ReposOwnerRepoPullsPullNumberUpdateBranchPutResponse202,
@@ -2888,7 +2889,7 @@ class PullsClient:
         repo: str,
         pull_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoPullsPullNumberUpdateBranchPutBodyType, None]
         ] = UNSET,

--- a/githubkit/versions/v2022_11_28/rest/rate_limit.py
+++ b/githubkit/versions/v2022_11_28/rest/rate_limit.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional
 from weakref import ref
 
@@ -40,7 +41,7 @@ class RateLimitClient:
     def get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 
@@ -63,7 +64,7 @@ class RateLimitClient:
     async def async_get(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RateLimitOverview, RateLimitOverviewType]:
         """See also: https://docs.github.com/rest/rate-limit/rate-limit#get-rate-limit-status-for-the-authenticated-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/reactions.py
+++ b/githubkit/versions/v2022_11_28/rest/reactions.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -70,7 +71,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
@@ -108,7 +109,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment"""
 
@@ -140,7 +141,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -153,7 +154,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -166,7 +167,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -211,7 +212,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -224,7 +225,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -237,7 +238,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -282,7 +283,7 @@ class ReactionsClient:
         comment_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-team-discussion-comment-reaction"""
 
@@ -304,7 +305,7 @@ class ReactionsClient:
         comment_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-team-discussion-comment-reaction"""
 
@@ -331,7 +332,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
@@ -368,7 +369,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion"""
 
@@ -399,7 +400,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -411,7 +412,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -423,7 +424,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
@@ -466,7 +467,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -478,7 +479,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -490,7 +491,7 @@ class ReactionsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
@@ -533,7 +534,7 @@ class ReactionsClient:
         discussion_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-team-discussion-reaction"""
 
@@ -554,7 +555,7 @@ class ReactionsClient:
         discussion_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-team-discussion-reaction"""
 
@@ -581,7 +582,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
@@ -621,7 +622,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-commit-comment"""
 
@@ -655,7 +656,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -667,7 +668,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -679,7 +680,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -724,7 +725,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -736,7 +737,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -748,7 +749,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -793,7 +794,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-a-commit-comment-reaction"""
 
@@ -814,7 +815,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-a-commit-comment-reaction"""
 
@@ -841,7 +842,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
@@ -881,7 +882,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue-comment"""
 
@@ -915,7 +916,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -927,7 +928,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -939,7 +940,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -986,7 +987,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -998,7 +999,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1010,7 +1011,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoIssuesCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -1057,7 +1058,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-an-issue-comment-reaction"""
 
@@ -1078,7 +1079,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-an-issue-comment-reaction"""
 
@@ -1105,7 +1106,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue"""
 
@@ -1146,7 +1147,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-an-issue"""
 
@@ -1181,7 +1182,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1193,7 +1194,7 @@ class ReactionsClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1205,7 +1206,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1250,7 +1251,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1262,7 +1263,7 @@ class ReactionsClient:
         issue_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1274,7 +1275,7 @@ class ReactionsClient:
         repo: str,
         issue_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoIssuesIssueNumberReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1319,7 +1320,7 @@ class ReactionsClient:
         issue_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-an-issue-reaction"""
 
@@ -1340,7 +1341,7 @@ class ReactionsClient:
         issue_number: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-an-issue-reaction"""
 
@@ -1367,7 +1368,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
@@ -1407,7 +1408,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-pull-request-review-comment"""
 
@@ -1441,7 +1442,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1453,7 +1454,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1465,7 +1466,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -1512,7 +1513,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1524,7 +1525,7 @@ class ReactionsClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1536,7 +1537,7 @@ class ReactionsClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoPullsCommentsCommentIdReactionsPostBodyType
         ] = UNSET,
@@ -1583,7 +1584,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-a-pull-request-comment-reaction"""
 
@@ -1606,7 +1607,7 @@ class ReactionsClient:
         comment_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-a-pull-request-comment-reaction"""
 
@@ -1633,7 +1634,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-release"""
 
@@ -1671,7 +1672,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-release"""
 
@@ -1705,7 +1706,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1717,7 +1718,7 @@ class ReactionsClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1727,7 +1728,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1772,7 +1773,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1784,7 +1785,7 @@ class ReactionsClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal["+1", "laugh", "heart", "hooray", "rocket", "eyes"],
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1794,7 +1795,7 @@ class ReactionsClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdReactionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Reaction, ReactionType]:
@@ -1839,7 +1840,7 @@ class ReactionsClient:
         release_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-a-release-reaction"""
 
@@ -1860,7 +1861,7 @@ class ReactionsClient:
         release_id: int,
         reaction_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/reactions/reactions#delete-a-release-reaction"""
 
@@ -1887,7 +1888,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
@@ -1924,7 +1925,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-comment-legacy"""
 
@@ -1955,7 +1956,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -1967,7 +1968,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -1979,7 +1980,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -2023,7 +2024,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -2035,7 +2036,7 @@ class ReactionsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -2047,7 +2048,7 @@ class ReactionsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberReactionsPostBodyType
         ] = UNSET,
@@ -2096,7 +2097,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
@@ -2132,7 +2133,7 @@ class ReactionsClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Reaction], list[ReactionType]]:
         """See also: https://docs.github.com/rest/reactions/reactions#list-reactions-for-a-team-discussion-legacy"""
 
@@ -2162,7 +2163,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -2173,7 +2174,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -2184,7 +2185,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,
@@ -2226,7 +2227,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType,
     ) -> Response[Reaction, ReactionType]: ...
 
@@ -2237,7 +2238,7 @@ class ReactionsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         content: Literal[
             "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
         ],
@@ -2248,7 +2249,7 @@ class ReactionsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberReactionsPostBodyType
         ] = UNSET,

--- a/githubkit/versions/v2022_11_28/rest/repos.py
+++ b/githubkit/versions/v2022_11_28/rest/repos.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -358,7 +359,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-organization-repositories"""
 
@@ -395,7 +396,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-organization-repositories"""
 
@@ -426,7 +427,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -436,7 +437,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -474,7 +475,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -517,7 +518,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -527,7 +528,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -565,7 +566,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -610,7 +611,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets"""
 
@@ -645,7 +646,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/orgs/rules#get-all-organization-repository-rulesets"""
 
@@ -678,7 +679,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -688,7 +689,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -733,7 +734,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -771,7 +772,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -781,7 +782,7 @@ class ReposClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -826,7 +827,7 @@ class ReposClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -870,7 +871,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#list-organization-rule-suites"""
 
@@ -913,7 +914,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#list-organization-rule-suites"""
 
@@ -950,7 +951,7 @@ class ReposClient:
         org: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
@@ -976,7 +977,7 @@ class ReposClient:
         org: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/orgs/rule-suites#get-an-organization-rule-suite"""
 
@@ -1002,7 +1003,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#get-an-organization-repository-ruleset"""
 
@@ -1028,7 +1029,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/orgs/rules#get-an-organization-repository-ruleset"""
 
@@ -1055,7 +1056,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -1066,7 +1067,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -1112,7 +1113,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -1155,7 +1156,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -1166,7 +1167,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push", "repository"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -1212,7 +1213,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -1254,7 +1255,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/rules#delete-an-organization-repository-ruleset"""
 
@@ -1279,7 +1280,7 @@ class ReposClient:
         org: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/orgs/rules#delete-an-organization-repository-ruleset"""
 
@@ -1304,7 +1305,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#get-a-repository"""
 
@@ -1330,7 +1331,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/repos/repos#get-a-repository"""
 
@@ -1356,7 +1357,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#delete-a-repository"""
 
@@ -1381,7 +1382,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#delete-a-repository"""
 
@@ -1407,7 +1408,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -1418,7 +1419,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -1457,7 +1458,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -1502,7 +1503,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -1513,7 +1514,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -1552,7 +1553,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -1615,7 +1616,7 @@ class ReposClient:
                 "merge_queue_merge",
             ]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-activities"""
 
@@ -1671,7 +1672,7 @@ class ReposClient:
                 "merge_queue_merge",
             ]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Activity], list[ActivityType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-activities"""
 
@@ -1709,7 +1710,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -1723,7 +1724,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -1735,7 +1736,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1782,7 +1783,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAttestationsPostBodyType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -1796,7 +1797,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         bundle: ReposOwnerRepoAttestationsPostBodyPropBundleType,
     ) -> Response[
         ReposOwnerRepoAttestationsPostResponse201,
@@ -1808,7 +1809,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAttestationsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[
@@ -1858,7 +1859,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
@@ -1894,7 +1895,7 @@ class ReposClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200,
         ReposOwnerRepoAttestationsSubjectDigestGetResponse200Type,
@@ -1926,7 +1927,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
@@ -1948,7 +1949,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Autolink], list[AutolinkType]]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-all-autolinks-of-a-repository"""
 
@@ -1971,7 +1972,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
     ) -> Response[Autolink, AutolinkType]: ...
 
@@ -1982,7 +1983,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
@@ -1993,7 +1994,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Autolink, AutolinkType]:
@@ -2031,7 +2032,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoAutolinksPostBodyType,
     ) -> Response[Autolink, AutolinkType]: ...
 
@@ -2042,7 +2043,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         key_prefix: str,
         url_template: str,
         is_alphanumeric: Missing[bool] = UNSET,
@@ -2053,7 +2054,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoAutolinksPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Autolink, AutolinkType]:
@@ -2091,7 +2092,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
@@ -2117,7 +2118,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Autolink, AutolinkType]:
         """See also: https://docs.github.com/rest/repos/autolinks#get-an-autolink-reference-of-a-repository"""
 
@@ -2143,7 +2144,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/autolinks#delete-an-autolink-reference-from-a-repository"""
 
@@ -2168,7 +2169,7 @@ class ReposClient:
         repo: str,
         autolink_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/autolinks#delete-an-autolink-reference-from-a-repository"""
 
@@ -2192,7 +2193,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
@@ -2215,7 +2216,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CheckAutomatedSecurityFixes, CheckAutomatedSecurityFixesType]:
         """See also: https://docs.github.com/rest/repos/repos#check-if-automated-security-fixes-are-enabled-for-a-repository"""
 
@@ -2238,7 +2239,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#enable-automated-security-fixes"""
 
@@ -2257,7 +2258,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#enable-automated-security-fixes"""
 
@@ -2276,7 +2277,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#disable-automated-security-fixes"""
 
@@ -2295,7 +2296,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#disable-automated-security-fixes"""
 
@@ -2317,7 +2318,7 @@ class ReposClient:
         protected: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/rest/branches/branches#list-branches"""
 
@@ -2352,7 +2353,7 @@ class ReposClient:
         protected: Missing[bool] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ShortBranch], list[ShortBranchType]]:
         """See also: https://docs.github.com/rest/branches/branches#list-branches"""
 
@@ -2385,7 +2386,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/rest/branches/branches#get-a-branch"""
 
@@ -2411,7 +2412,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
         """See also: https://docs.github.com/rest/branches/branches#get-a-branch"""
 
@@ -2437,7 +2438,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-branch-protection"""
 
@@ -2463,7 +2464,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchProtection, BranchProtectionType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-branch-protection"""
 
@@ -2490,7 +2491,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
     ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
@@ -2502,7 +2503,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         required_status_checks: Union[
             ReposOwnerRepoBranchesBranchProtectionPutBodyPropRequiredStatusChecksType,
             None,
@@ -2530,7 +2531,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProtectedBranch, ProtectedBranchType]:
@@ -2578,7 +2579,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionPutBodyType,
     ) -> Response[ProtectedBranch, ProtectedBranchType]: ...
 
@@ -2590,7 +2591,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         required_status_checks: Union[
             ReposOwnerRepoBranchesBranchProtectionPutBodyPropRequiredStatusChecksType,
             None,
@@ -2618,7 +2619,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchProtectionPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[ProtectedBranch, ProtectedBranchType]:
@@ -2665,7 +2666,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-branch-protection"""
 
@@ -2690,7 +2691,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-branch-protection"""
 
@@ -2715,7 +2716,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-admin-branch-protection"""
 
@@ -2738,7 +2739,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-admin-branch-protection"""
 
@@ -2761,7 +2762,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-admin-branch-protection"""
 
@@ -2784,7 +2785,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#set-admin-branch-protection"""
 
@@ -2807,7 +2808,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-admin-branch-protection"""
 
@@ -2832,7 +2833,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-admin-branch-protection"""
 
@@ -2857,7 +2858,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
     ]:
@@ -2882,7 +2883,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ProtectedBranchPullRequestReview, ProtectedBranchPullRequestReviewType
     ]:
@@ -2907,7 +2908,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-pull-request-review-protection"""
 
@@ -2932,7 +2933,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-pull-request-review-protection"""
 
@@ -2958,7 +2959,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -2974,7 +2975,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         dismissal_restrictions: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropDismissalRestrictionsType
         ] = UNSET,
@@ -2995,7 +2996,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3045,7 +3046,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3061,7 +3062,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         dismissal_restrictions: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyPropDismissalRestrictionsType
         ] = UNSET,
@@ -3082,7 +3083,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredPullRequestReviewsPatchBodyType
         ] = UNSET,
@@ -3131,7 +3132,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-commit-signature-protection"""
 
@@ -3157,7 +3158,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-commit-signature-protection"""
 
@@ -3183,7 +3184,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#create-commit-signature-protection"""
 
@@ -3209,7 +3210,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ProtectedBranchAdminEnforced, ProtectedBranchAdminEnforcedType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#create-commit-signature-protection"""
 
@@ -3235,7 +3236,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-commit-signature-protection"""
 
@@ -3260,7 +3261,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-commit-signature-protection"""
 
@@ -3285,7 +3286,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection"""
 
@@ -3313,7 +3314,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[StatusCheckPolicy, StatusCheckPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-status-checks-protection"""
 
@@ -3341,7 +3342,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-status-check-protection"""
 
@@ -3363,7 +3364,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#remove-status-check-protection"""
 
@@ -3386,7 +3387,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3400,7 +3401,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         strict: Missing[bool] = UNSET,
         contexts: Missing[list[str]] = UNSET,
         checks: Missing[
@@ -3416,7 +3417,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3468,7 +3469,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3482,7 +3483,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         strict: Missing[bool] = UNSET,
         contexts: Missing[list[str]] = UNSET,
         checks: Missing[
@@ -3498,7 +3499,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksPatchBodyType
         ] = UNSET,
@@ -3549,7 +3550,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-all-status-check-contexts"""
 
@@ -3575,7 +3576,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[str], list[str]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-all-status-check-contexts"""
 
@@ -3602,7 +3603,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -3619,7 +3620,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -3629,7 +3630,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -3686,7 +3687,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -3703,7 +3704,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -3713,7 +3714,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPutBodyOneof0Type,
@@ -3770,7 +3771,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -3787,7 +3788,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -3797,7 +3798,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -3855,7 +3856,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -3872,7 +3873,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -3882,7 +3883,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsPostBodyOneof0Type,
@@ -3940,7 +3941,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -3957,7 +3958,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -3967,7 +3968,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4024,7 +4025,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4041,7 +4042,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         contexts: list[str],
     ) -> Response[list[str], list[str]]: ...
 
@@ -4051,7 +4052,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRequiredStatusChecksContextsDeleteBodyOneof0Type,
@@ -4107,7 +4108,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-access-restrictions"""
 
@@ -4133,7 +4134,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[BranchRestrictionPolicy, BranchRestrictionPolicyType]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-access-restrictions"""
 
@@ -4159,7 +4160,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-access-restrictions"""
 
@@ -4179,7 +4180,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/branches/branch-protection#delete-access-restrictions"""
 
@@ -4199,7 +4200,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
@@ -4227,7 +4228,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Union[Integration, None]], list[Union[IntegrationType, None]]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-apps-with-access-to-the-protected-branch"""
 
@@ -4256,7 +4257,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4270,7 +4271,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4282,7 +4283,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
@@ -4331,7 +4332,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4345,7 +4346,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4357,7 +4358,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPutBodyType
         ] = UNSET,
@@ -4406,7 +4407,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4420,7 +4421,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4432,7 +4433,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
@@ -4481,7 +4482,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4495,7 +4496,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4507,7 +4508,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsPostBodyType
         ] = UNSET,
@@ -4556,7 +4557,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4570,7 +4571,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4582,7 +4583,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
@@ -4631,7 +4632,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType,
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4645,7 +4646,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         apps: list[str],
     ) -> Response[
         list[Union[Integration, None]], list[Union[IntegrationType, None]]
@@ -4657,7 +4658,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsAppsDeleteBodyType
         ] = UNSET,
@@ -4705,7 +4706,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
@@ -4731,7 +4732,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-teams-with-access-to-the-protected-branch"""
 
@@ -4758,7 +4759,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -4775,7 +4776,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -4785,7 +4786,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -4841,7 +4842,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -4858,7 +4859,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -4868,7 +4869,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPutBodyOneof0Type,
@@ -4924,7 +4925,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -4941,7 +4942,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -4951,7 +4952,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5007,7 +5008,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5024,7 +5025,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5034,7 +5035,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsPostBodyOneof0Type,
@@ -5090,7 +5091,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5107,7 +5108,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5117,7 +5118,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5173,7 +5174,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5190,7 +5191,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         teams: list[str],
     ) -> Response[list[Team], list[TeamType]]: ...
 
@@ -5200,7 +5201,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoBranchesBranchProtectionRestrictionsTeamsDeleteBodyOneof0Type,
@@ -5255,7 +5256,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
@@ -5281,7 +5282,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/branches/branch-protection#get-users-with-access-to-the-protected-branch"""
 
@@ -5308,7 +5309,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5320,7 +5321,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5330,7 +5331,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
@@ -5377,7 +5378,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5389,7 +5390,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5399,7 +5400,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPutBodyType
         ] = UNSET,
@@ -5446,7 +5447,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5458,7 +5459,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5468,7 +5469,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
@@ -5515,7 +5516,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5527,7 +5528,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5537,7 +5538,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersPostBodyType
         ] = UNSET,
@@ -5584,7 +5585,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5596,7 +5597,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5606,7 +5607,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
@@ -5653,7 +5654,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5665,7 +5666,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         users: list[str],
     ) -> Response[list[SimpleUser], list[SimpleUserType]]: ...
 
@@ -5675,7 +5676,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoBranchesBranchProtectionRestrictionsUsersDeleteBodyType
         ] = UNSET,
@@ -5722,7 +5723,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -5734,7 +5735,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: str,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -5744,7 +5745,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
@@ -5792,7 +5793,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoBranchesBranchRenamePostBodyType,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -5804,7 +5805,7 @@ class ReposClient:
         branch: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_name: str,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]: ...
 
@@ -5814,7 +5815,7 @@ class ReposClient:
         repo: str,
         branch: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoBranchesBranchRenamePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[BranchWithProtection, BranchWithProtectionType]:
@@ -5861,7 +5862,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/rest/repos/repos#list-codeowners-errors"""
 
@@ -5890,7 +5891,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CodeownersErrors, CodeownersErrorsType]:
         """See also: https://docs.github.com/rest/repos/repos#list-codeowners-errors"""
 
@@ -5924,7 +5925,7 @@ class ReposClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#list-repository-collaborators"""
 
@@ -5963,7 +5964,7 @@ class ReposClient:
         ] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Collaborator], list[CollaboratorType]]:
         """See also: https://docs.github.com/rest/collaborators/collaborators#list-repository-collaborators"""
 
@@ -5997,7 +5998,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/collaborators#check-if-a-user-is-a-repository-collaborator"""
 
@@ -6018,7 +6019,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/collaborators#check-if-a-user-is-a-repository-collaborator"""
 
@@ -6040,7 +6041,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6052,7 +6053,7 @@ class ReposClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6062,7 +6063,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -6109,7 +6110,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6121,7 +6122,7 @@ class ReposClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -6131,7 +6132,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCollaboratorsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -6177,7 +6178,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/collaborators#remove-a-repository-collaborator"""
 
@@ -6203,7 +6204,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/collaborators#remove-a-repository-collaborator"""
 
@@ -6229,7 +6230,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
     ]:
@@ -6257,7 +6258,7 @@ class ReposClient:
         repo: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         RepositoryCollaboratorPermission, RepositoryCollaboratorPermissionType
     ]:
@@ -6286,7 +6287,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments-for-a-repository"""
 
@@ -6316,7 +6317,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments-for-a-repository"""
 
@@ -6345,7 +6346,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#get-a-commit-comment"""
 
@@ -6371,7 +6372,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComment, CommitCommentType]:
         """See also: https://docs.github.com/rest/commits/comments#get-a-commit-comment"""
 
@@ -6397,7 +6398,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/commits/comments#delete-a-commit-comment"""
 
@@ -6422,7 +6423,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/commits/comments#delete-a-commit-comment"""
 
@@ -6448,7 +6449,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -6460,7 +6461,7 @@ class ReposClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -6470,7 +6471,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -6513,7 +6514,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommentsCommentIdPatchBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -6525,7 +6526,7 @@ class ReposClient:
         comment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -6535,7 +6536,7 @@ class ReposClient:
         repo: str,
         comment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommentsCommentIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -6584,7 +6585,7 @@ class ReposClient:
         until: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-commits"""
 
@@ -6632,7 +6633,7 @@ class ReposClient:
         until: Missing[datetime] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Commit], list[CommitType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-commits"""
 
@@ -6673,7 +6674,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-branches-for-head-commit"""
 
@@ -6700,7 +6701,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[BranchShort], list[BranchShortType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-branches-for-head-commit"""
 
@@ -6729,7 +6730,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments"""
 
@@ -6760,7 +6761,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitComment], list[CommitCommentType]]:
         """See also: https://docs.github.com/rest/commits/comments#list-commit-comments"""
 
@@ -6790,7 +6791,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -6802,7 +6803,7 @@ class ReposClient:
         commit_sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
@@ -6815,7 +6816,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -6862,7 +6863,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoCommitsCommitShaCommentsPostBodyType,
     ) -> Response[CommitComment, CommitCommentType]: ...
 
@@ -6874,7 +6875,7 @@ class ReposClient:
         commit_sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
         path: Missing[str] = UNSET,
         position: Missing[int] = UNSET,
@@ -6887,7 +6888,7 @@ class ReposClient:
         repo: str,
         commit_sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoCommitsCommitShaCommentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[CommitComment, CommitCommentType]:
@@ -6935,7 +6936,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
@@ -6969,7 +6970,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PullRequestSimple], list[PullRequestSimpleType]]:
         """See also: https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit"""
 
@@ -7003,7 +7004,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/rest/commits/commits#get-a-commit"""
 
@@ -7046,7 +7047,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Commit, CommitType]:
         """See also: https://docs.github.com/rest/commits/commits#get-a-commit"""
 
@@ -7089,7 +7090,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
@@ -7123,7 +7124,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CombinedCommitStatus, CombinedCommitStatusType]:
         """See also: https://docs.github.com/rest/commits/statuses#get-the-combined-status-for-a-specific-reference"""
 
@@ -7157,7 +7158,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
@@ -7188,7 +7189,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Status], list[StatusType]]:
         """See also: https://docs.github.com/rest/commits/statuses#list-commit-statuses-for-a-reference"""
 
@@ -7216,7 +7217,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/rest/metrics/community#get-community-profile-metrics"""
 
@@ -7238,7 +7239,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommunityProfile, CommunityProfileType]:
         """See also: https://docs.github.com/rest/metrics/community#get-community-profile-metrics"""
 
@@ -7263,7 +7264,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/rest/commits/commits#compare-two-commits"""
 
@@ -7303,7 +7304,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CommitComparison, CommitComparisonType]:
         """See also: https://docs.github.com/rest/commits/commits#compare-two-commits"""
 
@@ -7342,7 +7343,7 @@ class ReposClient:
         path: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
@@ -7398,7 +7399,7 @@ class ReposClient:
         path: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[
             list[ContentDirectoryItems], ContentFile, ContentSymlink, ContentSubmodule
@@ -7454,7 +7455,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -7466,7 +7467,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         content: str,
         sha: Missing[str] = UNSET,
@@ -7481,7 +7482,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -7530,7 +7531,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathPutBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -7542,7 +7543,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         content: str,
         sha: Missing[str] = UNSET,
@@ -7557,7 +7558,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -7606,7 +7607,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -7618,7 +7619,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         sha: str,
         branch: Missing[str] = UNSET,
@@ -7634,7 +7635,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -7682,7 +7683,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoContentsPathDeleteBodyType,
     ) -> Response[FileCommit, FileCommitType]: ...
 
@@ -7694,7 +7695,7 @@ class ReposClient:
         path: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         message: str,
         sha: str,
         branch: Missing[str] = UNSET,
@@ -7710,7 +7711,7 @@ class ReposClient:
         repo: str,
         path: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoContentsPathDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response[FileCommit, FileCommitType]:
@@ -7759,7 +7760,7 @@ class ReposClient:
         anon: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-contributors"""
 
@@ -7795,7 +7796,7 @@ class ReposClient:
         anon: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Contributor], list[ContributorType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-contributors"""
 
@@ -7834,7 +7835,7 @@ class ReposClient:
         environment: Missing[Union[str, None]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/rest/deployments/deployments#list-deployments"""
 
@@ -7872,7 +7873,7 @@ class ReposClient:
         environment: Missing[Union[str, None]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Deployment], list[DeploymentType]]:
         """See also: https://docs.github.com/rest/deployments/deployments#list-deployments"""
 
@@ -7905,7 +7906,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
     ) -> Response[Deployment, DeploymentType]: ...
 
@@ -7916,7 +7917,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         task: Missing[str] = UNSET,
         auto_merge: Missing[bool] = UNSET,
@@ -7935,7 +7936,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Deployment, DeploymentType]:
@@ -7977,7 +7978,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsPostBodyType,
     ) -> Response[Deployment, DeploymentType]: ...
 
@@ -7988,7 +7989,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         ref: str,
         task: Missing[str] = UNSET,
         auto_merge: Missing[bool] = UNSET,
@@ -8007,7 +8008,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Deployment, DeploymentType]:
@@ -8049,7 +8050,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/rest/deployments/deployments#get-a-deployment"""
 
@@ -8075,7 +8076,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Deployment, DeploymentType]:
         """See also: https://docs.github.com/rest/deployments/deployments#get-a-deployment"""
 
@@ -8101,7 +8102,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/deployments#delete-a-deployment"""
 
@@ -8127,7 +8128,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/deployments#delete-a-deployment"""
 
@@ -8155,7 +8156,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/rest/deployments/statuses#list-deployment-statuses"""
 
@@ -8189,7 +8190,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeploymentStatus], list[DeploymentStatusType]]:
         """See also: https://docs.github.com/rest/deployments/statuses#list-deployment-statuses"""
 
@@ -8222,7 +8223,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
     ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
@@ -8234,7 +8235,7 @@ class ReposClient:
         deployment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal[
             "error",
             "failure",
@@ -8258,7 +8259,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
@@ -8305,7 +8306,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType,
     ) -> Response[DeploymentStatus, DeploymentStatusType]: ...
 
@@ -8317,7 +8318,7 @@ class ReposClient:
         deployment_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal[
             "error",
             "failure",
@@ -8341,7 +8342,7 @@ class ReposClient:
         repo: str,
         deployment_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoDeploymentsDeploymentIdStatusesPostBodyType
         ] = UNSET,
@@ -8388,7 +8389,7 @@ class ReposClient:
         deployment_id: int,
         status_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/rest/deployments/statuses#get-a-deployment-status"""
 
@@ -8415,7 +8416,7 @@ class ReposClient:
         deployment_id: int,
         status_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentStatus, DeploymentStatusType]:
         """See also: https://docs.github.com/rest/deployments/statuses#get-a-deployment-status"""
 
@@ -8441,7 +8442,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -8452,7 +8453,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         event_type: str,
         client_payload: Missing[
             ReposOwnerRepoDispatchesPostBodyPropClientPayloadType
@@ -8464,7 +8465,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDispatchesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -8506,7 +8507,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoDispatchesPostBodyType,
     ) -> Response: ...
 
@@ -8517,7 +8518,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         event_type: str,
         client_payload: Missing[
             ReposOwnerRepoDispatchesPostBodyPropClientPayloadType
@@ -8529,7 +8530,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoDispatchesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -8572,7 +8573,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsGetResponse200,
         ReposOwnerRepoEnvironmentsGetResponse200Type,
@@ -8605,7 +8606,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsGetResponse200,
         ReposOwnerRepoEnvironmentsGetResponse200Type,
@@ -8637,7 +8638,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/rest/deployments/environments#get-an-environment"""
 
@@ -8660,7 +8661,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Environment, EnvironmentType]:
         """See also: https://docs.github.com/rest/deployments/environments#get-an-environment"""
 
@@ -8684,7 +8685,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -8698,7 +8699,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         wait_timer: Missing[int] = UNSET,
         prevent_self_review: Missing[bool] = UNSET,
         reviewers: Missing[
@@ -8720,7 +8721,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -8769,7 +8770,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -8783,7 +8784,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         wait_timer: Missing[int] = UNSET,
         prevent_self_review: Missing[bool] = UNSET,
         reviewers: Missing[
@@ -8805,7 +8806,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[ReposOwnerRepoEnvironmentsEnvironmentNamePutBodyType, None]
         ] = UNSET,
@@ -8853,7 +8854,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/environments#delete-an-environment"""
 
@@ -8873,7 +8874,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/environments#delete-an-environment"""
 
@@ -8895,7 +8896,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
@@ -8931,7 +8932,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentBranchPoliciesGetResponse200Type,
@@ -8966,7 +8967,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -8978,7 +8979,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
@@ -8989,7 +8990,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9029,7 +9030,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternWithTypeType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9041,7 +9042,7 @@ class ReposClient:
         environment_name: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         type: Missing[Literal["branch", "tag"]] = UNSET,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
@@ -9052,7 +9053,7 @@ class ReposClient:
         repo: str,
         environment_name: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternWithTypeType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9092,7 +9093,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
@@ -9116,7 +9117,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
         """See also: https://docs.github.com/rest/deployments/branch-policies#get-a-deployment-branch-policy"""
 
@@ -9141,7 +9142,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9154,7 +9155,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9165,7 +9166,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9202,7 +9203,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: DeploymentBranchPolicyNamePatternType,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9215,7 +9216,7 @@ class ReposClient:
         branch_policy_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]: ...
 
@@ -9226,7 +9227,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[DeploymentBranchPolicyNamePatternType] = UNSET,
         **kwargs,
     ) -> Response[DeploymentBranchPolicy, DeploymentBranchPolicyType]:
@@ -9262,7 +9263,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/branch-policies#delete-a-deployment-branch-policy"""
 
@@ -9283,7 +9284,7 @@ class ReposClient:
         environment_name: str,
         branch_policy_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/branch-policies#delete-a-deployment-branch-policy"""
 
@@ -9303,7 +9304,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
@@ -9331,7 +9332,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesGetResponse200Type,
@@ -9360,7 +9361,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -9372,7 +9373,7 @@ class ReposClient:
         owner: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         integration_id: Missing[int] = UNSET,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -9382,7 +9383,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
@@ -9426,7 +9427,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -9438,7 +9439,7 @@ class ReposClient:
         owner: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         integration_id: Missing[int] = UNSET,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]: ...
 
@@ -9448,7 +9449,7 @@ class ReposClient:
         repo: str,
         owner: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesPostBodyType
         ] = UNSET,
@@ -9493,7 +9494,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
@@ -9529,7 +9530,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200,
         ReposOwnerRepoEnvironmentsEnvironmentNameDeploymentProtectionRulesAppsGetResponse200Type,
@@ -9564,7 +9565,7 @@ class ReposClient:
         environment_name: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
@@ -9588,7 +9589,7 @@ class ReposClient:
         environment_name: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeploymentProtectionRule, DeploymentProtectionRuleType]:
         """See also: https://docs.github.com/rest/deployments/protection-rules#get-a-custom-deployment-protection-rule"""
 
@@ -9612,7 +9613,7 @@ class ReposClient:
         owner: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/protection-rules#disable-a-custom-protection-rule-for-an-environment"""
 
@@ -9633,7 +9634,7 @@ class ReposClient:
         owner: str,
         protection_rule_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deployments/protection-rules#disable-a-custom-protection-rule-for-an-environment"""
 
@@ -9655,7 +9656,7 @@ class ReposClient:
         sort: Missing[Literal["newest", "oldest", "stargazers", "watchers"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/forks#list-forks"""
 
@@ -9690,7 +9691,7 @@ class ReposClient:
         sort: Missing[Literal["newest", "oldest", "stargazers", "watchers"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/forks#list-forks"""
 
@@ -9723,7 +9724,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -9734,7 +9735,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
@@ -9745,7 +9746,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -9793,7 +9794,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -9804,7 +9805,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         organization: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
         default_branch_only: Missing[bool] = UNSET,
@@ -9815,7 +9816,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoForksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -9864,7 +9865,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-repository-webhooks"""
 
@@ -9897,7 +9898,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Hook], list[HookType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-repository-webhooks"""
 
@@ -9929,7 +9930,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
     ) -> Response[Hook, HookType]: ...
 
@@ -9940,7 +9941,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
@@ -9952,7 +9953,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -9999,7 +10000,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
     ) -> Response[Hook, HookType]: ...
 
@@ -10010,7 +10011,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         config: Missing[ReposOwnerRepoHooksPostBodyPropConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
@@ -10022,7 +10023,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[ReposOwnerRepoHooksPostBodyType, None]] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10069,7 +10070,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-repository-webhook"""
 
@@ -10095,7 +10096,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hook, HookType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-repository-webhook"""
 
@@ -10121,7 +10122,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/webhooks#delete-a-repository-webhook"""
 
@@ -10146,7 +10147,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/webhooks#delete-a-repository-webhook"""
 
@@ -10172,7 +10173,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
     ) -> Response[Hook, HookType]: ...
 
@@ -10184,7 +10185,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[WebhookConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         add_events: Missing[list[str]] = UNSET,
@@ -10198,7 +10199,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10243,7 +10244,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoHooksHookIdPatchBodyType,
     ) -> Response[Hook, HookType]: ...
 
@@ -10255,7 +10256,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         config: Missing[WebhookConfigType] = UNSET,
         events: Missing[list[str]] = UNSET,
         add_events: Missing[list[str]] = UNSET,
@@ -10269,7 +10270,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Hook, HookType]:
@@ -10313,7 +10314,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
@@ -10336,7 +10337,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[WebhookConfig, WebhookConfigType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-webhook-configuration-for-a-repository"""
 
@@ -10360,7 +10361,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -10372,7 +10373,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -10385,7 +10386,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -10421,7 +10422,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
     ) -> Response[WebhookConfig, WebhookConfigType]: ...
 
@@ -10433,7 +10434,7 @@ class ReposClient:
         hook_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         url: Missing[str] = UNSET,
         content_type: Missing[str] = UNSET,
         secret: Missing[str] = UNSET,
@@ -10446,7 +10447,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoHooksHookIdConfigPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[WebhookConfig, WebhookConfigType]:
@@ -10483,7 +10484,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
@@ -10518,7 +10519,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         cursor: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[HookDeliveryItem], list[HookDeliveryItemType]]:
         """See also: https://docs.github.com/rest/repos/webhooks#list-deliveries-for-a-repository-webhook"""
 
@@ -10552,7 +10553,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
@@ -10580,7 +10581,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[HookDelivery, HookDeliveryType]:
         """See also: https://docs.github.com/rest/repos/webhooks#get-a-delivery-for-a-repository-webhook"""
 
@@ -10608,7 +10609,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -10643,7 +10644,7 @@ class ReposClient:
         hook_id: int,
         delivery_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -10677,7 +10678,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/webhooks#ping-a-repository-webhook"""
 
@@ -10702,7 +10703,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/webhooks#ping-a-repository-webhook"""
 
@@ -10727,7 +10728,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/webhooks#test-the-push-repository-webhook"""
 
@@ -10752,7 +10753,7 @@ class ReposClient:
         repo: str,
         hook_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/webhooks#test-the-push-repository-webhook"""
 
@@ -10778,7 +10779,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations"""
 
@@ -10808,7 +10809,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations"""
 
@@ -10837,7 +10838,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/invitations#delete-a-repository-invitation"""
 
@@ -10857,7 +10858,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/invitations#delete-a-repository-invitation"""
 
@@ -10878,7 +10879,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -10890,7 +10891,7 @@ class ReposClient:
         invitation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
@@ -10902,7 +10903,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -10943,7 +10944,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]: ...
 
@@ -10955,7 +10956,7 @@ class ReposClient:
         invitation_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permissions: Missing[
             Literal["read", "write", "maintain", "triage", "admin"]
         ] = UNSET,
@@ -10967,7 +10968,7 @@ class ReposClient:
         repo: str,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoInvitationsInvitationIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryInvitation, RepositoryInvitationType]:
@@ -11008,7 +11009,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
@@ -11038,7 +11039,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[DeployKey], list[DeployKeyType]]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#list-deploy-keys"""
 
@@ -11067,7 +11068,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
     ) -> Response[DeployKey, DeployKeyType]: ...
 
@@ -11078,7 +11079,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
@@ -11089,7 +11090,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[DeployKey, DeployKeyType]:
@@ -11127,7 +11128,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoKeysPostBodyType,
     ) -> Response[DeployKey, DeployKeyType]: ...
 
@@ -11138,7 +11139,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
         read_only: Missing[bool] = UNSET,
@@ -11149,7 +11150,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[DeployKey, DeployKeyType]:
@@ -11187,7 +11188,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
@@ -11213,7 +11214,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[DeployKey, DeployKeyType]:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#get-a-deploy-key"""
 
@@ -11239,7 +11240,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#delete-a-deploy-key"""
 
@@ -11259,7 +11260,7 @@ class ReposClient:
         repo: str,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/deploy-keys/deploy-keys#delete-a-deploy-key"""
 
@@ -11278,7 +11279,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-languages"""
 
@@ -11300,7 +11301,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Language, LanguageType]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-languages"""
 
@@ -11323,7 +11324,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -11334,7 +11335,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         branch: str,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -11343,7 +11344,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MergedUpstream, MergedUpstreamType]:
@@ -11379,7 +11380,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergeUpstreamPostBodyType,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -11390,7 +11391,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         branch: str,
     ) -> Response[MergedUpstream, MergedUpstreamType]: ...
 
@@ -11399,7 +11400,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergeUpstreamPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MergedUpstream, MergedUpstreamType]:
@@ -11435,7 +11436,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
     ) -> Response[Commit, CommitType]: ...
 
@@ -11446,7 +11447,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
@@ -11457,7 +11458,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Commit, CommitType]:
@@ -11501,7 +11502,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoMergesPostBodyType,
     ) -> Response[Commit, CommitType]: ...
 
@@ -11512,7 +11513,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         base: str,
         head: str,
         commit_message: Missing[str] = UNSET,
@@ -11523,7 +11524,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoMergesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Commit, CommitType]:
@@ -11566,7 +11567,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site"""
 
@@ -11591,7 +11592,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Page, PageType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site"""
 
@@ -11617,7 +11618,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPutBodyAnyof0Type,
             ReposOwnerRepoPagesPutBodyAnyof1Type,
@@ -11634,7 +11635,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Literal["legacy", "workflow"],
@@ -11653,7 +11654,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11670,7 +11671,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Union[str, None],
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11689,7 +11690,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11708,7 +11709,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: bool,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11725,7 +11726,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPutBodyAnyof0Type,
@@ -11791,7 +11792,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPutBodyAnyof0Type,
             ReposOwnerRepoPagesPutBodyAnyof1Type,
@@ -11808,7 +11809,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Literal["legacy", "workflow"],
@@ -11827,7 +11828,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11844,7 +11845,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Union[str, None],
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11863,7 +11864,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: Missing[bool] = UNSET,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11882,7 +11883,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         cname: Missing[Union[str, None]] = UNSET,
         https_enforced: bool,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
@@ -11899,7 +11900,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPutBodyAnyof0Type,
@@ -11965,7 +11966,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPostBodyAnyof0Type,
             None,
@@ -11981,7 +11982,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
     ) -> Response[Page, PageType]: ...
@@ -11993,7 +11994,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
     ) -> Response[Page, PageType]: ...
@@ -12003,7 +12004,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPostBodyAnyof0Type,
@@ -12065,7 +12066,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Union[
             ReposOwnerRepoPagesPostBodyAnyof0Type,
             None,
@@ -12081,7 +12082,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Missing[Literal["legacy", "workflow"]] = UNSET,
         source: ReposOwnerRepoPagesPostBodyPropSourceType,
     ) -> Response[Page, PageType]: ...
@@ -12093,7 +12094,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         build_type: Literal["legacy", "workflow"],
         source: Missing[ReposOwnerRepoPagesPostBodyPropSourceType] = UNSET,
     ) -> Response[Page, PageType]: ...
@@ -12103,7 +12104,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[
                 ReposOwnerRepoPagesPostBodyAnyof0Type,
@@ -12164,7 +12165,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pages/pages#delete-a-apiname-pages-site"""
 
@@ -12190,7 +12191,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pages/pages#delete-a-apiname-pages-site"""
 
@@ -12218,7 +12219,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/rest/pages/pages#list-apiname-pages-builds"""
 
@@ -12248,7 +12249,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[PageBuild], list[PageBuildType]]:
         """See also: https://docs.github.com/rest/pages/pages#list-apiname-pages-builds"""
 
@@ -12276,7 +12277,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#request-a-apiname-pages-build"""
 
@@ -12298,7 +12299,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuildStatus, PageBuildStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#request-a-apiname-pages-build"""
 
@@ -12320,7 +12321,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-latest-pages-build"""
 
@@ -12342,7 +12343,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-latest-pages-build"""
 
@@ -12365,7 +12366,7 @@ class ReposClient:
         repo: str,
         build_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-apiname-pages-build"""
 
@@ -12388,7 +12389,7 @@ class ReposClient:
         repo: str,
         build_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PageBuild, PageBuildType]:
         """See also: https://docs.github.com/rest/pages/pages#get-apiname-pages-build"""
 
@@ -12411,7 +12412,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
     ) -> Response[PageDeployment, PageDeploymentType]: ...
 
@@ -12422,7 +12423,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         artifact_id: Missing[float] = UNSET,
         artifact_url: Missing[str] = UNSET,
         environment: Missing[str] = UNSET,
@@ -12435,7 +12436,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PageDeployment, PageDeploymentType]:
@@ -12480,7 +12481,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPagesDeploymentsPostBodyType,
     ) -> Response[PageDeployment, PageDeploymentType]: ...
 
@@ -12491,7 +12492,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         artifact_id: Missing[float] = UNSET,
         artifact_url: Missing[str] = UNSET,
         environment: Missing[str] = UNSET,
@@ -12504,7 +12505,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPagesDeploymentsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[PageDeployment, PageDeploymentType]:
@@ -12549,7 +12550,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
@@ -12575,7 +12576,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesDeploymentStatus, PagesDeploymentStatusType]:
         """See also: https://docs.github.com/rest/pages/pages#get-the-status-of-a-github-pages-deployment"""
 
@@ -12601,7 +12602,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pages/pages#cancel-a-github-pages-deployment"""
 
@@ -12626,7 +12627,7 @@ class ReposClient:
         repo: str,
         pages_deployment_id: Union[int, str],
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/pages/pages#cancel-a-github-pages-deployment"""
 
@@ -12650,7 +12651,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
@@ -12675,7 +12676,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[PagesHealthCheck, PagesHealthCheckType]:
         """See also: https://docs.github.com/rest/pages/pages#get-a-dns-health-check-for-github-pages"""
 
@@ -12700,7 +12701,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
@@ -12731,7 +12732,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200,
         ReposOwnerRepoPrivateVulnerabilityReportingGetResponse200Type,
@@ -12762,7 +12763,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository"""
 
@@ -12786,7 +12787,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#enable-private-vulnerability-reporting-for-a-repository"""
 
@@ -12810,7 +12811,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository"""
 
@@ -12834,7 +12835,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#disable-private-vulnerability-reporting-for-a-repository"""
 
@@ -12858,7 +12859,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
@@ -12884,7 +12885,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CustomPropertyValue], list[CustomPropertyValueType]]:
         """See also: https://docs.github.com/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository"""
 
@@ -12911,7 +12912,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -12922,7 +12923,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
 
@@ -12931,7 +12932,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -12974,7 +12975,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoPropertiesValuesPatchBodyType,
     ) -> Response: ...
 
@@ -12985,7 +12986,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         properties: list[CustomPropertyValueType],
     ) -> Response: ...
 
@@ -12994,7 +12995,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoPropertiesValuesPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -13037,7 +13038,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme"""
 
@@ -13069,7 +13070,7 @@ class ReposClient:
         repo: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme"""
 
@@ -13102,7 +13103,7 @@ class ReposClient:
         dir_: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
@@ -13135,7 +13136,7 @@ class ReposClient:
         dir_: str,
         *,
         ref: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ContentFile, ContentFileType]:
         """See also: https://docs.github.com/rest/repos/contents#get-a-repository-readme-for-a-directory"""
 
@@ -13168,7 +13169,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/rest/releases/releases#list-releases"""
 
@@ -13201,7 +13202,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Release], list[ReleaseType]]:
         """See also: https://docs.github.com/rest/releases/releases#list-releases"""
 
@@ -13233,7 +13234,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -13244,7 +13245,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -13261,7 +13262,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -13305,7 +13306,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesPostBodyType,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -13316,7 +13317,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -13333,7 +13334,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -13377,7 +13378,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#get-a-release-asset"""
 
@@ -13403,7 +13404,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#get-a-release-asset"""
 
@@ -13429,7 +13430,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/releases/assets#delete-a-release-asset"""
 
@@ -13449,7 +13450,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/releases/assets#delete-a-release-asset"""
 
@@ -13470,7 +13471,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
     ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
@@ -13482,7 +13483,7 @@ class ReposClient:
         asset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
@@ -13494,7 +13495,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
@@ -13532,7 +13533,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
     ) -> Response[ReleaseAsset, ReleaseAssetType]: ...
 
@@ -13544,7 +13545,7 @@ class ReposClient:
         asset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         label: Missing[str] = UNSET,
         state: Missing[str] = UNSET,
@@ -13556,7 +13557,7 @@ class ReposClient:
         repo: str,
         asset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesAssetsAssetIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
@@ -13593,7 +13594,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
@@ -13604,7 +13605,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
@@ -13616,7 +13617,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
@@ -13660,7 +13661,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoReleasesGenerateNotesPostBodyType,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]: ...
 
@@ -13671,7 +13672,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: str,
         target_commitish: Missing[str] = UNSET,
         previous_tag_name: Missing[str] = UNSET,
@@ -13683,7 +13684,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesGenerateNotesPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[ReleaseNotesContent, ReleaseNotesContentType]:
@@ -13726,7 +13727,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-the-latest-release"""
 
@@ -13748,7 +13749,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-the-latest-release"""
 
@@ -13771,7 +13772,7 @@ class ReposClient:
         repo: str,
         tag: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name"""
 
@@ -13797,7 +13798,7 @@ class ReposClient:
         repo: str,
         tag: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name"""
 
@@ -13823,7 +13824,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release"""
 
@@ -13847,7 +13848,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Release, ReleaseType]:
         """See also: https://docs.github.com/rest/releases/releases#get-a-release"""
 
@@ -13871,7 +13872,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/releases/releases#delete-a-release"""
 
@@ -13891,7 +13892,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/releases/releases#delete-a-release"""
 
@@ -13912,7 +13913,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -13924,7 +13925,7 @@ class ReposClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: Missing[str] = UNSET,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -13941,7 +13942,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -13984,7 +13985,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
     ) -> Response[Release, ReleaseType]: ...
 
@@ -13996,7 +13997,7 @@ class ReposClient:
         release_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         tag_name: Missing[str] = UNSET,
         target_commitish: Missing[str] = UNSET,
         name: Missing[str] = UNSET,
@@ -14013,7 +14014,7 @@ class ReposClient:
         repo: str,
         release_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoReleasesReleaseIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[Release, ReleaseType]:
@@ -14057,7 +14058,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/rest/releases/assets#list-release-assets"""
 
@@ -14088,7 +14089,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReleaseAsset], list[ReleaseAssetType]]:
         """See also: https://docs.github.com/rest/releases/assets#list-release-assets"""
 
@@ -14119,7 +14120,7 @@ class ReposClient:
         *,
         name: str,
         label: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: FileTypes,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#upload-a-release-asset"""
@@ -14159,7 +14160,7 @@ class ReposClient:
         *,
         name: str,
         label: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: FileTypes,
     ) -> Response[ReleaseAsset, ReleaseAssetType]:
         """See also: https://docs.github.com/rest/releases/assets#upload-a-release-asset"""
@@ -14199,7 +14200,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -14313,7 +14314,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[
             Union[
@@ -14428,7 +14429,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         includes_parents: Missing[bool] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets"""
 
@@ -14466,7 +14467,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         includes_parents: Missing[bool] = UNSET,
         targets: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryRuleset], list[RepositoryRulesetType]]:
         """See also: https://docs.github.com/rest/repos/rules#get-all-repository-rulesets"""
 
@@ -14501,7 +14502,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -14512,7 +14513,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -14552,7 +14553,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -14595,7 +14596,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoRulesetsPostBodyType,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -14606,7 +14607,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Literal["disabled", "active", "evaluate"],
@@ -14646,7 +14647,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -14694,7 +14695,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites"""
 
@@ -14736,7 +14737,7 @@ class ReposClient:
         rule_suite_result: Missing[Literal["pass", "fail", "bypass", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RuleSuitesItems], list[RuleSuitesItemsType]]:
         """See also: https://docs.github.com/rest/repos/rule-suites#list-repository-rule-suites"""
 
@@ -14773,7 +14774,7 @@ class ReposClient:
         repo: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite"""
 
@@ -14800,7 +14801,7 @@ class ReposClient:
         repo: str,
         rule_suite_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RuleSuite, RuleSuiteType]:
         """See also: https://docs.github.com/rest/repos/rule-suites#get-a-repository-rule-suite"""
 
@@ -14828,7 +14829,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         includes_parents: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#get-a-repository-ruleset"""
 
@@ -14861,7 +14862,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         includes_parents: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
         """See also: https://docs.github.com/rest/repos/rules#get-a-repository-ruleset"""
 
@@ -14894,7 +14895,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -14906,7 +14907,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -14947,7 +14948,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -14991,7 +14992,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]: ...
 
@@ -15003,7 +15004,7 @@ class ReposClient:
         ruleset_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         target: Missing[Literal["branch", "tag", "push"]] = UNSET,
         enforcement: Missing[Literal["disabled", "active", "evaluate"]] = UNSET,
@@ -15044,7 +15045,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoRulesetsRulesetIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryRuleset, RepositoryRulesetType]:
@@ -15087,7 +15088,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/rules#delete-a-repository-ruleset"""
 
@@ -15113,7 +15114,7 @@ class ReposClient:
         repo: str,
         ruleset_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/rules#delete-a-repository-ruleset"""
 
@@ -15138,7 +15139,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-activity"""
 
@@ -15159,7 +15160,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-activity"""
 
@@ -15180,7 +15181,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
@@ -15202,7 +15203,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[CommitActivity], list[CommitActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-last-year-of-commit-activity"""
 
@@ -15224,7 +15225,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-all-contributor-commit-activity"""
 
@@ -15246,7 +15247,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContributorActivity], list[ContributorActivityType]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-all-contributor-commit-activity"""
 
@@ -15268,7 +15269,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-count"""
 
@@ -15293,7 +15294,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ParticipationStats, ParticipationStatsType]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-weekly-commit-count"""
 
@@ -15318,7 +15319,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
@@ -15338,7 +15339,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[list[int]], list[list[int]]]:
         """See also: https://docs.github.com/rest/metrics/statistics#get-the-hourly-commit-count-for-each-day"""
 
@@ -15360,7 +15361,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
     ) -> Response[Status, StatusType]: ...
 
@@ -15372,7 +15373,7 @@ class ReposClient:
         sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["error", "failure", "pending", "success"],
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
@@ -15385,7 +15386,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Status, StatusType]:
@@ -15421,7 +15422,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoStatusesShaPostBodyType,
     ) -> Response[Status, StatusType]: ...
 
@@ -15433,7 +15434,7 @@ class ReposClient:
         sha: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["error", "failure", "pending", "success"],
         target_url: Missing[Union[str, None]] = UNSET,
         description: Missing[Union[str, None]] = UNSET,
@@ -15446,7 +15447,7 @@ class ReposClient:
         repo: str,
         sha: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoStatusesShaPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Status, StatusType]:
@@ -15482,7 +15483,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-tags"""
 
@@ -15512,7 +15513,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Tag], list[TagType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-tags"""
 
@@ -15540,7 +15541,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
@@ -15566,7 +15567,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TagProtection], list[TagProtectionType]]:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---list-tag-protection-states-for-a-repository"""
 
@@ -15593,7 +15594,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -15604,7 +15605,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pattern: str,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -15613,7 +15614,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TagProtection, TagProtectionType]:
@@ -15656,7 +15657,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTagsProtectionPostBodyType,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -15667,7 +15668,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         pattern: str,
     ) -> Response[TagProtection, TagProtectionType]: ...
 
@@ -15676,7 +15677,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTagsProtectionPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TagProtection, TagProtectionType]:
@@ -15719,7 +15720,7 @@ class ReposClient:
         repo: str,
         tag_protection_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---delete-a-tag-protection-state-for-a-repository"""
 
@@ -15745,7 +15746,7 @@ class ReposClient:
         repo: str,
         tag_protection_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/tags#closing-down---delete-a-tag-protection-state-for-a-repository"""
 
@@ -15771,7 +15772,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/contents#download-a-repository-archive-tar"""
 
@@ -15791,7 +15792,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/contents#download-a-repository-archive-tar"""
 
@@ -15812,7 +15813,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-teams"""
 
@@ -15845,7 +15846,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repository-teams"""
 
@@ -15878,7 +15879,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/rest/repos/repos#get-all-repository-topics"""
 
@@ -15911,7 +15912,7 @@ class ReposClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Topic, TopicType]:
         """See also: https://docs.github.com/rest/repos/repos#get-all-repository-topics"""
 
@@ -15943,7 +15944,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
     ) -> Response[Topic, TopicType]: ...
 
@@ -15954,7 +15955,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         names: list[str],
     ) -> Response[Topic, TopicType]: ...
 
@@ -15963,7 +15964,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Topic, TopicType]:
@@ -16007,7 +16008,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTopicsPutBodyType,
     ) -> Response[Topic, TopicType]: ...
 
@@ -16018,7 +16019,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         names: list[str],
     ) -> Response[Topic, TopicType]: ...
 
@@ -16027,7 +16028,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTopicsPutBodyType] = UNSET,
         **kwargs,
     ) -> Response[Topic, TopicType]:
@@ -16071,7 +16072,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-repository-clones"""
 
@@ -16102,7 +16103,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[CloneTraffic, CloneTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-repository-clones"""
 
@@ -16132,7 +16133,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-paths"""
 
@@ -16157,7 +16158,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ContentTraffic], list[ContentTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-paths"""
 
@@ -16182,7 +16183,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-sources"""
 
@@ -16207,7 +16208,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[ReferrerTraffic], list[ReferrerTrafficType]]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-top-referral-sources"""
 
@@ -16233,7 +16234,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-page-views"""
 
@@ -16264,7 +16265,7 @@ class ReposClient:
         repo: str,
         *,
         per: Missing[Literal["day", "week"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[ViewTraffic, ViewTrafficType]:
         """See also: https://docs.github.com/rest/metrics/traffic#get-page-views"""
 
@@ -16295,7 +16296,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
     ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
@@ -16306,7 +16307,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
@@ -16317,7 +16318,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MinimalRepository, MinimalRepositoryType]:
@@ -16352,7 +16353,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoTransferPostBodyType,
     ) -> Response[MinimalRepository, MinimalRepositoryType]: ...
 
@@ -16363,7 +16364,7 @@ class ReposClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         new_owner: str,
         new_name: Missing[str] = UNSET,
         team_ids: Missing[list[int]] = UNSET,
@@ -16374,7 +16375,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposOwnerRepoTransferPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[MinimalRepository, MinimalRepositoryType]:
@@ -16408,7 +16409,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository"""
 
@@ -16428,7 +16429,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#check-if-vulnerability-alerts-are-enabled-for-a-repository"""
 
@@ -16448,7 +16449,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#enable-vulnerability-alerts"""
 
@@ -16467,7 +16468,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#enable-vulnerability-alerts"""
 
@@ -16486,7 +16487,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#disable-vulnerability-alerts"""
 
@@ -16505,7 +16506,7 @@ class ReposClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/repos#disable-vulnerability-alerts"""
 
@@ -16525,7 +16526,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/contents#download-a-repository-archive-zip"""
 
@@ -16545,7 +16546,7 @@ class ReposClient:
         repo: str,
         ref: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/repos/contents#download-a-repository-archive-zip"""
 
@@ -16565,7 +16566,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -16576,7 +16577,7 @@ class ReposClient:
         template_repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         owner: Missing[str] = UNSET,
         name: str,
         description: Missing[str] = UNSET,
@@ -16589,7 +16590,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -16629,7 +16630,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposTemplateOwnerTemplateRepoGeneratePostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
@@ -16640,7 +16641,7 @@ class ReposClient:
         template_repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         owner: Missing[str] = UNSET,
         name: str,
         description: Missing[str] = UNSET,
@@ -16653,7 +16654,7 @@ class ReposClient:
         template_owner: str,
         template_repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[ReposTemplateOwnerTemplateRepoGeneratePostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -16691,7 +16692,7 @@ class ReposClient:
         self,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-public-repositories"""
 
@@ -16720,7 +16721,7 @@ class ReposClient:
         self,
         *,
         since: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-public-repositories"""
 
@@ -16757,7 +16758,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         before: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
@@ -16804,7 +16805,7 @@ class ReposClient:
         page: Missing[int] = UNSET,
         since: Missing[datetime] = UNSET,
         before: Missing[datetime] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Repository], list[RepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-the-authenticated-user"""
 
@@ -16841,7 +16842,10 @@ class ReposClient:
 
     @overload
     def create_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
@@ -16849,7 +16853,7 @@ class ReposClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -16882,7 +16886,7 @@ class ReposClient:
     def create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -16925,7 +16929,10 @@ class ReposClient:
 
     @overload
     async def async_create_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserReposPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserReposPostBodyType,
     ) -> Response[FullRepository, FullRepositoryType]: ...
 
     @overload
@@ -16933,7 +16940,7 @@ class ReposClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         homepage: Missing[str] = UNSET,
@@ -16966,7 +16973,7 @@ class ReposClient:
     async def async_create_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserReposPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[FullRepository, FullRepositoryType]:
@@ -17012,7 +17019,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
@@ -17045,7 +17052,7 @@ class ReposClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryInvitation], list[RepositoryInvitationType]]:
         """See also: https://docs.github.com/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user"""
 
@@ -17077,7 +17084,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/invitations#decline-a-repository-invitation"""
 
@@ -17102,7 +17109,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/invitations#decline-a-repository-invitation"""
 
@@ -17127,7 +17134,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/invitations#accept-a-repository-invitation"""
 
@@ -17152,7 +17159,7 @@ class ReposClient:
         self,
         invitation_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/collaborators/invitations#accept-a-repository-invitation"""
 
@@ -17182,7 +17189,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-a-user"""
 
@@ -17217,7 +17224,7 @@ class ReposClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/repos/repos#list-repositories-for-a-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/search.py
+++ b/githubkit/versions/v2022_11_28/rest/search.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional
 from weakref import ref
 
@@ -66,7 +67,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-code"""
 
@@ -110,7 +111,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCodeGetResponse200, SearchCodeGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-code"""
 
@@ -154,7 +155,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-commits"""
 
@@ -188,7 +189,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchCommitsGetResponse200, SearchCommitsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-commits"""
 
@@ -236,7 +237,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-issues-and-pull-requests"""
 
@@ -294,7 +295,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchIssuesGetResponse200, SearchIssuesGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-issues-and-pull-requests"""
 
@@ -339,7 +340,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-labels"""
 
@@ -380,7 +381,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchLabelsGetResponse200, SearchLabelsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-labels"""
 
@@ -422,7 +423,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
     ]:
@@ -468,7 +469,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         SearchRepositoriesGetResponse200, SearchRepositoriesGetResponse200Type
     ]:
@@ -510,7 +511,7 @@ class SearchClient:
         q: str,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-topics"""
 
@@ -540,7 +541,7 @@ class SearchClient:
         q: str,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchTopicsGetResponse200, SearchTopicsGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-topics"""
 
@@ -572,7 +573,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-users"""
 
@@ -614,7 +615,7 @@ class SearchClient:
         order: Missing[Literal["desc", "asc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SearchUsersGetResponse200, SearchUsersGetResponse200Type]:
         """See also: https://docs.github.com/rest/search/search#search-users"""
 

--- a/githubkit/versions/v2022_11_28/rest/secret_scanning.py
+++ b/githubkit/versions/v2022_11_28/rest/secret_scanning.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -74,7 +75,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -131,7 +132,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -189,7 +190,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -248,7 +249,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         list[OrganizationSecretScanningAlert], list[OrganizationSecretScanningAlertType]
     ]:
@@ -308,7 +309,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
@@ -364,7 +365,7 @@ class SecretScanningClient:
         validity: Missing[str] = UNSET,
         is_publicly_leaked: Missing[bool] = UNSET,
         is_multi_repo: Missing[bool] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningAlert], list[SecretScanningAlertType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-secret-scanning-alerts-for-a-repository"""
 
@@ -409,7 +410,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
@@ -438,7 +439,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#get-a-secret-scanning-alert"""
 
@@ -468,7 +469,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
@@ -480,7 +481,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "resolved"],
         resolution: Missing[
             Union[
@@ -496,7 +497,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
@@ -543,7 +544,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType,
     ) -> Response[SecretScanningAlert, SecretScanningAlertType]: ...
 
@@ -555,7 +556,7 @@ class SecretScanningClient:
         alert_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         state: Literal["open", "resolved"],
         resolution: Missing[
             Union[
@@ -571,7 +572,7 @@ class SecretScanningClient:
         repo: str,
         alert_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningAlertsAlertNumberPatchBodyType
         ] = UNSET,
@@ -619,7 +620,7 @@ class SecretScanningClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
@@ -656,7 +657,7 @@ class SecretScanningClient:
         *,
         page: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SecretScanningLocation], list[SecretScanningLocationType]]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#list-locations-for-a-secret-scanning-alert"""
 
@@ -691,7 +692,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
     ) -> Response[
         SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
@@ -704,7 +705,7 @@ class SecretScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
     ) -> Response[
@@ -716,7 +717,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
@@ -764,7 +765,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType,
     ) -> Response[
         SecretScanningPushProtectionBypass, SecretScanningPushProtectionBypassType
@@ -777,7 +778,7 @@ class SecretScanningClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         reason: Literal["false_positive", "used_in_tests", "will_fix_later"],
         placeholder_id: str,
     ) -> Response[
@@ -789,7 +790,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             ReposOwnerRepoSecretScanningPushProtectionBypassesPostBodyType
         ] = UNSET,
@@ -836,7 +837,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningScanHistory, SecretScanningScanHistoryType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#get-secret-scanning-scan-history-for-a-repository"""
 
@@ -864,7 +865,7 @@ class SecretScanningClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SecretScanningScanHistory, SecretScanningScanHistoryType]:
         """See also: https://docs.github.com/rest/secret-scanning/secret-scanning#get-secret-scanning-scan-history-for-a-repository"""
 

--- a/githubkit/versions/v2022_11_28/rest/security_advisories.py
+++ b/githubkit/versions/v2022_11_28/rest/security_advisories.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -104,7 +105,7 @@ class SecurityAdvisoriesClient:
         sort: Missing[
             Literal["updated", "published", "epss_percentage", "epss_percentile"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#list-global-security-advisories"""
 
@@ -188,7 +189,7 @@ class SecurityAdvisoriesClient:
         sort: Missing[
             Literal["updated", "published", "epss_percentage", "epss_percentile"]
         ] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GlobalAdvisory], list[GlobalAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#list-global-security-advisories"""
 
@@ -235,7 +236,7 @@ class SecurityAdvisoriesClient:
         self,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
@@ -259,7 +260,7 @@ class SecurityAdvisoriesClient:
         self,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GlobalAdvisory, GlobalAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/global-advisories#get-a-global-security-advisory"""
 
@@ -289,7 +290,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
@@ -330,7 +331,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories-for-an-organization"""
 
@@ -372,7 +373,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
@@ -414,7 +415,7 @@ class SecurityAdvisoriesClient:
         after: Missing[str] = UNSET,
         per_page: Missing[int] = UNSET,
         state: Missing[Literal["triage", "draft", "published", "closed"]] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[RepositoryAdvisory], list[RepositoryAdvisoryType]]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#list-repository-security-advisories"""
 
@@ -451,7 +452,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -462,7 +463,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -483,7 +484,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -528,7 +529,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -539,7 +540,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -560,7 +561,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -605,7 +606,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -616,7 +617,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         vulnerabilities: Missing[
@@ -637,7 +638,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -682,7 +683,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: PrivateVulnerabilityReportCreateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -693,7 +694,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: str,
         description: str,
         vulnerabilities: Missing[
@@ -714,7 +715,7 @@ class SecurityAdvisoriesClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[PrivateVulnerabilityReportCreateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -759,7 +760,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
@@ -786,7 +787,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#get-a-repository-security-advisory"""
 
@@ -814,7 +815,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -826,7 +827,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -852,7 +853,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -898,7 +899,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: RepositoryAdvisoryUpdateType,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]: ...
 
@@ -910,7 +911,7 @@ class SecurityAdvisoriesClient:
         ghsa_id: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         summary: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         cve_id: Missing[Union[str, None]] = UNSET,
@@ -936,7 +937,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[RepositoryAdvisoryUpdateType] = UNSET,
         **kwargs,
     ) -> Response[RepositoryAdvisory, RepositoryAdvisoryType]:
@@ -981,7 +982,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1017,7 +1018,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202,
         AppHookDeliveriesDeliveryIdAttemptsPostResponse202Type,
@@ -1053,7 +1054,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 
@@ -1082,7 +1083,7 @@ class SecurityAdvisoriesClient:
         repo: str,
         ghsa_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[FullRepository, FullRepositoryType]:
         """See also: https://docs.github.com/rest/security-advisories/repository-advisories#create-a-temporary-private-fork"""
 

--- a/githubkit/versions/v2022_11_28/rest/teams.py
+++ b/githubkit/versions/v2022_11_28/rest/teams.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, overload
 from weakref import ref
 
@@ -90,7 +91,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams"""
 
@@ -122,7 +123,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams"""
 
@@ -153,7 +154,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -163,7 +164,7 @@ class TeamsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         maintainers: Missing[list[str]] = UNSET,
@@ -180,7 +181,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -218,7 +219,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsPostBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -228,7 +229,7 @@ class TeamsClient:
         org: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         maintainers: Missing[list[str]] = UNSET,
@@ -245,7 +246,7 @@ class TeamsClient:
         self,
         org: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -283,7 +284,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-by-name"""
 
@@ -308,7 +309,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-by-name"""
 
@@ -333,7 +334,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#delete-a-team"""
 
@@ -352,7 +353,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#delete-a-team"""
 
@@ -372,7 +373,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -383,7 +384,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -399,7 +400,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -444,7 +445,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -455,7 +456,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -471,7 +472,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -519,7 +520,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         pinned: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions"""
 
@@ -553,7 +554,7 @@ class TeamsClient:
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
         pinned: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions"""
 
@@ -584,7 +585,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -595,7 +596,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -606,7 +607,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -641,7 +642,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -652,7 +653,7 @@ class TeamsClient:
         team_slug: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -663,7 +664,7 @@ class TeamsClient:
         org: str,
         team_slug: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -698,7 +699,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion"""
 
@@ -721,7 +722,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion"""
 
@@ -744,7 +745,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussions#delete-a-discussion"""
 
@@ -764,7 +765,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussions#delete-a-discussion"""
 
@@ -785,7 +786,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -799,7 +800,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -810,7 +811,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -853,7 +854,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -867,7 +868,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -878,7 +879,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberPatchBodyType
         ] = UNSET,
@@ -923,7 +924,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments"""
 
@@ -956,7 +957,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments"""
 
@@ -987,7 +988,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -999,7 +1000,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1009,7 +1010,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -1052,7 +1053,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1064,7 +1065,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1074,7 +1075,7 @@ class TeamsClient:
         team_slug: str,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -1117,7 +1118,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment"""
 
@@ -1141,7 +1142,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment"""
 
@@ -1165,7 +1166,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussion-comments#delete-a-discussion-comment"""
 
@@ -1186,7 +1187,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussion-comments#delete-a-discussion-comment"""
 
@@ -1208,7 +1209,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1221,7 +1222,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1232,7 +1233,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -1277,7 +1278,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1290,7 +1291,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -1301,7 +1302,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             OrgsOrgTeamsTeamSlugDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -1345,7 +1346,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations"""
 
@@ -1375,7 +1376,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations"""
 
@@ -1406,7 +1407,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members"""
 
@@ -1438,7 +1439,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members"""
 
@@ -1468,7 +1469,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user"""
 
@@ -1492,7 +1493,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user"""
 
@@ -1517,7 +1518,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1529,7 +1530,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1539,7 +1540,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -1581,7 +1582,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1593,7 +1594,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -1603,7 +1604,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -1644,7 +1645,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#remove-team-membership-for-a-user"""
 
@@ -1665,7 +1666,7 @@ class TeamsClient:
         team_slug: str,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#remove-team-membership-for-a-user"""
 
@@ -1687,7 +1688,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects"""
 
@@ -1717,7 +1718,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects"""
 
@@ -1746,7 +1747,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project"""
 
@@ -1770,7 +1771,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project"""
 
@@ -1795,7 +1796,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -1809,7 +1810,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -1819,7 +1820,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -1866,7 +1867,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -1880,7 +1881,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -1890,7 +1891,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             Union[OrgsOrgTeamsTeamSlugProjectsProjectIdPutBodyType, None]
         ] = UNSET,
@@ -1936,7 +1937,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team"""
 
@@ -1956,7 +1957,7 @@ class TeamsClient:
         team_slug: str,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team"""
 
@@ -1977,7 +1978,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories"""
 
@@ -2007,7 +2008,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories"""
 
@@ -2037,7 +2038,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository"""
 
@@ -2062,7 +2063,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository"""
 
@@ -2088,7 +2089,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -2101,7 +2102,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -2112,7 +2113,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2148,7 +2149,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -2161,7 +2162,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[str] = UNSET,
     ) -> Response: ...
 
@@ -2172,7 +2173,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[OrgsOrgTeamsTeamSlugReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2207,7 +2208,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team"""
 
@@ -2228,7 +2229,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team"""
 
@@ -2249,7 +2250,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams"""
 
@@ -2279,7 +2280,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams"""
 
@@ -2306,7 +2307,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-legacy"""
 
@@ -2330,7 +2331,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamFull, TeamFullType]:
         """See also: https://docs.github.com/rest/teams/teams#get-a-team-legacy"""
 
@@ -2354,7 +2355,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#delete-a-team-legacy"""
 
@@ -2378,7 +2379,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#delete-a-team-legacy"""
 
@@ -2403,7 +2404,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -2413,7 +2414,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -2428,7 +2429,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -2467,7 +2468,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdPatchBodyType,
     ) -> Response[TeamFull, TeamFullType]: ...
 
@@ -2477,7 +2478,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: str,
         description: Missing[str] = UNSET,
         privacy: Missing[Literal["secret", "closed"]] = UNSET,
@@ -2492,7 +2493,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamFull, TeamFullType]:
@@ -2533,7 +2534,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions-legacy"""
 
@@ -2564,7 +2565,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussion], list[TeamDiscussionType]]:
         """See also: https://docs.github.com/rest/teams/discussions#list-discussions-legacy"""
 
@@ -2593,7 +2594,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -2603,7 +2604,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -2613,7 +2614,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -2647,7 +2648,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsPostBodyType,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -2657,7 +2658,7 @@ class TeamsClient:
         team_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: str,
         body: str,
         private: Missing[bool] = UNSET,
@@ -2667,7 +2668,7 @@ class TeamsClient:
         self,
         team_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -2701,7 +2702,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion-legacy"""
 
@@ -2723,7 +2724,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
         """See also: https://docs.github.com/rest/teams/discussions#get-a-discussion-legacy"""
 
@@ -2745,7 +2746,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussions#delete-a-discussion-legacy"""
 
@@ -2764,7 +2765,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussions#delete-a-discussion-legacy"""
 
@@ -2784,7 +2785,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -2795,7 +2796,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -2805,7 +2806,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -2845,7 +2846,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
 
@@ -2856,7 +2857,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         body: Missing[str] = UNSET,
     ) -> Response[TeamDiscussion, TeamDiscussionType]: ...
@@ -2866,7 +2867,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdDiscussionsDiscussionNumberPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamDiscussion, TeamDiscussionType]:
@@ -2908,7 +2909,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
@@ -2940,7 +2941,7 @@ class TeamsClient:
         direction: Missing[Literal["asc", "desc"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamDiscussionComment], list[TeamDiscussionCommentType]]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#list-discussion-comments-legacy"""
 
@@ -2970,7 +2971,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -2981,7 +2982,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -2990,7 +2991,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -3032,7 +3033,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3043,7 +3044,7 @@ class TeamsClient:
         discussion_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3052,7 +3053,7 @@ class TeamsClient:
         team_id: int,
         discussion_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsPostBodyType
         ] = UNSET,
@@ -3094,7 +3095,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
@@ -3117,7 +3118,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]:
         """See also: https://docs.github.com/rest/teams/discussion-comments#get-a-discussion-comment-legacy"""
 
@@ -3140,7 +3141,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussion-comments#delete-a-discussion-comment-legacy"""
 
@@ -3160,7 +3161,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/discussion-comments#delete-a-discussion-comment-legacy"""
 
@@ -3181,7 +3182,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3193,7 +3194,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3203,7 +3204,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -3247,7 +3248,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3259,7 +3260,7 @@ class TeamsClient:
         comment_number: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         body: str,
     ) -> Response[TeamDiscussionComment, TeamDiscussionCommentType]: ...
 
@@ -3269,7 +3270,7 @@ class TeamsClient:
         discussion_number: int,
         comment_number: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[
             TeamsTeamIdDiscussionsDiscussionNumberCommentsCommentNumberPatchBodyType
         ] = UNSET,
@@ -3312,7 +3313,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations-legacy"""
 
@@ -3341,7 +3342,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[OrganizationInvitation], list[OrganizationInvitationType]]:
         """See also: https://docs.github.com/rest/teams/members#list-pending-team-invitations-legacy"""
 
@@ -3371,7 +3372,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members-legacy"""
 
@@ -3405,7 +3406,7 @@ class TeamsClient:
         role: Missing[Literal["member", "maintainer", "all"]] = UNSET,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/teams/members#list-team-members-legacy"""
 
@@ -3437,7 +3438,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#get-team-member-legacy"""
 
@@ -3457,7 +3458,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#get-team-member-legacy"""
 
@@ -3477,7 +3478,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#add-team-member-legacy"""
 
@@ -3501,7 +3502,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#add-team-member-legacy"""
 
@@ -3525,7 +3526,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#remove-team-member-legacy"""
 
@@ -3545,7 +3546,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#remove-team-member-legacy"""
 
@@ -3565,7 +3566,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user-legacy"""
 
@@ -3590,7 +3591,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamMembership, TeamMembershipType]:
         """See also: https://docs.github.com/rest/teams/members#get-team-membership-for-a-user-legacy"""
 
@@ -3616,7 +3617,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -3627,7 +3628,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -3636,7 +3637,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -3678,7 +3679,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -3689,7 +3690,7 @@ class TeamsClient:
         username: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         role: Missing[Literal["member", "maintainer"]] = UNSET,
     ) -> Response[TeamMembership, TeamMembershipType]: ...
 
@@ -3698,7 +3699,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdMembershipsUsernamePutBodyType] = UNSET,
         **kwargs,
     ) -> Response[TeamMembership, TeamMembershipType]:
@@ -3739,7 +3740,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#remove-team-membership-for-a-user-legacy"""
 
@@ -3759,7 +3760,7 @@ class TeamsClient:
         team_id: int,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/members#remove-team-membership-for-a-user-legacy"""
 
@@ -3780,7 +3781,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects-legacy"""
 
@@ -3812,7 +3813,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamProject], list[TeamProjectType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-projects-legacy"""
 
@@ -3843,7 +3844,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
@@ -3866,7 +3867,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamProject, TeamProjectType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-project-legacy"""
 
@@ -3890,7 +3891,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -3901,7 +3902,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -3910,7 +3911,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -3954,7 +3955,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -3965,7 +3966,7 @@ class TeamsClient:
         project_id: int,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["read", "write", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -3974,7 +3975,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdProjectsProjectIdPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4017,7 +4018,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team-legacy"""
 
@@ -4042,7 +4043,7 @@ class TeamsClient:
         team_id: int,
         project_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-project-from-a-team-legacy"""
 
@@ -4068,7 +4069,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories-legacy"""
 
@@ -4100,7 +4101,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[MinimalRepository], list[MinimalRepositoryType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-team-repositories-legacy"""
 
@@ -4132,7 +4133,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
@@ -4156,7 +4157,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[TeamRepository, TeamRepositoryType]:
         """See also: https://docs.github.com/rest/teams/teams#check-team-permissions-for-a-repository-legacy"""
 
@@ -4181,7 +4182,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -4193,7 +4194,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -4203,7 +4204,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4246,7 +4247,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
     ) -> Response: ...
 
@@ -4258,7 +4259,7 @@ class TeamsClient:
         repo: str,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         permission: Missing[Literal["pull", "push", "admin"]] = UNSET,
     ) -> Response: ...
 
@@ -4268,7 +4269,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[TeamsTeamIdReposOwnerRepoPutBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -4310,7 +4311,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team-legacy"""
 
@@ -4330,7 +4331,7 @@ class TeamsClient:
         owner: str,
         repo: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/teams/teams#remove-a-repository-from-a-team-legacy"""
 
@@ -4350,7 +4351,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams-legacy"""
 
@@ -4384,7 +4385,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Team], list[TeamType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-child-teams-legacy"""
 
@@ -4417,7 +4418,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams-for-the-authenticated-user"""
 
@@ -4449,7 +4450,7 @@ class TeamsClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[TeamFull], list[TeamFullType]]:
         """See also: https://docs.github.com/rest/teams/teams#list-teams-for-the-authenticated-user"""
 

--- a/githubkit/versions/v2022_11_28/rest/users.py
+++ b/githubkit/versions/v2022_11_28/rest/users.py
@@ -9,6 +9,7 @@ See https://github.com/github/rest-api-description for more information.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Literal, Optional, overload
 from weakref import ref
 
@@ -81,7 +82,7 @@ class UsersClient:
     def get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -109,7 +110,7 @@ class UsersClient:
     async def async_get_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -138,7 +139,7 @@ class UsersClient:
     def update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
     ) -> Response[PrivateUser, PrivateUserType]: ...
 
@@ -147,7 +148,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
         blog: Missing[str] = UNSET,
@@ -161,7 +162,7 @@ class UsersClient:
     def update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PrivateUser, PrivateUserType]:
@@ -200,7 +201,7 @@ class UsersClient:
     async def async_update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
     ) -> Response[PrivateUser, PrivateUserType]: ...
 
@@ -209,7 +210,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         email: Missing[str] = UNSET,
         blog: Missing[str] = UNSET,
@@ -223,7 +224,7 @@ class UsersClient:
     async def async_update_authenticated(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[PrivateUser, PrivateUserType]:
@@ -263,7 +264,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
@@ -296,7 +297,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/blocking#list-users-blocked-by-the-authenticated-user"""
 
@@ -328,7 +329,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/blocking#check-if-a-user-is-blocked-by-the-authenticated-user"""
 
@@ -353,7 +354,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/blocking#check-if-a-user-is-blocked-by-the-authenticated-user"""
 
@@ -378,7 +379,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/blocking#block-a-user"""
 
@@ -404,7 +405,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/blocking#block-a-user"""
 
@@ -430,7 +431,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/blocking#unblock-a-user"""
 
@@ -455,7 +456,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/blocking#unblock-a-user"""
 
@@ -480,7 +481,7 @@ class UsersClient:
     def set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -489,14 +490,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal["public", "private"],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     def set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -540,7 +541,7 @@ class UsersClient:
     async def async_set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserEmailVisibilityPatchBodyType,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -549,14 +550,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         visibility: Literal["public", "private"],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_set_primary_email_visibility_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserEmailVisibilityPatchBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -601,7 +602,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
@@ -634,7 +635,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-email-addresses-for-the-authenticated-user"""
 
@@ -666,7 +667,7 @@ class UsersClient:
     def add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -675,14 +676,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     def add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -737,7 +738,7 @@ class UsersClient:
     async def async_add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response[list[Email], list[EmailType]]: ...
 
@@ -746,14 +747,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response[list[Email], list[EmailType]]: ...
 
     async def async_add_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsPostBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response[list[Email], list[EmailType]]:
@@ -808,7 +809,7 @@ class UsersClient:
     def delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response: ...
 
@@ -817,14 +818,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response: ...
 
     def delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response:
@@ -873,7 +874,7 @@ class UsersClient:
     async def async_delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
     ) -> Response: ...
 
@@ -882,14 +883,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         emails: list[str],
     ) -> Response: ...
 
     async def async_delete_email_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[Union[UserEmailsDeleteBodyOneof0Type, list[str], str]] = UNSET,
         **kwargs,
     ) -> Response:
@@ -939,7 +940,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-the-authenticated-user"""
 
@@ -971,7 +972,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-the-authenticated-user"""
 
@@ -1003,7 +1004,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
@@ -1035,7 +1036,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-the-authenticated-user-follows"""
 
@@ -1066,7 +1067,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#check-if-a-person-is-followed-by-the-authenticated-user"""
 
@@ -1091,7 +1092,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#check-if-a-person-is-followed-by-the-authenticated-user"""
 
@@ -1116,7 +1117,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#follow-a-user"""
 
@@ -1142,7 +1143,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#follow-a-user"""
 
@@ -1168,7 +1169,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#unfollow-a-user"""
 
@@ -1193,7 +1194,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#unfollow-a-user"""
 
@@ -1219,7 +1220,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
@@ -1252,7 +1253,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-the-authenticated-user"""
 
@@ -1282,7 +1283,10 @@ class UsersClient:
 
     @overload
     def create_gpg_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserGpgKeysPostBodyType,
     ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
@@ -1290,7 +1294,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
     ) -> Response[GpgKey, GpgKeyType]: ...
@@ -1298,7 +1302,7 @@ class UsersClient:
     def create_gpg_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GpgKey, GpgKeyType]:
@@ -1335,7 +1339,10 @@ class UsersClient:
 
     @overload
     async def async_create_gpg_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserGpgKeysPostBodyType
+        self,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        data: UserGpgKeysPostBodyType,
     ) -> Response[GpgKey, GpgKeyType]: ...
 
     @overload
@@ -1343,7 +1350,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         name: Missing[str] = UNSET,
         armored_public_key: str,
     ) -> Response[GpgKey, GpgKeyType]: ...
@@ -1351,7 +1358,7 @@ class UsersClient:
     async def async_create_gpg_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserGpgKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[GpgKey, GpgKeyType]:
@@ -1390,7 +1397,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
@@ -1416,7 +1423,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[GpgKey, GpgKeyType]:
         """See also: https://docs.github.com/rest/users/gpg-keys#get-a-gpg-key-for-the-authenticated-user"""
 
@@ -1442,7 +1449,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user"""
 
@@ -1468,7 +1475,7 @@ class UsersClient:
         self,
         gpg_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/gpg-keys#delete-a-gpg-key-for-the-authenticated-user"""
 
@@ -1495,7 +1502,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
@@ -1528,7 +1535,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Key], list[KeyType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-ssh-keys-for-the-authenticated-user"""
 
@@ -1558,7 +1565,7 @@ class UsersClient:
 
     @overload
     def create_public_ssh_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: UserKeysPostBodyType
     ) -> Response[Key, KeyType]: ...
 
     @overload
@@ -1566,7 +1573,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[Key, KeyType]: ...
@@ -1574,7 +1581,7 @@ class UsersClient:
     def create_public_ssh_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Key, KeyType]:
@@ -1611,7 +1618,7 @@ class UsersClient:
 
     @overload
     async def async_create_public_ssh_key_for_authenticated_user(
-        self, *, headers: Optional[dict[str, str]] = None, data: UserKeysPostBodyType
+        self, *, headers: Optional[Mapping[str, str]] = None, data: UserKeysPostBodyType
     ) -> Response[Key, KeyType]: ...
 
     @overload
@@ -1619,7 +1626,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[Key, KeyType]: ...
@@ -1627,7 +1634,7 @@ class UsersClient:
     async def async_create_public_ssh_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[Key, KeyType]:
@@ -1666,7 +1673,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1692,7 +1699,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Key, KeyType]:
         """See also: https://docs.github.com/rest/users/keys#get-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1718,7 +1725,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1743,7 +1750,7 @@ class UsersClient:
         self,
         key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/keys#delete-a-public-ssh-key-for-the-authenticated-user"""
 
@@ -1769,7 +1776,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
@@ -1802,7 +1809,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[Email], list[EmailType]]:
         """See also: https://docs.github.com/rest/users/emails#list-public-email-addresses-for-the-authenticated-user"""
 
@@ -1835,7 +1842,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
@@ -1868,7 +1875,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-the-authenticated-user"""
 
@@ -1900,7 +1907,7 @@ class UsersClient:
     def add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
@@ -1909,14 +1916,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     def add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
@@ -1960,7 +1967,7 @@ class UsersClient:
     async def async_add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsPostBodyType,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
@@ -1969,14 +1976,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response[list[SocialAccount], list[SocialAccountType]]: ...
 
     async def async_add_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
@@ -2020,7 +2027,7 @@ class UsersClient:
     def delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsDeleteBodyType,
     ) -> Response: ...
 
@@ -2029,14 +2036,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response: ...
 
     def delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2074,7 +2081,7 @@ class UsersClient:
     async def async_delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSocialAccountsDeleteBodyType,
     ) -> Response: ...
 
@@ -2083,14 +2090,14 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         account_urls: list[str],
     ) -> Response: ...
 
     async def async_delete_social_account_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSocialAccountsDeleteBodyType] = UNSET,
         **kwargs,
     ) -> Response:
@@ -2129,7 +2136,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
@@ -2162,7 +2169,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-the-authenticated-user"""
 
@@ -2194,7 +2201,7 @@ class UsersClient:
     def create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
@@ -2203,7 +2210,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
@@ -2211,7 +2218,7 @@ class UsersClient:
     def create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
@@ -2255,7 +2262,7 @@ class UsersClient:
     async def async_create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: UserSshSigningKeysPostBodyType,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
 
@@ -2264,7 +2271,7 @@ class UsersClient:
         self,
         *,
         data: UnsetType = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         title: Missing[str] = UNSET,
         key: str,
     ) -> Response[SshSigningKey, SshSigningKeyType]: ...
@@ -2272,7 +2279,7 @@ class UsersClient:
     async def async_create_ssh_signing_key_for_authenticated_user(
         self,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
         data: Missing[UserSshSigningKeysPostBodyType] = UNSET,
         **kwargs,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
@@ -2316,7 +2323,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2342,7 +2349,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[SshSigningKey, SshSigningKeyType]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#get-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2368,7 +2375,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2393,7 +2400,7 @@ class UsersClient:
         self,
         ssh_signing_key_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#delete-an-ssh-signing-key-for-the-authenticated-user"""
 
@@ -2418,7 +2425,7 @@ class UsersClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2446,7 +2453,7 @@ class UsersClient:
         self,
         account_id: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2475,7 +2482,7 @@ class UsersClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/users#list-users"""
 
@@ -2503,7 +2510,7 @@ class UsersClient:
         *,
         since: Missing[int] = UNSET,
         per_page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/users#list-users"""
 
@@ -2530,7 +2537,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2558,7 +2565,7 @@ class UsersClient:
         self,
         username: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         Union[PrivateUser, PublicUser], Union[PrivateUserType, PublicUserType]
     ]:
@@ -2590,7 +2597,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UsersUsernameAttestationsSubjectDigestGetResponse200,
         UsersUsernameAttestationsSubjectDigestGetResponse200Type,
@@ -2631,7 +2638,7 @@ class UsersClient:
         per_page: Missing[int] = UNSET,
         before: Missing[str] = UNSET,
         after: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[
         UsersUsernameAttestationsSubjectDigestGetResponse200,
         UsersUsernameAttestationsSubjectDigestGetResponse200Type,
@@ -2670,7 +2677,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-a-user"""
 
@@ -2699,7 +2706,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-followers-of-a-user"""
 
@@ -2728,7 +2735,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-a-user-follows"""
 
@@ -2757,7 +2764,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SimpleUser], list[SimpleUserType]]:
         """See also: https://docs.github.com/rest/users/followers#list-the-people-a-user-follows"""
 
@@ -2785,7 +2792,7 @@ class UsersClient:
         username: str,
         target_user: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#check-if-a-user-follows-another-user"""
 
@@ -2805,7 +2812,7 @@ class UsersClient:
         username: str,
         target_user: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response:
         """See also: https://docs.github.com/rest/users/followers#check-if-a-user-follows-another-user"""
 
@@ -2826,7 +2833,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
@@ -2855,7 +2862,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[GpgKey], list[GpgKeyType]]:
         """See also: https://docs.github.com/rest/users/gpg-keys#list-gpg-keys-for-a-user"""
 
@@ -2886,7 +2893,7 @@ class UsersClient:
             Literal["organization", "repository", "issue", "pull_request"]
         ] = UNSET,
         subject_id: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/rest/users/users#get-contextual-information-for-a-user"""
 
@@ -2921,7 +2928,7 @@ class UsersClient:
             Literal["organization", "repository", "issue", "pull_request"]
         ] = UNSET,
         subject_id: Missing[str] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[Hovercard, HovercardType]:
         """See also: https://docs.github.com/rest/users/users#get-contextual-information-for-a-user"""
 
@@ -2954,7 +2961,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-keys-for-a-user"""
 
@@ -2983,7 +2990,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[KeySimple], list[KeySimpleType]]:
         """See also: https://docs.github.com/rest/users/keys#list-public-keys-for-a-user"""
 
@@ -3012,7 +3019,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-a-user"""
 
@@ -3041,7 +3048,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SocialAccount], list[SocialAccountType]]:
         """See also: https://docs.github.com/rest/users/social-accounts#list-social-accounts-for-a-user"""
 
@@ -3070,7 +3077,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 
@@ -3099,7 +3106,7 @@ class UsersClient:
         *,
         per_page: Missing[int] = UNSET,
         page: Missing[int] = UNSET,
-        headers: Optional[dict[str, str]] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Response[list[SshSigningKey], list[SshSigningKeyType]]:
         """See also: https://docs.github.com/rest/users/ssh-signing-keys#list-ssh-signing-keys-for-a-user"""
 

--- a/githubkit/versions/v2022_11_28/webhooks/_namespace.py
+++ b/githubkit/versions/v2022_11_28/webhooks/_namespace.py
@@ -7,6 +7,7 @@ bash ./scripts/run-codegen.sh
 See https://github.com/github/rest-api-description for more information.
 """
 
+from collections.abc import Mapping
 import hmac
 import importlib
 import json
@@ -637,7 +638,7 @@ class WebhookNamespace:
         return type_validate_json(Event, payload)
 
     @staticmethod
-    def parse_obj_without_name(payload: dict[str, Any]) -> "WebhookEvent":
+    def parse_obj_without_name(payload: Mapping[str, Any]) -> "WebhookEvent":
         """Parse the webhook payload dict without event name.
 
         Note:
@@ -647,7 +648,7 @@ class WebhookNamespace:
             the result may not be the correct type as expected.
 
         Args:
-            payload (dict[str, Any]): webhook payload dict.
+            payload (Mapping[str, Any]): webhook payload dict.
         """
 
         from ._types import WebhookEvent
@@ -657,375 +658,381 @@ class WebhookNamespace:
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["branch_protection_configuration"], payload: dict[str, Any]
+        name: Literal["branch_protection_configuration"], payload: Mapping[str, Any]
     ) -> "BranchProtectionConfigurationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["branch_protection_rule"], payload: dict[str, Any]
+        name: Literal["branch_protection_rule"], payload: Mapping[str, Any]
     ) -> "BranchProtectionRuleEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["check_run"], payload: dict[str, Any]
+        name: Literal["check_run"], payload: Mapping[str, Any]
     ) -> "CheckRunEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["check_suite"], payload: dict[str, Any]
+        name: Literal["check_suite"], payload: Mapping[str, Any]
     ) -> "CheckSuiteEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["code_scanning_alert"], payload: dict[str, Any]
+        name: Literal["code_scanning_alert"], payload: Mapping[str, Any]
     ) -> "CodeScanningAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["commit_comment"], payload: dict[str, Any]
+        name: Literal["commit_comment"], payload: Mapping[str, Any]
     ) -> "CommitCommentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["create"], payload: dict[str, Any]
+        name: Literal["create"], payload: Mapping[str, Any]
     ) -> "CreateEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["custom_property"], payload: dict[str, Any]
+        name: Literal["custom_property"], payload: Mapping[str, Any]
     ) -> "CustomPropertyEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["custom_property_values"], payload: dict[str, Any]
+        name: Literal["custom_property_values"], payload: Mapping[str, Any]
     ) -> "CustomPropertyValuesEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["delete"], payload: dict[str, Any]
+        name: Literal["delete"], payload: Mapping[str, Any]
     ) -> "DeleteEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["dependabot_alert"], payload: dict[str, Any]
+        name: Literal["dependabot_alert"], payload: Mapping[str, Any]
     ) -> "DependabotAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deploy_key"], payload: dict[str, Any]
+        name: Literal["deploy_key"], payload: Mapping[str, Any]
     ) -> "DeployKeyEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment"], payload: dict[str, Any]
+        name: Literal["deployment"], payload: Mapping[str, Any]
     ) -> "DeploymentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment_protection_rule"], payload: dict[str, Any]
+        name: Literal["deployment_protection_rule"], payload: Mapping[str, Any]
     ) -> "DeploymentProtectionRuleEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment_review"], payload: dict[str, Any]
+        name: Literal["deployment_review"], payload: Mapping[str, Any]
     ) -> "DeploymentReviewEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["deployment_status"], payload: dict[str, Any]
+        name: Literal["deployment_status"], payload: Mapping[str, Any]
     ) -> "DeploymentStatusEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["discussion"], payload: dict[str, Any]
+        name: Literal["discussion"], payload: Mapping[str, Any]
     ) -> "DiscussionEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["discussion_comment"], payload: dict[str, Any]
+        name: Literal["discussion_comment"], payload: Mapping[str, Any]
     ) -> "DiscussionCommentEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["fork"], payload: dict[str, Any]) -> "ForkEvent": ...
+    def parse_obj(name: Literal["fork"], payload: Mapping[str, Any]) -> "ForkEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["github_app_authorization"], payload: dict[str, Any]
+        name: Literal["github_app_authorization"], payload: Mapping[str, Any]
     ) -> "GithubAppAuthorizationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["gollum"], payload: dict[str, Any]
+        name: Literal["gollum"], payload: Mapping[str, Any]
     ) -> "GollumEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["installation"], payload: dict[str, Any]
+        name: Literal["installation"], payload: Mapping[str, Any]
     ) -> "InstallationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["installation_repositories"], payload: dict[str, Any]
+        name: Literal["installation_repositories"], payload: Mapping[str, Any]
     ) -> "InstallationRepositoriesEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["installation_target"], payload: dict[str, Any]
+        name: Literal["installation_target"], payload: Mapping[str, Any]
     ) -> "InstallationTargetEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["issue_comment"], payload: dict[str, Any]
+        name: Literal["issue_comment"], payload: Mapping[str, Any]
     ) -> "IssueCommentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["issues"], payload: dict[str, Any]
+        name: Literal["issues"], payload: Mapping[str, Any]
     ) -> "IssuesEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["label"], payload: dict[str, Any]) -> "LabelEvent": ...
+    def parse_obj(
+        name: Literal["label"], payload: Mapping[str, Any]
+    ) -> "LabelEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["marketplace_purchase"], payload: dict[str, Any]
+        name: Literal["marketplace_purchase"], payload: Mapping[str, Any]
     ) -> "MarketplacePurchaseEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["member"], payload: dict[str, Any]
+        name: Literal["member"], payload: Mapping[str, Any]
     ) -> "MemberEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["membership"], payload: dict[str, Any]
+        name: Literal["membership"], payload: Mapping[str, Any]
     ) -> "MembershipEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["merge_group"], payload: dict[str, Any]
+        name: Literal["merge_group"], payload: Mapping[str, Any]
     ) -> "MergeGroupEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["meta"], payload: dict[str, Any]) -> "MetaEvent": ...
+    def parse_obj(name: Literal["meta"], payload: Mapping[str, Any]) -> "MetaEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["milestone"], payload: dict[str, Any]
+        name: Literal["milestone"], payload: Mapping[str, Any]
     ) -> "MilestoneEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["org_block"], payload: dict[str, Any]
+        name: Literal["org_block"], payload: Mapping[str, Any]
     ) -> "OrgBlockEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["organization"], payload: dict[str, Any]
+        name: Literal["organization"], payload: Mapping[str, Any]
     ) -> "OrganizationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["package"], payload: dict[str, Any]
+        name: Literal["package"], payload: Mapping[str, Any]
     ) -> "PackageEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["page_build"], payload: dict[str, Any]
+        name: Literal["page_build"], payload: Mapping[str, Any]
     ) -> "PageBuildEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["personal_access_token_request"], payload: dict[str, Any]
+        name: Literal["personal_access_token_request"], payload: Mapping[str, Any]
     ) -> "PersonalAccessTokenRequestEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["ping"], payload: dict[str, Any]) -> "PingEvent": ...
+    def parse_obj(name: Literal["ping"], payload: Mapping[str, Any]) -> "PingEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["project_card"], payload: dict[str, Any]
+        name: Literal["project_card"], payload: Mapping[str, Any]
     ) -> "ProjectCardEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["project"], payload: dict[str, Any]
+        name: Literal["project"], payload: Mapping[str, Any]
     ) -> "ProjectEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["project_column"], payload: dict[str, Any]
+        name: Literal["project_column"], payload: Mapping[str, Any]
     ) -> "ProjectColumnEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["projects_v2"], payload: dict[str, Any]
+        name: Literal["projects_v2"], payload: Mapping[str, Any]
     ) -> "ProjectsV2Event": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["projects_v2_item"], payload: dict[str, Any]
+        name: Literal["projects_v2_item"], payload: Mapping[str, Any]
     ) -> "ProjectsV2ItemEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["projects_v2_status_update"], payload: dict[str, Any]
+        name: Literal["projects_v2_status_update"], payload: Mapping[str, Any]
     ) -> "ProjectsV2StatusUpdateEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["public"], payload: dict[str, Any]
+        name: Literal["public"], payload: Mapping[str, Any]
     ) -> "PublicEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request"], payload: dict[str, Any]
+        name: Literal["pull_request"], payload: Mapping[str, Any]
     ) -> "PullRequestEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request_review_comment"], payload: dict[str, Any]
+        name: Literal["pull_request_review_comment"], payload: Mapping[str, Any]
     ) -> "PullRequestReviewCommentEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request_review"], payload: dict[str, Any]
+        name: Literal["pull_request_review"], payload: Mapping[str, Any]
     ) -> "PullRequestReviewEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["pull_request_review_thread"], payload: dict[str, Any]
+        name: Literal["pull_request_review_thread"], payload: Mapping[str, Any]
     ) -> "PullRequestReviewThreadEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["push"], payload: dict[str, Any]) -> "PushEvent": ...
+    def parse_obj(name: Literal["push"], payload: Mapping[str, Any]) -> "PushEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["registry_package"], payload: dict[str, Any]
+        name: Literal["registry_package"], payload: Mapping[str, Any]
     ) -> "RegistryPackageEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["release"], payload: dict[str, Any]
+        name: Literal["release"], payload: Mapping[str, Any]
     ) -> "ReleaseEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_advisory"], payload: dict[str, Any]
+        name: Literal["repository_advisory"], payload: Mapping[str, Any]
     ) -> "RepositoryAdvisoryEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository"], payload: dict[str, Any]
+        name: Literal["repository"], payload: Mapping[str, Any]
     ) -> "RepositoryEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_dispatch"], payload: dict[str, Any]
+        name: Literal["repository_dispatch"], payload: Mapping[str, Any]
     ) -> "RepositoryDispatchEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_import"], payload: dict[str, Any]
+        name: Literal["repository_import"], payload: Mapping[str, Any]
     ) -> "RepositoryImportEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_ruleset"], payload: dict[str, Any]
+        name: Literal["repository_ruleset"], payload: Mapping[str, Any]
     ) -> "RepositoryRulesetEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["repository_vulnerability_alert"], payload: dict[str, Any]
+        name: Literal["repository_vulnerability_alert"], payload: Mapping[str, Any]
     ) -> "RepositoryVulnerabilityAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["secret_scanning_alert"], payload: dict[str, Any]
+        name: Literal["secret_scanning_alert"], payload: Mapping[str, Any]
     ) -> "SecretScanningAlertEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["secret_scanning_alert_location"], payload: dict[str, Any]
+        name: Literal["secret_scanning_alert_location"], payload: Mapping[str, Any]
     ) -> "SecretScanningAlertLocationEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["secret_scanning_scan"], payload: dict[str, Any]
+        name: Literal["secret_scanning_scan"], payload: Mapping[str, Any]
     ) -> "SecretScanningScanEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["security_advisory"], payload: dict[str, Any]
+        name: Literal["security_advisory"], payload: Mapping[str, Any]
     ) -> "SecurityAdvisoryEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["security_and_analysis"], payload: dict[str, Any]
+        name: Literal["security_and_analysis"], payload: Mapping[str, Any]
     ) -> "SecurityAndAnalysisEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["sponsorship"], payload: dict[str, Any]
+        name: Literal["sponsorship"], payload: Mapping[str, Any]
     ) -> "SponsorshipEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["star"], payload: dict[str, Any]) -> "StarEvent": ...
+    def parse_obj(name: Literal["star"], payload: Mapping[str, Any]) -> "StarEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["status"], payload: dict[str, Any]
+        name: Literal["status"], payload: Mapping[str, Any]
     ) -> "StatusEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["sub_issues"], payload: dict[str, Any]
+        name: Literal["sub_issues"], payload: Mapping[str, Any]
     ) -> "SubIssuesEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["team_add"], payload: dict[str, Any]
+        name: Literal["team_add"], payload: Mapping[str, Any]
     ) -> "TeamAddEvent": ...
     @overload
     @staticmethod
-    def parse_obj(name: Literal["team"], payload: dict[str, Any]) -> "TeamEvent": ...
-    @overload
-    @staticmethod
-    def parse_obj(name: Literal["watch"], payload: dict[str, Any]) -> "WatchEvent": ...
+    def parse_obj(name: Literal["team"], payload: Mapping[str, Any]) -> "TeamEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["workflow_dispatch"], payload: dict[str, Any]
+        name: Literal["watch"], payload: Mapping[str, Any]
+    ) -> "WatchEvent": ...
+    @overload
+    @staticmethod
+    def parse_obj(
+        name: Literal["workflow_dispatch"], payload: Mapping[str, Any]
     ) -> "WorkflowDispatchEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["workflow_job"], payload: dict[str, Any]
+        name: Literal["workflow_job"], payload: Mapping[str, Any]
     ) -> "WorkflowJobEvent": ...
     @overload
     @staticmethod
     def parse_obj(
-        name: Literal["workflow_run"], payload: dict[str, Any]
+        name: Literal["workflow_run"], payload: Mapping[str, Any]
     ) -> "WorkflowRunEvent": ...
 
     @overload
     @staticmethod
-    def parse_obj(name: EventNameType, payload: dict[str, Any]) -> "WebhookEvent": ...
+    def parse_obj(
+        name: EventNameType, payload: Mapping[str, Any]
+    ) -> "WebhookEvent": ...
 
     @overload
     @staticmethod
-    def parse_obj(name: str, payload: dict[str, Any]) -> "WebhookEvent": ...
+    def parse_obj(name: str, payload: Mapping[str, Any]) -> "WebhookEvent": ...
 
     @staticmethod
     def parse_obj(
-        name: Union[EventNameType, str], payload: dict[str, Any]
+        name: Union[EventNameType, str], payload: Mapping[str, Any]
     ) -> "WebhookEvent":
         """Parse the webhook payload dict with event name.
 
         Args:
             name (EventNameType): event name.
-            payload (dict[str, Any]): webhook payload dict.
+            payload (Mapping[str, Any]): webhook payload dict.
         """
 
         if name not in VALID_EVENT_NAMES:


### PR DESCRIPTION
- Most `dict` parameters can be any mapping type
- Most `list` parameters can be any iterable, or if stored, any sequence

These changes make it a lot easier to use, say, `TypedDict` to define GraphQL query input values. 

Also see the [*Arguments and Return Types* section](https://typing.readthedocs.io/en/latest/reference/best_practices.html#arguments-and-return-types) in the _Typing Best Practices_ chapter of the Python static typing documentation.
