### PR TITLE
Fix: add missing enum values for dependabot and code scanning alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -522,7 +522,7 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
 "/webhooks/repository-dispatch-sample.collected/post" = { operationId = "repository-dispatch" }
 # "/components/schemas/webhook-repository-dispatch-sample/properties/action" = { enum = "<unset>" }
 
-# Relationship between alert and repository as well as code scanning alert source were missing values, see issue: # https://github.com/yanyongyu/githubkit/issues/201
+# Relationship between alert and repository as well as code scanning alert source were missing values, see issue: # https://github.com/yanyongyu/githubkit/issues/205
 "/components/schemas/dependabot-alert-with-repository/properties/dependency/properties/relationship/enum" = { "<add>" = [
   "inconclusive",
 ] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -522,6 +522,14 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
 "/webhooks/repository-dispatch-sample.collected/post" = { operationId = "repository-dispatch" }
 # "/components/schemas/webhook-repository-dispatch-sample/properties/action" = { enum = "<unset>" }
 
+# Relationship between alert and repository as well as code scanning alert source were missing values, see issue: # https://github.com/yanyongyu/githubkit/issues/201
+"/components/schemas/dependabot-alert-with-repository/properties/dependency/properties/relationship/enum" = { "<add>" = [
+  "inconclusive",
+] }
+"/components/schemas/code-scanning-alert-classification/enum" = { "<add>" = [
+  "documentation",
+] }
+
 [build-system]
 requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -522,10 +522,12 @@ source = "https://raw.githubusercontent.com/github/rest-api-description/main/des
 "/webhooks/repository-dispatch-sample.collected/post" = { operationId = "repository-dispatch" }
 # "/components/schemas/webhook-repository-dispatch-sample/properties/action" = { enum = "<unset>" }
 
-# Relationship between alert and repository as well as code scanning alert source were missing values, see issue: # https://github.com/yanyongyu/githubkit/issues/205
+# https://github.com/yanyongyu/githubkit/issues/205
+# https://github.com/github/rest-api-description/issues/4727
 "/components/schemas/dependabot-alert-with-repository/properties/dependency/properties/relationship/enum" = { "<add>" = [
   "inconclusive",
 ] }
+# https://github.com/github/rest-api-description/issues/4728
 "/components/schemas/code-scanning-alert-classification/enum" = { "<add>" = [
   "documentation",
 ] }


### PR DESCRIPTION
Adds missing values to dependabot-alert-with-repository and code-scanning-alert-classification.