### PR TITLE
Feature: add httpx `verify` config

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -12,6 +12,7 @@ github = GitHub(
     user_agent="GitHubKit/Python",
     follow_redirects=True,
     timeout=None,
+    ssl_verify=True,
     cache_strategy=None,
     http_cache=True,
     throttler=None,
@@ -34,6 +35,7 @@ config = Config(
     user_agent="GitHubKit/Python",
     follow_redirects=True,
     timeout=httpx.Timeout(None),
+    ssl_verify=True,
     cache_strategy=DEFAULT_CACHE_STRATEGY,
     http_cache=True,
     throttler=None,
@@ -69,6 +71,10 @@ The `follow_redirects` option is used to enable or disable the HTTP redirect fol
 ### `timeout`
 
 The `timeout` option is used to set the request timeout. You can pass a float, `None` or `httpx.Timeout` to this field. By default, the requests will never timeout. See [Timeout](https://www.python-httpx.org/advanced/timeouts/) for more information.
+
+### `ssl_verify`
+
+The `ssl_verify` option is used to customize the SSL certificate verification. By default, githubkit enables the SSL certificate verification. If you want to disable the SSL certificate verification, you can set this option to `False`. Or you can provide a custom ssl context to this option. See [SSL](https://www.python-httpx.org/advanced/ssl/) for more information.
 
 ### `cache_strategy`
 

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
-import ssl
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from typing_extensions import Self
 
 import httpx
@@ -11,6 +10,9 @@ from .retry import RETRY_DEFAULT
 from .throttling import BaseThrottler, LocalThrottler
 from .typing import RetryDecisionFunc
 
+if TYPE_CHECKING:
+    import ssl
+
 
 @dataclass(frozen=True)
 class Config:
@@ -19,7 +21,7 @@ class Config:
     user_agent: str
     follow_redirects: bool
     timeout: httpx.Timeout
-    ssl_verify: Union[bool, ssl.SSLContext]
+    ssl_verify: Union[bool, "ssl.SSLContext"]
     cache_strategy: BaseCacheStrategy
     http_cache: bool
     throttler: BaseThrottler
@@ -106,7 +108,7 @@ def get_config(
     user_agent: Optional[str] = None,
     follow_redirects: bool = True,
     timeout: Optional[Union[float, httpx.Timeout]] = None,
-    ssl_verify: Union[bool, ssl.SSLContext] = True,
+    ssl_verify: Union[bool, "ssl.SSLContext"] = True,
     cache_strategy: Optional[BaseCacheStrategy] = None,
     http_cache: bool = True,
     throttler: Optional[BaseThrottler] = None,

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -19,12 +19,12 @@ class Config:
     user_agent: str
     follow_redirects: bool
     timeout: httpx.Timeout
+    ssl_verify: Union[bool, ssl.SSLContext]
     cache_strategy: BaseCacheStrategy
     http_cache: bool
     throttler: BaseThrottler
     auto_retry: Optional[RetryDecisionFunc]
     rest_api_validate_body: bool
-    ssl_verify: Union[bool, ssl.SSLContext]
 
     def dict(self) -> dict[str, Any]:
         """Return the config as a dictionary without copy values."""
@@ -106,12 +106,12 @@ def get_config(
     user_agent: Optional[str] = None,
     follow_redirects: bool = True,
     timeout: Optional[Union[float, httpx.Timeout]] = None,
+    ssl_verify: Union[bool, ssl.SSLContext] = True,
     cache_strategy: Optional[BaseCacheStrategy] = None,
     http_cache: bool = True,
     throttler: Optional[BaseThrottler] = None,
     auto_retry: Union[bool, RetryDecisionFunc] = True,
     rest_api_validate_body: bool = True,
-    ssl_verify: Union[bool, ssl.SSLContext] = True,
 ) -> Config:
     """Build the configs from the given options."""
     return Config(
@@ -120,10 +120,10 @@ def get_config(
         build_user_agent(user_agent),
         follow_redirects,
         build_timeout(timeout),
+        ssl_verify,
         build_cache_strategy(cache_strategy),
         http_cache,
         build_throttler(throttler),
         build_auto_retry(auto_retry),
         rest_api_validate_body,
-        ssl_verify,
     )

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from typing_extensions import Self
 
 import httpx
@@ -9,6 +11,9 @@ from .cache import DEFAULT_CACHE_STRATEGY, BaseCacheStrategy
 from .retry import RETRY_DEFAULT
 from .throttling import BaseThrottler, LocalThrottler
 from .typing import RetryDecisionFunc
+
+if TYPE_CHECKING:
+    import ssl
 
 
 @dataclass(frozen=True)
@@ -23,6 +28,7 @@ class Config:
     throttler: BaseThrottler
     auto_retry: Optional[RetryDecisionFunc]
     rest_api_validate_body: bool
+    verify: Union[bool, str, ssl.SSLContext]
 
     def dict(self) -> dict[str, Any]:
         """Return the config as a dictionary without copy values."""
@@ -109,6 +115,7 @@ def get_config(
     throttler: Optional[BaseThrottler] = None,
     auto_retry: Union[bool, RetryDecisionFunc] = True,
     rest_api_validate_body: bool = True,
+    verify: Union[bool, str, ssl.SSLContext] = True,
 ) -> Config:
     """Build the configs from the given options."""
     return Config(
@@ -122,4 +129,5 @@ def get_config(
         build_throttler(throttler),
         build_auto_retry(auto_retry),
         rest_api_validate_body,
+        verify,
     )

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -13,7 +13,7 @@ from .throttling import BaseThrottler, LocalThrottler
 from .typing import RetryDecisionFunc
 
 if TYPE_CHECKING:
-    import ssl
+    import ssl  # pragma: no cover
 
 
 @dataclass(frozen=True)

--- a/githubkit/config.py
+++ b/githubkit/config.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING, Any, Optional, Union
+import ssl
+from typing import Any, Optional, Union
 from typing_extensions import Self
 
 import httpx
@@ -11,9 +10,6 @@ from .cache import DEFAULT_CACHE_STRATEGY, BaseCacheStrategy
 from .retry import RETRY_DEFAULT
 from .throttling import BaseThrottler, LocalThrottler
 from .typing import RetryDecisionFunc
-
-if TYPE_CHECKING:
-    import ssl  # pragma: no cover
 
 
 @dataclass(frozen=True)
@@ -28,7 +24,7 @@ class Config:
     throttler: BaseThrottler
     auto_retry: Optional[RetryDecisionFunc]
     rest_api_validate_body: bool
-    verify: Union[bool, str, ssl.SSLContext]
+    ssl_verify: Union[bool, ssl.SSLContext]
 
     def dict(self) -> dict[str, Any]:
         """Return the config as a dictionary without copy values."""
@@ -115,7 +111,7 @@ def get_config(
     throttler: Optional[BaseThrottler] = None,
     auto_retry: Union[bool, RetryDecisionFunc] = True,
     rest_api_validate_body: bool = True,
-    verify: Union[bool, str, ssl.SSLContext] = True,
+    ssl_verify: Union[bool, ssl.SSLContext] = True,
 ) -> Config:
     """Build the configs from the given options."""
     return Config(
@@ -129,5 +125,5 @@ def get_config(
         build_throttler(throttler),
         build_auto_retry(auto_retry),
         rest_api_validate_body,
-        verify,
+        ssl_verify,
     )

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -84,12 +84,12 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        ssl_verify: Union[bool, ssl.SSLContext] = ...,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        ssl_verify: Union[bool, ssl.SSLContext] = ...,
     ): ...
 
     # token auth without config
@@ -104,12 +104,12 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        ssl_verify: Union[bool, ssl.SSLContext] = ...,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        ssl_verify: Union[bool, ssl.SSLContext] = ...,
     ): ...
 
     # other auth strategies without config
@@ -124,12 +124,12 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        ssl_verify: Union[bool, ssl.SSLContext] = ...,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        ssl_verify: Union[bool, ssl.SSLContext] = ...,
     ): ...
 
     def __init__(
@@ -143,12 +143,12 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        ssl_verify: Union[bool, ssl.SSLContext] = True,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        ssl_verify: Union[bool, ssl.SSLContext] = True,
     ):
         auth = auth or UnauthAuthStrategy()  # type: ignore
         self.auth: A = (  # type: ignore
@@ -162,12 +162,12 @@ class GitHubCore(Generic[A]):
             user_agent=user_agent,
             follow_redirects=follow_redirects,
             timeout=timeout,
+            ssl_verify=ssl_verify,
             cache_strategy=cache_strategy,
             http_cache=http_cache,
             throttler=throttler,
             auto_retry=auto_retry,
             rest_api_validate_body=rest_api_validate_body,
-            ssl_verify=ssl_verify,
         )
 
         self.__sync_client: ContextVar[Optional[httpx.Client]] = ContextVar(

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
@@ -91,7 +89,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        verify: Union[bool, str, ssl.SSLContext] = ...,
+        ssl_verify: Union[bool, ssl.SSLContext] = ...,
     ): ...
 
     # token auth without config
@@ -111,7 +109,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        verify: Union[bool, str, ssl.SSLContext] = ...,
+        ssl_verify: Union[bool, ssl.SSLContext] = ...,
     ): ...
 
     # other auth strategies without config
@@ -131,7 +129,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        verify: Union[bool, str, ssl.SSLContext] = ...,
+        ssl_verify: Union[bool, ssl.SSLContext] = ...,
     ): ...
 
     def __init__(
@@ -150,7 +148,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
-        verify: Union[bool, str, ssl.SSLContext] = True,
+        ssl_verify: Union[bool, ssl.SSLContext] = True,
     ):
         auth = auth or UnauthAuthStrategy()  # type: ignore
         self.auth: A = (  # type: ignore
@@ -169,7 +167,7 @@ class GitHubCore(Generic[A]):
             throttler=throttler,
             auto_retry=auto_retry,
             rest_api_validate_body=rest_api_validate_body,
-            verify=verify,
+            ssl_verify=ssl_verify,
         )
 
         self.__sync_client: ContextVar[Optional[httpx.Client]] = ContextVar(
@@ -222,7 +220,7 @@ class GitHubCore(Generic[A]):
             },
             "timeout": self.config.timeout,
             "follow_redirects": self.config.follow_redirects,
-            "verify": self.config.verify,
+            "verify": self.config.ssl_verify,
         }
 
     # create sync client

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -2,10 +2,9 @@ from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
-import ssl
 import time
 from types import TracebackType
-from typing import Any, Generic, Optional, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, cast, overload
 
 import anyio
 import hishel
@@ -36,6 +35,9 @@ from .typing import (
     URLTypes,
 )
 from .utils import UNSET
+
+if TYPE_CHECKING:
+    import ssl
 
 T = TypeVar("T")
 A = TypeVar("A", bound="BaseAuthStrategy")
@@ -82,7 +84,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
-        ssl_verify: Union[bool, ssl.SSLContext] = ...,
+        ssl_verify: Union[bool, "ssl.SSLContext"] = ...,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
@@ -102,7 +104,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
-        ssl_verify: Union[bool, ssl.SSLContext] = ...,
+        ssl_verify: Union[bool, "ssl.SSLContext"] = ...,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
@@ -122,7 +124,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
-        ssl_verify: Union[bool, ssl.SSLContext] = ...,
+        ssl_verify: Union[bool, "ssl.SSLContext"] = ...,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,
@@ -141,7 +143,7 @@ class GitHubCore(Generic[A]):
         user_agent: Optional[str] = None,
         follow_redirects: bool = True,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
-        ssl_verify: Union[bool, ssl.SSLContext] = True,
+        ssl_verify: Union[bool, "ssl.SSLContext"] = True,
         cache_strategy: Optional[BaseCacheStrategy] = None,
         http_cache: bool = True,
         throttler: Optional[BaseThrottler] = None,

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -2,9 +2,10 @@ from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
+import ssl
 import time
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, cast, overload
+from typing import Any, Generic, Optional, TypeVar, Union, cast, overload
 
 import anyio
 import hishel
@@ -35,9 +36,6 @@ from .typing import (
     URLTypes,
 )
 from .utils import UNSET
-
-if TYPE_CHECKING:
-    import ssl  # pragma: no cover
 
 T = TypeVar("T")
 A = TypeVar("A", bound="BaseAuthStrategy")

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -39,7 +39,7 @@ from .typing import (
 from .utils import UNSET
 
 if TYPE_CHECKING:
-    import ssl
+    import ssl  # pragma: no cover
 
 T = TypeVar("T")
 A = TypeVar("A", bound="BaseAuthStrategy")

--- a/githubkit/core.py
+++ b/githubkit/core.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
 import time
 from types import TracebackType
-from typing import Any, Generic, Optional, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, cast, overload
 
 import anyio
 import hishel
@@ -35,6 +37,9 @@ from .typing import (
     URLTypes,
 )
 from .utils import UNSET
+
+if TYPE_CHECKING:
+    import ssl
 
 T = TypeVar("T")
 A = TypeVar("A", bound="BaseAuthStrategy")
@@ -86,6 +91,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
+        verify: Union[bool, str, ssl.SSLContext] = ...,
     ): ...
 
     # token auth without config
@@ -105,6 +111,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
+        verify: Union[bool, str, ssl.SSLContext] = ...,
     ): ...
 
     # other auth strategies without config
@@ -124,6 +131,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
+        verify: Union[bool, str, ssl.SSLContext] = ...,
     ): ...
 
     def __init__(
@@ -142,6 +150,7 @@ class GitHubCore(Generic[A]):
         throttler: Optional[BaseThrottler] = None,
         auto_retry: Union[bool, RetryDecisionFunc] = True,
         rest_api_validate_body: bool = True,
+        verify: Union[bool, str, ssl.SSLContext] = True,
     ):
         auth = auth or UnauthAuthStrategy()  # type: ignore
         self.auth: A = (  # type: ignore
@@ -160,6 +169,7 @@ class GitHubCore(Generic[A]):
             throttler=throttler,
             auto_retry=auto_retry,
             rest_api_validate_body=rest_api_validate_body,
+            verify=verify,
         )
 
         self.__sync_client: ContextVar[Optional[httpx.Client]] = ContextVar(
@@ -212,6 +222,7 @@ class GitHubCore(Generic[A]):
             },
             "timeout": self.config.timeout,
             "follow_redirects": self.config.follow_redirects,
