### PR TITLE
CI: support uv_build 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ conflicts = [[{ group = "pydantic-v1" }, { group = "pydantic-v2" }]]
 module-root = ""
 
 [build-system]
-requires = ["uv_build >=0.8.3, <0.9.0"]
+requires = ["uv_build >=0.8.3, <0.10.0"]
 build-backend = "uv_build"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Related to https://github.com/NixOS/nixpkgs/pull/449568.

Reference: https://github.com/astral-sh/uv/releases/tag/0.9.0