+            "verify": self.config.verify,
         }
 
     # create sync client

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -1,5 +1,6 @@
 from collections.abc import Awaitable, Sequence
 from functools import cached_property
+import ssl
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, overload
 from typing_extensions import ParamSpec
 
@@ -79,6 +80,7 @@ class GitHub(GitHubCore[A]):
             throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
+            ssl_verify: Union[bool, ssl.SSLContext] = ...,
         ): ...
 
         # token auth without config
@@ -98,6 +100,7 @@ class GitHub(GitHubCore[A]):
             throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
+            ssl_verify: Union[bool, ssl.SSLContext] = ...,
         ): ...
 
         # other auth strategies without config
@@ -117,6 +120,7 @@ class GitHub(GitHubCore[A]):
             throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
+            ssl_verify: Union[bool, ssl.SSLContext] = ...,
         ): ...
 
         def __init__(self, *args, **kwargs): ...

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -1,6 +1,5 @@
 from collections.abc import Awaitable, Sequence
 from functools import cached_property
-import ssl
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, overload
 from typing_extensions import ParamSpec
 
@@ -13,6 +12,8 @@ from .typing import RetryDecisionFunc
 from .versions import RestVersionSwitcher, WebhooksVersionSwitcher
 
 if TYPE_CHECKING:
+    import ssl
+
     import httpx
 
     from .auth import TokenAuthStrategy, UnauthAuthStrategy
@@ -75,7 +76,7 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
-            ssl_verify: Union[bool, ssl.SSLContext] = ...,
+            ssl_verify: Union[bool, "ssl.SSLContext"] = ...,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
             throttler: Optional["BaseThrottler"] = None,
@@ -95,7 +96,7 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
-            ssl_verify: Union[bool, ssl.SSLContext] = ...,
+            ssl_verify: Union[bool, "ssl.SSLContext"] = ...,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
             throttler: Optional["BaseThrottler"] = None,
@@ -115,7 +116,7 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
-            ssl_verify: Union[bool, ssl.SSLContext] = ...,
+            ssl_verify: Union[bool, "ssl.SSLContext"] = ...,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
             throttler: Optional["BaseThrottler"] = None,

--- a/githubkit/github.py
+++ b/githubkit/github.py
@@ -75,12 +75,12 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
+            ssl_verify: Union[bool, ssl.SSLContext] = ...,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
             throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
-            ssl_verify: Union[bool, ssl.SSLContext] = ...,
         ): ...
 
         # token auth without config
@@ -95,12 +95,12 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
+            ssl_verify: Union[bool, ssl.SSLContext] = ...,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
             throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
-            ssl_verify: Union[bool, ssl.SSLContext] = ...,
         ): ...
 
         # other auth strategies without config
@@ -115,12 +115,12 @@ class GitHub(GitHubCore[A]):
             user_agent: Optional[str] = None,
             follow_redirects: bool = True,
             timeout: Optional[Union[float, httpx.Timeout]] = None,
+            ssl_verify: Union[bool, ssl.SSLContext] = ...,
             cache_strategy: Optional["BaseCacheStrategy"] = None,
             http_cache: bool = True,
             throttler: Optional["BaseThrottler"] = None,
             auto_retry: Union[bool, RetryDecisionFunc] = True,
             rest_api_validate_body: bool = True,
-            ssl_verify: Union[bool, ssl.SSLContext] = ...,
         ): ...
 
         def __init__(self, *args, **kwargs): ...


### PR DESCRIPTION
This PR should pass-through the `verify` argument to the underlying HTTPX `Client` or `AsyncClient`.

https://www.python-httpx.org/advanced/ssl/

- Resolves #208 


### TODO
- [ ] Add tests
- [x] Update docs